### PR TITLE
fix: production-readiness fixes from code review (round 1)

### DIFF
--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -181,13 +181,21 @@ namespace ProxiFyre
                     throw new InvalidOperationException(message);
                 }
 
+                // Drop null/blank application names so they are never marshalled
+                // to the unmanaged layer, where marshal_as<std::wstring> throws
+                // on a null String^.
                 if (proxy.AppNames == null)
                     proxy.AppNames = new List<string>();
+                else
+                    proxy.AppNames.RemoveAll(string.IsNullOrWhiteSpace);
 
                 if (proxy.AppNames.Count == 0)
                     LoggerInstance.Warn(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
             }
+
+            // Drop null/blank excluded entries for the same reason.
+            settings.ExcludedList.RemoveAll(string.IsNullOrWhiteSpace);
 
             return settings;
         }

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -48,10 +48,12 @@ namespace ProxiFyre
             // Form the path to NLog.config
             var logConfigFilePath = Path.Combine(directoryPath ?? string.Empty, "NLog.config");
 
-            // Load the configuration from JSON
-            var serviceSettings = JsonConvert.DeserializeObject<ProxiFyreSettings>(File.ReadAllText(configFilePath));
+            // Configure logging first so that any configuration problems below are recorded.
+            if (File.Exists(logConfigFilePath))
+                LogManager.Configuration = new XmlLoggingConfiguration(logConfigFilePath);
 
-            LogManager.Configuration = new XmlLoggingConfiguration(logConfigFilePath);
+            // Load and validate the configuration from JSON
+            var serviceSettings = LoadConfiguration(configFilePath);
 
             // Handle the global log level from the configuration
             _logLevel = Enum.TryParse<LogLevel>(serviceSettings.LogLevel, true, out var globalLogLevel)
@@ -83,11 +85,19 @@ namespace ProxiFyre
                     appSettings.Password, appSettings.SupportedProtocolsParse,
                     true); // Assuming the AddSocks5Proxy method supports a list of protocols
 
+                if (proxy.ToInt64() == -1)
+                {
+                    LoggerInstance.Warn(
+                        $"Failed to create SOCKS5 proxy for endpoint {appSettings.Socks5ProxyEndpoint}; skipping its application associations.");
+                    continue;
+                }
+
+                var protocols = string.Join(", ", appSettings.SupportedProtocols ?? new List<string>());
                 foreach (var appName in appSettings.AppNames)
                     // Associate the defined application names to the proxies
-                    if (proxy.ToInt64() != -1 && _socksify.AssociateProcessNameToProxy(appName, proxy) && _logLevel >= LogLevel.Info)
+                    if (_socksify.AssociateProcessNameToProxy(appName, proxy) && _logLevel >= LogLevel.Info)
                         LoggerInstance.Info(
-                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {string.Join(", ", appSettings.SupportedProtocols)}!");
+                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {protocols}!");
             }
 
             foreach (var excludedEntry in serviceSettings.ExcludedList)
@@ -108,12 +118,77 @@ namespace ProxiFyre
         }
 
         /// <summary>
