### PR TITLE
Process name exclusion (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@
 /wiresock_service/obj/x64/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs
 /wiresock_service/obj/x86/Debug/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs
 /wiresock_service/obj/x86/Release/.NETFramework,Version=v4.7.2.AssemblyAttributes.cs
+ProxiFyre/bin
+ProxiFyre/obj

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -86,9 +86,9 @@ namespace ProxiFyre
             {
                 // Add the relevant entries dynamically to the excluded list
                 if (_socksify.ExcludeProcessName(excludedEntry)) {
-                    LoggerInstance.Info($"Successfully excluded {encludedEntry} from being proxied.");
+                    LoggerInstance.Info($"Successfully excluded {excludedEntry} from being proxied.");
                 } else {
-                    LoggerInstance.Info($"Failed to exclude {encludedEntry} from being proxied.");
+                    LoggerInstance.Info($"Failed to exclude {excludedEntry} from being proxied.");
                 }
             }
 

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -82,6 +82,11 @@ namespace ProxiFyre
                             $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {string.Join(", ", appSettings.SupportedProtocols)}!");
             }
 
+            foreach (var excludedEntry in serviceSettings.ExcludedList)
+            {
+                // Add the relevant entries dynamically to the excluded list
+            }
+
             _socksify.Start();
 
             // Inform user that the application is running
@@ -148,10 +153,11 @@ namespace ProxiFyre
             /// </summary>
             /// <param name="logLevel">The log level as a string.</param>
             /// <param name="proxies">The list of proxy application settings.</param>
-            public ProxiFyreSettings(string logLevel, List<AppSettings> proxies)
+            public ProxiFyreSettings(string logLevel, List<AppSettings> proxies, List<string> excludedList)
             {
                 LogLevel = logLevel;
                 Proxies = proxies;
+                ExcludedList = excludedList;
             }
 
             /// <summary>
@@ -163,6 +169,12 @@ namespace ProxiFyre
             /// Gets the list of proxy application settings.
             /// </summary>
             public List<AppSettings> Proxies { get; }
+
+            /// <summary>
+            /// Gets the list of app names to exclude.
+            /// </summary>
+            [JsonProperty("excludes")]
+            public List<string> ExcludedList { get; } = new List<string>();
         }
 
         /// <summary>

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -85,6 +85,11 @@ namespace ProxiFyre
             foreach (var excludedEntry in serviceSettings.ExcludedList)
             {
                 // Add the relevant entries dynamically to the excluded list
+                if (_socksify.ExcludeProcessName(excludedEntry)) {
+                    LoggerInstance.Info($"Successfully excluded {encludedEntry} from being proxied.");
+                } else {
+                    LoggerInstance.Info($"Failed to exclude {encludedEntry} from being proxied.");
+                }
             }
 
             _socksify.Start();

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -233,7 +233,7 @@ namespace proxy
                             }
                             process_resolve_buffer_queue_cv_.notify_one();
                         }
-                        else 
+                        else
                         {
                             // Handle the error, e.g., log it or take corrective action
                             NETLIB_LOG(log_level::error, "Failed to allocate buffer.");
@@ -248,7 +248,7 @@ namespace proxy
                             return result.value();
                         }
                         // Queue for the later processing
-                        if (auto allocated_buffer = ndisapi::intermediate_buffer_pool::instance().allocate(buffer)) 
+                        if (auto allocated_buffer = ndisapi::intermediate_buffer_pool::instance().allocate(buffer))
                         {
                             {
                                 std::lock_guard lock(process_resolve_buffer_mutex_);
@@ -256,7 +256,7 @@ namespace proxy
                             }
                             process_resolve_buffer_queue_cv_.notify_one();
                         }