+        /// Loads, parses and validates the ProxiFyre configuration file.
+        /// </summary>
+        /// <param name="configFilePath">Full path to app-config.json.</param>
+        /// <returns>The validated <see cref="ProxiFyreSettings"/>.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the file is missing, cannot be parsed, or fails validation.
+        /// </exception>
+        private static ProxiFyreSettings LoadConfiguration(string configFilePath)
+        {
+            if (!File.Exists(configFilePath))
+            {
+                var message = $"Configuration file not found: '{configFilePath}'. " +
+                              "Create an app-config.json next to ProxiFyre.exe before starting the service.";
+                LoggerInstance.Error(message);
+                throw new InvalidOperationException(message);
+            }
+
+            ProxiFyreSettings settings;
+            try
+            {
+                settings = JsonConvert.DeserializeObject<ProxiFyreSettings>(File.ReadAllText(configFilePath));
+            }
+            catch (Exception ex)
+            {
+                var message = $"Failed to read or parse configuration file '{configFilePath}': {ex.Message}";
+                LoggerInstance.Error(ex, message);
+                throw new InvalidOperationException(message, ex);
+            }
+
+            if (settings == null)
+            {
+                var message = $"Configuration file '{configFilePath}' is empty or contains no settings.";
+                LoggerInstance.Error(message);
+                throw new InvalidOperationException(message);
+            }
+
+            if (settings.Proxies == null || settings.Proxies.Count == 0)
+            {
+                var message = $"Configuration file '{configFilePath}' does not define any proxies. " +
+                              "Add at least one entry under \"proxies\".";
+                LoggerInstance.Error(message);
+                throw new InvalidOperationException(message);
+            }
+
+            foreach (var proxy in settings.Proxies)
+            {
+                if (string.IsNullOrWhiteSpace(proxy.Socks5ProxyEndpoint))
+                {
+                    var message = "Each proxy entry must specify a non-empty \"socks5ProxyEndpoint\".";
+                    LoggerInstance.Error(message);
+                    throw new InvalidOperationException(message);
+                }
+
+                if (proxy.AppNames == null)
+                    proxy.AppNames = new List<string>();
+
+                if (proxy.AppNames.Count == 0)
+                    LoggerInstance.Warn(
+                        $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
+            }
+
+            return settings;
+        }
+
+        /// <summary>
         /// Stops the ProxiFyre service and disposes of resources.
         /// </summary>
         public void Stop()
         {
             // Dispose of the Socksifier before exiting
-            _socksify.Dispose();
+            _socksify?.Dispose();
             if (_logLevel >= LogLevel.Info)
                 LoggerInstance.Info("ProxiFyre Service has stopped.");
             LogManager.Shutdown();
@@ -260,7 +335,7 @@ namespace ProxiFyre
             {
                 get
                 {
-                    if (SupportedProtocols.Count == 0 ||
+                    if (SupportedProtocols == null || SupportedProtocols.Count == 0 ||
                         (SupportedProtocols.Contains("TCP") && SupportedProtocols.Contains("UDP")))
                         return SupportedProtocolsEnum.BOTH;
                     if (SupportedProtocols.Contains("TCP"))

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -92,7 +92,9 @@ namespace ProxiFyre
                     continue;
                 }
 
-                var protocols = string.Join(", ", appSettings.SupportedProtocols ?? new List<string>());
+                var protocols = appSettings.SupportedProtocols != null && appSettings.SupportedProtocols.Count > 0
+                    ? string.Join(", ", appSettings.SupportedProtocols)
+                    : "TCP, UDP";
                 foreach (var appName in appSettings.AppNames)
                     // Associate the defined application names to the proxies
                     if (_socksify.AssociateProcessNameToProxy(appName, proxy) && _logLevel >= LogLevel.Info)
@@ -164,6 +166,14 @@ namespace ProxiFyre
 
             foreach (var proxy in settings.Proxies)
             {
+                if (proxy == null)
+                {
+                    var message = $"Configuration file '{configFilePath}' contains a null entry under \"proxies\". " +
+                                  "Remove the empty entry or replace it with a valid proxy definition.";
+                    LoggerInstance.Error(message);
+                    throw new InvalidOperationException(message);
+                }
+
                 if (string.IsNullOrWhiteSpace(proxy.Socks5ProxyEndpoint))
                 {
                     var message = "Each proxy entry must specify a non-empty \"socks5ProxyEndpoint\".";

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -181,6 +181,7 @@ namespace proxy
                                         nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
                                     {
                                         tcp_proxy_socket<T>::close_client(false, false);
+                                        return;
                                     }
 
                                     current_state_ = socks5_state::password_sent;
@@ -224,6 +225,7 @@ namespace proxy
                                 nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
                             {
                                 tcp_proxy_socket<T>::close_client(false, false);
+                                return;
                             }
 
                             current_state_ = socks5_state::connect_sent;
@@ -283,6 +285,7 @@ namespace proxy
                             nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
                         {
                             tcp_proxy_socket<T>::close_client(false, false);
+                            return;
                         }
 
                         current_state_ = socks5_state::connect_sent;

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1133,7 +1133,13 @@ namespace proxy
         static std::wstring to_upper(const std::wstring& str)
         {
             std::wstring upper_case;
-            std::ranges::transform(str, std::back_inserter(upper_case), toupper);
+            upper_case.reserve(str.size());
+            // Use the wide-character ::towupper. The narrow ::toupper(int) has
+            // undefined behaviour for wchar_t values outside the unsigned char
+            // range and does not upper-case non-ASCII characters, which made
+            // process-name/exclusion matching diverge from network_process,
+            // whose names are upper-cased with ::towupper.
+            std::ranges::transform(str, std::back_inserter(upper_case), ::towupper);
             return upper_case;
         }
 

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1134,12 +1134,15 @@ namespace proxy
         {
             std::wstring upper_case;
             upper_case.reserve(str.size());
-            // Use the wide-character ::towupper. The narrow ::toupper(int) has
+            // Use the wide-character towupper. The narrow toupper(int) has
             // undefined behaviour for wchar_t values outside the unsigned char
             // range and does not upper-case non-ASCII characters, which made
             // process-name/exclusion matching diverge from network_process,
-            // whose names are upper-cased with ::towupper.
-            std::ranges::transform(str, std::back_inserter(upper_case), ::towupper);
+            // whose names are upper-cased with towupper. Wrap it in a lambda so
+            // the wchar_t -> wint_t -> wchar_t conversion is explicit and the
+            // call does not depend on towupper being a non-overloaded function.
+            std::ranges::transform(str, std::back_inserter(upper_case),
+                                   [](const wchar_t c) { return static_cast<wchar_t>(::towupper(c)); });
             return upper_case;
         }
 

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -138,7 +138,10 @@ bool socksify_unmanaged::stop() const
         return false;
     }
 
-    if (proxy_->stop())
+    // socks_local_router::stop() returns true on success (and false when the
+    // router was not active). Treating a successful stop as a failure here
+    // produced a misleading "[ERROR]" log and an inverted return value.
+    if (!proxy_->stop())
     {
         print_log(log_level_mx::info, "[ERROR]: Failed to stop the SOCKS5 Local Router instance."s);
         return false;

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -32,6 +32,18 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
         throw std::runtime_error(message);
     }
 
+    // WSAStartup succeeded. Because a constructor that exits via an exception
+    // does not run the destructor, the remainder of construction must release
+    // the Winsock reference acquired above if it throws (e.g. the pcap log file
+    // fails to open, or router construction throws). This guard calls
+    // WSACleanup() on such a failure and is disengaged once construction
+    // completes, leaving the matching cleanup to the destructor.
+    struct winsock_cleanup_guard
+    {
+        bool engaged = true;
+        ~winsock_cleanup_guard() { if (engaged) ::WSACleanup(); }
+    } winsock_guard;
+
     lock_ = std::make_unique<mutex_impl>();
 
     print_log(log_level_mx::info, "Creating SOCKS5 Local Router instance..."s);
@@ -63,7 +75,7 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
     }
 
     // Conditionally open the pcap log file if the log level is debug or higher
-    if (um_log_level > netlib::log::log_level::debug) {
+    if (um_log_level >= netlib::log::log_level::debug) {
         pcap_log_file_.emplace("proxifyre_log.pcap", std::ios::binary | std::ios::out);
         // Check if the optional contains a value and then access it to call is_open()
         if (!pcap_log_file_->is_open()) {
@@ -87,6 +99,9 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
     }
 
     print_log(log_level_mx::info, "SOCKS5 Local Router instance successfully created."s);
+
+    // Construction succeeded; hand Winsock cleanup back to the destructor.
+    winsock_guard.engaged = false;
 }
 
 /**

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -21,9 +21,15 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
 
     WSADATA wsa_data;
 
-    if (constexpr auto version_requested = MAKEWORD(2, 2); ::WSAStartup(version_requested, &wsa_data) != 0)
+    constexpr auto version_requested = MAKEWORD(2, 2);
+    if (const auto wsa_error = ::WSAStartup(version_requested, &wsa_data); wsa_error != 0)
     {
-        print_log(log_level_mx::error, "WSAStartup failed with error\n");
+        // WSAStartup returns the error code directly. Winsock is unusable when
+        // it fails, so fail fast (as documented) instead of continuing with a
+        // broken socket subsystem and producing confusing follow-on errors.
+        const auto message = "WSAStartup failed with error "s + std::to_string(wsa_error);
+        print_log(log_level_mx::error, message);
+        throw std::runtime_error(message);
     }
 
     lock_ = std::make_unique<mutex_impl>();

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -23,7 +23,7 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
 
     if (constexpr auto version_requested = MAKEWORD(2, 2); ::WSAStartup(version_requested, &wsa_data) != 0)
     {
-        print_log(log_level_mx::info, "WSAStartup failed with error\n");
+        print_log(log_level_mx::error, "WSAStartup failed with error\n");
     }
 
     lock_ = std::make_unique<mutex_impl>();
@@ -76,7 +76,7 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
 
     if (!proxy_)
     {
-        print_log(log_level_mx::info, "[ERROR]: Failed to create the SOCKS5 Local Router instance!"s);
+        print_log(log_level_mx::error, "Failed to create the SOCKS5 Local Router instance!"s);
         throw std::runtime_error("[ERROR]: Failed to create the SOCKS5 Local Router instance!");
     }
 
@@ -114,7 +114,7 @@ bool socksify_unmanaged::start() const
 
     if (!proxy_->start())
     {
-        print_log(log_level_mx::info, "[ERROR]: Failed to start the SOCKS5 Local Router instance!"s);
+        print_log(log_level_mx::error, "Failed to start the SOCKS5 Local Router instance!"s);
         return false;
     }
 
@@ -133,17 +133,17 @@ bool socksify_unmanaged::stop() const
 
     if (!proxy_)
     {
-        print_log(log_level_mx::info,
-            "[ERROR]: Failed to stop the SOCKS5 Local Router instance. Instance does not exist."s);
+        print_log(log_level_mx::error,
+            "Failed to stop the SOCKS5 Local Router instance. Instance does not exist."s);
         return false;
     }
 
     // socks_local_router::stop() returns true on success (and false when the
     // router was not active). Treating a successful stop as a failure here
-    // produced a misleading "[ERROR]" log and an inverted return value.
+    // produced a misleading error log and an inverted return value.
     if (!proxy_->stop())
     {
-        print_log(log_level_mx::info, "[ERROR]: Failed to stop the SOCKS5 Local Router instance."s);
+        print_log(log_level_mx::error, "Failed to stop the SOCKS5 Local Router instance."s);
         return false;
     }
 
@@ -297,7 +297,13 @@ void socksify_unmanaged::log_event(const event_mx log)
  */
 void socksify_unmanaged::print_log(const log_level_mx level, const std::string& message) const
 {
-    if (level < log_level_)
+    // Emit the message when its severity is at or below the configured
+    // verbosity threshold. log_level_mx orders severities from error (0) to
+    // all (255), so a message must be printed when level <= log_level_. The
+    // previous strict comparison dropped messages whose level equalled the
+    // threshold, e.g. error messages were never shown at the "error" level and
+    // info messages were never shown at the "info" level.
+    if (level <= log_level_)
     {
         log_printer(message.c_str());
     }

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -95,7 +95,7 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
     if (!proxy_)
     {
         print_log(log_level_mx::error, "Failed to create the SOCKS5 Local Router instance!"s);
-        throw std::runtime_error("[ERROR]: Failed to create the SOCKS5 Local Router instance!");
+        throw std::runtime_error("Failed to create the SOCKS5 Local Router instance!");
     }
 
     print_log(log_level_mx::info, "SOCKS5 Local Router instance successfully created."s);
@@ -159,12 +159,15 @@ bool socksify_unmanaged::stop() const
         return false;
     }
 
-    // socks_local_router::stop() returns true on success (and false when the
-    // router was not active). Treating a successful stop as a failure here
-    // produced a misleading error log and an inverted return value.
+    // socks_local_router::stop() returns true on success and false only when
+    // the router was already inactive (an idempotent no-op, e.g. when Dispose
+    // runs after an explicit Stop()). That is not a failure, so log it at info
+    // level to avoid noisy error logs while preserving the documented false
+    // return for callers that distinguish "stopped now" from "was not active".
     if (!proxy_->stop())
     {
-        print_log(log_level_mx::error, "Failed to stop the SOCKS5 Local Router instance."s);
+        print_log(log_level_mx::info,
+            "SOCKS5 Local Router instance was already stopped (not active)."s);
         return false;
     }
 


### PR DESCRIPTION
## Summary

First round of fixes from the production-readiness review. These are the safe, self-contained correctness/reliability fixes. Each is a separate commit so they can be reviewed independently. Larger items that need a design decision (IPv6 leak handling, test/CI bootstrap) are intentionally **not** included here — see "Follow-ups" below.

## Fixes in this PR

### 1. Inverted `stop()` return value — `socksify/socksify_unmanaged.cpp`
`socks_local_router::stop()` returns `true` on success (and `false` when the router was already inactive), mirroring `start()`. The wrapper treated a successful stop as a failure, logging a misleading `[ERROR]` and returning an inverted result to the public API. Changed `if (proxy_->stop())` → `if (!proxy_->stop())`.
**Severity: High** (wrong public-API result + misleading logs).

### 2. Wide-char upper-casing in `to_upper` — `netlib/src/proxy/socks_local_router.h`
`to_upper` ran `wchar_t` values through the narrow `::toupper(int)`, which is undefined behaviour for code units outside the `unsigned char` range and does not upper-case non-ASCII characters. Process-name/exclusion matching therefore silently failed for any process whose name or path contained non-ASCII characters, diverging from `network_process::to_upper` (which uses `::towupper`). Switched to `::towupper` (already available in this translation unit via `process_lookup.h`) and reserved the result buffer.
**Severity: High** (silent matching failure → traffic not proxied/excluded as configured).

### 3. Missing `return` after send-failure `close_client()` — `netlib/src/proxy/socks5_tcp_proxy_socket.h`
In `process_receive_negotiate_complete`, each `WSASend`-failure branch called `close_client()` but then fell through to update `current_state_` and post a `WSARecv` on the just-closed socket (handle already `INVALID_SOCKET`). It only stayed "safe" by relying on the second I/O failing and re-entering `close_client`. Added an explicit `return;` after each send-failure close, matching the pattern already used in `remote_negotiate()`.
**Severity: Medium** (relies on accidental safety; fragile under future edits).

### 4. Configuration validation before startup — `ProxiFyre/Program.cs`
`Start()` read `app-config.json` with `File.ReadAllText` (bare `FileNotFoundException` when missing), deserialized with no null check, and iterated `Proxies` / `SupportedProtocols` / `AppNames` without null guards — producing opaque `NullReferenceException`s on malformed or partial configs. Added a `LoadConfiguration` helper that:
- reports a clear error when `app-config.json` is missing,
- wraps parse failures with context instead of leaking raw JSON exceptions,
- rejects empty configs and configs without proxies or endpoints,
- defaults `AppNames` and warns when a proxy matches no applications.

Also: configure NLog **before** loading config so these errors are actually logged; skip proxies that fail to create instead of associating apps to an invalid handle; null-guard `SupportedProtocolsParse`; null-guard `Stop()`.
**Severity: Medium** (operability — failures were opaque crashes).

## Testing
No automated build was run in this environment: the native toolchain dependencies (vcpkg `ms-gsl` + `boost-pool`, and the WinpkFilter SDK) are not provisioned here, so a full MSBuild of the C++/CLI projects isn't possible. Changes were kept small and verified against the codebase's conventions (e.g. `process_receive_negotiate_complete` is `void` so the added `return;` is valid; `::towupper` is already used by `process_lookup.h`, included before `socks_local_router.h`). Please let CI / a maintainer build validate.

## Follow-ups (not in this PR — need a decision)
- **IPv6 leak:** the filter callback passes all non-`ETH_P_IP` traffic, and `process_lookup_v6_` is constructed but unused, so proxied apps' IPv6 traffic egresses unproxied. Options: implement IPv6 proxying, block IPv6 for proxied apps, or document the limitation. Needs a product decision.
- **Tests/CI:** there are no tests, and CI only runs on tag push (no PR validation). Worth adding at least PR-triggered build validation.

---
Reviewing over rounds before merge per request.