-                        else 
+                        else
                         {
                             // Handle the error, e.g., log it or take corrective action
                             NETLIB_LOG(log_level::error, "Failed to allocate buffer.");
@@ -350,7 +350,7 @@ namespace proxy
                 // Start proxies
                 for (auto& [tcp, udp] : proxy_servers_)
                 {
-                    if (tcp) 
+                    if (tcp)
                     {
                         if (!tcp->start())
                         {
@@ -675,7 +675,7 @@ namespace proxy
          */
         bool associate_process_name_to_proxy(const std::wstring& process_name, const size_t proxy_id)
         {
-            // The lock_guard object acquires the lock in a safe manner, 
+            // The lock_guard object acquires the lock in a safe manner,
             // ensuring it gets released even if an exception is thrown.
             std::lock_guard lock(lock_);
 
@@ -687,7 +687,7 @@ namespace proxy
                 return false; // Return false since the proxy_id is out of range
             }
 
-            // Associate the given process name to the specified proxy ID. 
+            // Associate the given process name to the specified proxy ID.
             // If the process_name already exists in the map, its associated proxy ID is updated.
             name_to_proxy_[to_upper(process_name)] = proxy_id;
 
@@ -788,6 +788,19 @@ namespace proxy
             // Exclude the current process by process ID
             if (process && process->id == ::GetCurrentProcessId())
                 return false;
+
+            // Solution from NukaColaM to exclude programs linearly, will be rewritten to allow dynamic updates.
+            static const std::vector<std::wstring> excluded_entries = {
+                L"svchost.exe"
+            };
+            for (const auto& excluded_entry : excluded_entries) {
+                if (
+                    to_upper(process->path_name).find(excluded_entry) != std::wstring::npos ||
+                    to_upper(process->name).find(excluded_entry) != std::wstring::npos
+                ) {
+                    return false;
+                }
+            }
 
             return (app.find(L'\\') != std::wstring::npos || app.find(L'/') != std::wstring::npos)
                 ? (to_upper(process->path_name).find(app) != std::wstring::npos)
@@ -1172,10 +1185,10 @@ namespace proxy
 
                     auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer_ptr->m_IBuffer);
 
-                    if (const auto* const ip_header = reinterpret_cast<iphdr_ptr>(ethernet_header + 1); 
+                    if (const auto* const ip_header = reinterpret_cast<iphdr_ptr>(ethernet_header + 1);
                         ip_header->ip_p == IPPROTO_UDP)
                     {
-                        if (const auto result = process_udp_packet(*buffer_ptr, true); 
+                        if (const auto result = process_udp_packet(*buffer_ptr, true);
                             result && result->action == packet_filter::packet_action::action_type::pass)
                         {
                             to_adapters.push_back(std::move(buffer_ptr));
@@ -1192,7 +1205,7 @@ namespace proxy
                     }
                     else if (ip_header->ip_p == IPPROTO_TCP)
                     {
-                        if (const auto result = process_tcp_packet(*buffer_ptr, true); 
+                        if (const auto result = process_tcp_packet(*buffer_ptr, true);
                             result && result->action == packet_filter::packet_action::action_type::pass)
                         {
                             to_adapters.push_back(std::move(buffer_ptr));

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -80,7 +80,7 @@ namespace proxy
         std::unordered_map<std::wstring, size_t> name_to_proxy_;
 
         /**
-         * @brief A list of
+         * @brief A list of excluded process names.
          */
         std::vector<std::wstring> excluded_list_;
 
@@ -710,7 +710,7 @@ namespace proxy
             std::lock_guard lock(lock_);
 
             // Append the excluded entry
-            excluded_list_.push_back(excluded_entry);
+            excluded_list_.push_back(to_upper(excluded_entry));
 
             // If successful, return true
             return true;
@@ -805,7 +805,7 @@ namespace proxy
          * @param process The process details to check against the application pattern.
          * @return true if the process details match the application pattern and are not the current process, false otherwise.
          */
-        static bool match_app_name(const std::wstring& app, const std::shared_ptr<iphelper::network_process>& process)
+        bool match_app_name(const std::wstring& app, const std::shared_ptr<iphelper::network_process>& process)
         {
             // Exclude the current process by process ID
             if (process && process->id == ::GetCurrentProcessId())
@@ -814,8 +814,8 @@ namespace proxy
             // Solution from NukaColaM (#46) to exclude programs linearly, will be rewritten to allow dynamic updates.
             for (const auto& excluded_entry : excluded_list_) {
                 if (
-                    to_upper(process->path_name).find(excluded_entry) != std::wstring::npos ||
-                    to_upper(process->name).find(excluded_entry) != std::wstring::npos
+                    process->path_name.find(excluded_entry) != std::wstring::npos ||
+                    process->name.find(excluded_entry) != std::wstring::npos
                 ) {
                     return false;
                 }

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -789,7 +789,7 @@ namespace proxy
             if (process && process->id == ::GetCurrentProcessId())
                 return false;
 
-            // Solution from NukaColaM to exclude programs linearly, will be rewritten to allow dynamic updates.
+            // Solution from NukaColaM (#46) to exclude programs linearly, will be rewritten to allow dynamic updates.
             static const std::vector<std::wstring> excluded_entries = {
                 L"svchost.exe"
             };

--- a/socksify/Socksifier.cpp
+++ b/socksify/Socksifier.cpp
@@ -242,7 +242,7 @@ bool Socksifier::Socksifier::AssociateProcessNameToProxy(String^ processName, In
 /// </summary>
 /// <param name="excludedEntry">The process name to exclude.</param>.</param>
 /// <returns>True if exclusion was successful, otherwise false.</returns>
-bool ExcludeProcessName(String^ excludedEntry)
+bool Socksifier::Socksifier::ExcludeProcessName(String^ excludedEntry)
 {
     if (!unmanaged_ptr_) {
         return false;

--- a/socksify/Socksifier.cpp
+++ b/socksify/Socksifier.cpp
@@ -236,3 +236,16 @@ bool Socksifier::Socksifier::AssociateProcessNameToProxy(String^ processName, In
         proxy.ToInt32());
 #endif //_WIN64
 }
+
+/// <summary>
+/// Excludes a process from being tunnelled by the gateway.
+/// </summary>
+/// <param name="excludedEntry">The process name to exclude.</param>.</param>
+/// <returns>True if exclusion was successful, otherwise false.</returns>
+bool ExcludeProcessName(String^ excludedEntry)
+{
+    if (!unmanaged_ptr_) {
+        return false;
+    }
+    return unmanaged_ptr_->exclude_process_name(msclr::interop::marshal_as<std::wstring>(excludedEntry));
+}

--- a/socksify/Socksifier.h
+++ b/socksify/Socksifier.h
@@ -254,6 +254,13 @@ namespace Socksifier
         bool AssociateProcessNameToProxy(String^ processName, IntPtr proxy);
 
         /// <summary>
+        /// Excludes a process from being tunnelled by the gateway.
+        /// </summary>
+        /// <param name="excludedEntry">The process name to exclude.</param>.</param>
+        /// <returns>True if exclusion was successful, otherwise false.</returns>
+        bool ExcludeProcessName(String^ excludedEntry);
+
+        /// <summary>
         /// Gets or sets the interval (in milliseconds) for log event notifications.
         /// </summary>
         property Int32 LogEventInterval

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -208,6 +208,16 @@ bool socksify_unmanaged::associate_process_name_to_proxy(const std::wstring& pro
 }
 
 /**
+ * @brief Associates a process name to the exclusion list.
+ * @param process_name The process name to associate.
+ * @return True if addition was successful, false otherwise.
+ */
+bool socksify_unmanaged::exclude_process_name(const std::wstring& process_name) const
+{
+    return proxy_->exclude_process_name(process_name);
+}
+
+/**
  * @brief Sets the maximum number of log entries to keep.
  * @param log_limit The new log limit.
  */


### PR DESCRIPTION
Built upon the snippet from @NukaColaM (now deleted) in #46, this PR allows loading excluded processes from config, preceding actual process to proxy associations.

I have no experience with C++, and I do not have a Windows machine to test it, only building on your example as much as possible. If viable, please also consider adding a global default proxy endpoint, so that ProxiFyre could be run in whitelist mode, allowing for better user experience.