### PR TITLE
IPv6 proxying: deep code-review hardening

### DIFF
--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -80,6 +80,15 @@ namespace ProxiFyre
 
             foreach (var appSettings in serviceSettings.Proxies)
             {
+                // Warn on a half-specified credential: SOCKS5 username/password auth needs
+                // both, so providing only one silently falls back to no authentication.
+                var hasUser = !string.IsNullOrEmpty(appSettings.Username);
+                var hasPass = !string.IsNullOrEmpty(appSettings.Password);
+                if (hasUser != hasPass)
+                    LoggerInstance.Warn(
+                        $"Proxy {appSettings.Socks5ProxyEndpoint}: only one of username/password is set; " +
+                        "authentication will be skipped. Provide both or neither.");
+
                 // Add the defined SOCKS5 proxies
                 var proxy = _socksify.AddSocks5Proxy(appSettings.Socks5ProxyEndpoint, appSettings.Username,
                     appSettings.Password, appSettings.SupportedProtocolsParse,
@@ -192,6 +201,21 @@ namespace ProxiFyre
                 if (proxy.AppNames.Count == 0)
                     LoggerInstance.Warn(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
+
+                // Warn on unrecognized protocol tokens: SupportedProtocolsParse treats a list
+                // containing neither "TCP" nor "UDP" as BOTH, so a typo would silently proxy
+                // everything instead of what the user intended.
+                if (proxy.SupportedProtocols != null)
+                {
+                    var unknownProtocols = proxy.SupportedProtocols
+                        .Where(p => p != "TCP" && p != "UDP")
+                        .ToList();
+                    if (unknownProtocols.Count > 0)
+                        LoggerInstance.Warn(
+                            $"Proxy '{proxy.Socks5ProxyEndpoint}' lists unrecognized protocol(s): " +
+                            $"{string.Join(", ", unknownProtocols)}. Only \"TCP\" and \"UDP\" are recognized; " +
+                            "the entry will be treated as both.");
+                }
             }
 
             // Drop null/blank excluded entries for the same reason.
@@ -225,7 +249,7 @@ namespace ProxiFyre
                 // Format log entry with ISO 8601 timestamp, event, description, and data.
                 //var logMessage =
                 //    $"{DateTimeOffset.FromUnixTimeMilliseconds(entry.TimeStamp):u} | Event: {entry.Event} | Description: {entry.Description ?? string.Empty} | Data: {entry.Data}";
-                LoggerInstance.Info(entry.Description?.Replace("\n", "").Replace("\r", ""));
+                LoggerInstance.Info((entry.Description ?? string.Empty).Replace("\n", "").Replace("\r", ""));
             }
         }
 

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -202,9 +202,10 @@ namespace ProxiFyre
                     LoggerInstance.Warn(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
 
-                // Warn on unrecognized protocol tokens: SupportedProtocolsParse treats a list
-                // containing neither "TCP" nor "UDP" as BOTH, so a typo would silently proxy
-                // everything instead of what the user intended.
+                // Warn on unrecognized protocol tokens: SupportedProtocolsParse only counts
+                // "TCP"/"UDP" and ignores anything else, defaulting to BOTH only when neither
+                // is present -- so a typo alongside a valid token is silently dropped, and a
+                // typo on its own silently proxies both protocols.
                 if (proxy.SupportedProtocols != null)
                 {
                     var unknownProtocols = proxy.SupportedProtocols
@@ -214,7 +215,7 @@ namespace ProxiFyre
                         LoggerInstance.Warn(
                             $"Proxy '{proxy.Socks5ProxyEndpoint}' lists unrecognized protocol(s): " +
                             $"{string.Join(", ", unknownProtocols)}. Only \"TCP\" and \"UDP\" are recognized; " +
-                            "the entry will be treated as both.");
+                            "unrecognized tokens are ignored (a proxy with no recognized protocol defaults to both).");
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ As of **v2.1.1**, ProxiFyre also supports **process exclusions**, allowing you t
 
 As of **v2.2.0**, ProxiFyre supports **LAN bypass**, allowing local network traffic to pass through without being proxied.
 
+As of **v2.3.0**, ProxiFyre also proxies **IPv6** destinations. Previously only IPv4 traffic from a matched application was routed through the proxy while its IPv6 TCP/UDP traffic leaked out directly; now both address families are redirected to the configured SOCKS5 proxy. Existing IPv4 proxy endpoints (e.g. `127.0.0.1:1080`) continue to work unchanged — ProxiFyre reaches an IPv4 SOCKS5 server over a dual-stack connection when relaying IPv6 destinations. Note that to actually carry IPv6 destinations your SOCKS5 server must accept IPv6 target addresses (SOCKS5 `ATYP=4`); servers that only support IPv4/domain targets will reject them. **Limitation:** *fragmented* IPv6 datagrams are not redirected. To avoid corrupting a partially rewritten datagram, IPv6 packets that arrive fragmented are passed through unproxied — so an application that emits oversized IPv6 UDP datagrams (which the OS fragments at the source) can leak those datagrams outside the proxy. Most traffic is unaffected: TCP is never source-fragmented, and UDP that honors path-MTU discovery (e.g. QUIC/HTTP3) does not fragment. A one-time warning is logged when such a packet is first passed through.
+
 ---
 
 ## Configuration

--- a/netlib/src/iphelper/process_lookup.h
+++ b/netlib/src/iphelper/process_lookup.h
@@ -114,9 +114,12 @@ namespace iphelper
         std::wstring device_path_name;      ///< Device path version of path_name (uppercase)
         std::optional<uint16_t> tcp_proxy_port = std::nullopt; // Optional TCP proxy port if the process is associated with a proxy
         std::optional<uint16_t> udp_proxy_port = std::nullopt; // Optional UDP proxy port if the process is associated with a proxy
-        bool excluded = false;          ///< Whether the process is excluded from proxying
-        bool bypass_tcp = false;        ///< Whether TCP connections should bypass proxying (no proxy configured)
-        bool bypass_udp = false;        ///< Whether UDP connections should bypass proxying (no proxy configured)
+        // These cache flags can be set from match_app_name()/packet handlers running on
+        // multiple threads for the same process, so they are atomic to avoid a data race
+        // (the writes are idempotent 'true' stores; relaxed ordering would suffice).
+        std::atomic<bool> excluded{ false };    ///< Whether the process is excluded from proxying
+        std::atomic<bool> bypass_tcp{ false };  ///< Whether TCP connections should bypass proxying (no proxy configured)
+        std::atomic<bool> bypass_udp{ false };  ///< Whether UDP connections should bypass proxying (no proxy configured)
     };
 
     /**
@@ -194,8 +197,8 @@ namespace iphelper
         // Core data structures
         tcp_hashtable_t  tcp_to_app_;           ///< TCP sessions to process mapping
         udp_hashtable_t  udp_to_app_;           ///< UDP endpoints to process mapping
-        std::shared_mutex tcp_to_app_mutex_;    ///< Reader-writer lock for TCP hash table
-        std::shared_mutex udp_to_app_mutex_;    ///< Reader-writer lock for UDP hash table
+        mutable std::shared_mutex tcp_to_app_mutex_;    ///< Reader-writer lock for TCP hash table (mutable: locked by const readers)
+        mutable std::shared_mutex udp_to_app_mutex_;    ///< Reader-writer lock for UDP hash table
 
         // Protected apps cache (for processes that couldn't be resolved)
         tcp_protected_t tcp_protected_apps_;        ///< TCP sessions with unresolvable processes
@@ -420,6 +423,8 @@ namespace iphelper
         std::vector<net::ip_session<T>> get_all_tcp_sessions() const
         {
             std::vector<net::ip_session<T>> sessions;
+
+            std::shared_lock lock(tcp_to_app_mutex_); // Guard concurrent access like the other readers
             sessions.reserve(tcp_to_app_.size()); // Reserve memory to avoid multiple allocations
 
             for (const auto& entry : tcp_to_app_)

--- a/netlib/src/ndisapi/socks5_udp_local_redirect.h
+++ b/netlib/src/ndisapi/socks5_udp_local_redirect.h
@@ -305,6 +305,24 @@ namespace ndisapi
                     std::string{ T{ip_header->ip_dst} },
                     ntohs(udp_header->th_dport));
 
+                // Validate lengths before inserting the SOCKS5 UDP header: the UDP header
+                // must be fully captured, and the packet must have room to grow by
+                // socks5_header_size. Without the MAX_ETHER_FRAME guard a near-MTU datagram
+                // makes the memmove (and the m_Length increment below) write past m_IBuffer;
+                // the captured-size check prevents the payload-size underflow on a truncated
+                // frame. Mirrors the IPv6 attach guards.
+                {
+                    constexpr auto socks5_header_size = sizeof(proxy::socks5_udp_header<T>);
+                    const auto* const packet_end = packet.m_IBuffer + packet.m_Length;
+                    const auto* const udp_header_bytes = reinterpret_cast<const uint8_t*>(udp_header);
+                    if (udp_header_bytes > packet_end ||
+                        static_cast<size_t>(packet_end - udp_header_bytes) < sizeof(udphdr) ||
+                        packet.m_Length + socks5_header_size > MAX_ETHER_FRAME)
+                    {
+                        return false;
+                    }
+                }
+
                 auto* udp_payload = reinterpret_cast<uint8_t*>(udp_header + 1);
                 const auto udp_payload_size = static_cast<uint16_t>(packet.m_Length - sizeof(ether_header) - sizeof(
                     DWORD) * ip_header->ip_hl - sizeof(udphdr));
@@ -376,18 +394,32 @@ namespace ndisapi
                     std::string{ T{ip_header->ip6_dst} },
                     ntohs(udp_header->th_dport));
 
+                constexpr auto socks5_header_size = sizeof(proxy::socks5_udp_header<T>);
+                const auto* const packet_end = packet.m_IBuffer + packet.m_Length;
+                const auto* const udp_header_bytes = reinterpret_cast<const uint8_t*>(udp_header);
+                if (udp_header_bytes > packet_end ||
+                    static_cast<size_t>(packet_end - udp_header_bytes) < sizeof(udphdr))
+                {
+                    return false;
+                }
+
+                const auto udp_length = ntohs(udp_header->length);
+                const auto captured_udp_size = static_cast<size_t>(packet_end - udp_header_bytes);
+                if (udp_length < sizeof(udphdr) ||
+                    udp_length > captured_udp_size ||
+                    packet.m_Length + socks5_header_size > MAX_ETHER_FRAME)
+                {
+                    return false;
+                }
+
                 // Attach SOCK5 UDP header here
                 auto* udp_payload = reinterpret_cast<uint8_t*>(udp_header + 1);
-                const auto udp_payload_size = static_cast<uint16_t>(packet.m_Length - sizeof(ether_header) - sizeof(
-                    ipv6hdr) - sizeof(udphdr));
-                constexpr auto udp_max_payload_size = static_cast<uint16_t>(MAX_ETHER_FRAME - sizeof(ether_header) -
-                    sizeof(ipv6hdr) - sizeof(udphdr));
-                memmove(udp_payload + sizeof(proxy::socks5_udp_header<T>), udp_payload,
-                    std::min(udp_payload_size, udp_max_payload_size));
+                const auto udp_payload_size = static_cast<size_t>(udp_length - sizeof(udphdr));
+                memmove(udp_payload + socks5_header_size, udp_payload, udp_payload_size);
 
-                packet.m_Length += sizeof(proxy::socks5_udp_header<T>);
-                ip_header->ip6_len = htons(ntohs(ip_header->ip6_len) + sizeof(proxy::socks5_udp_header<T>));
-                udp_header->length = htons(ntohs(udp_header->length) + sizeof(proxy::socks5_udp_header<T>));
+                packet.m_Length += socks5_header_size;
+                ip_header->ip6_len = htons(ntohs(ip_header->ip6_len) + socks5_header_size);
+                udp_header->length = htons(ntohs(udp_header->length) + socks5_header_size);
                 auto* socks5_udp_header_ptr = reinterpret_cast<proxy::socks5_udp_header<T>*>(udp_payload);
 
                 socks5_udp_header_ptr->reserved = 0;
@@ -459,6 +491,31 @@ namespace ndisapi
                 if (it == endpoints_.cend())
                     return false;
 
+                // Validate lengths before mutating anything: udp_header->length comes from
+                // the received datagram. Without these guards a short/forged length makes
+                // udp_payload_size - socks5_header_size underflow into a huge value and the
+                // memmove writes far out of bounds. Mirrors the IPv6 detach guards.
+                constexpr auto socks5_header_size = sizeof(proxy::socks5_udp_header<T>);
+                const auto* const packet_end = packet.m_IBuffer + packet.m_Length;
+                const auto* const udp_header_bytes = reinterpret_cast<const uint8_t*>(udp_header);
+                const auto udp_length = ntohs(udp_header->length);
+                if (udp_header_bytes > packet_end ||
+                    static_cast<size_t>(packet_end - udp_header_bytes) < sizeof(udphdr) ||
+                    udp_length < sizeof(udphdr) + socks5_header_size ||
+                    udp_length > static_cast<size_t>(packet_end - udp_header_bytes) ||
+                    packet.m_Length < socks5_header_size ||
+                    ntohs(ip_header->ip_len) < socks5_header_size)
+                {
+                    return false;
+                }
+
+                // Reject a reply whose SOCKS5 UDP header ATYP doesn't match this relay's family
+                // (IPv4 = 1): parsing a mismatched layout (e.g. a 16-byte IPv6 address as IPv4)
+                // would hand the client a spoofed/garbage source endpoint. The bounds check above
+                // guarantees the SOCKS5 header is fully captured. Done before any mutation.
+                if (reinterpret_cast<const proxy::socks5_udp_header<T>*>(udp_header + 1)->address_type != 1)
+                    return false;
+
                 NETLIB_DEBUG(
                     "S2C: {}:{} -> {}:{}",
                     std::string{ T{ip_header->ip_src} },
@@ -478,9 +535,9 @@ namespace ndisapi
                 ip_header->ip_src = socks5_udp_header_ptr->dest_address;
                 udp_header->th_sport = socks5_udp_header_ptr->dest_port;
 
-                const auto udp_payload_size = static_cast<uint16_t>(ntohs(udp_header->length) - sizeof(udphdr));
-                memmove(udp_payload, udp_payload + sizeof(proxy::socks5_udp_header<T>),
-                    udp_payload_size - sizeof(proxy::socks5_udp_header<T>));
+                const auto udp_payload_size = static_cast<size_t>(udp_length - sizeof(udphdr));
+                memmove(udp_payload, udp_payload + socks5_header_size,
+                    udp_payload_size - socks5_header_size);
 
                 packet.m_Length -= sizeof(proxy::socks5_udp_header<T>);
                 ip_header->ip_len = htons(ntohs(ip_header->ip_len) - sizeof(proxy::socks5_udp_header<T>));
@@ -528,26 +585,51 @@ namespace ndisapi
                     std::string{ T{ip_header->ip6_dst} },
                     ntohs(udp_header->th_dport));
 
+                // Remove SOCK5 UDP header here
+                constexpr auto socks5_header_size = sizeof(proxy::socks5_udp_header<T>);
+                const auto* const packet_end = packet.m_IBuffer + packet.m_Length;
+                const auto* const udp_header_bytes = reinterpret_cast<const uint8_t*>(udp_header);
+                if (udp_header_bytes > packet_end ||
+                    static_cast<size_t>(packet_end - udp_header_bytes) < sizeof(udphdr))
+                {
+                    return false;
+                }
+
+                const auto udp_length = ntohs(udp_header->length);
+                const auto captured_udp_size = static_cast<size_t>(packet_end - udp_header_bytes);
+                if (udp_length < sizeof(udphdr) + socks5_header_size ||
+                    udp_length > captured_udp_size ||
+                    packet.m_Length < socks5_header_size ||
+                    ntohs(ip_header->ip6_len) < socks5_header_size)
+                {
+                    return false;
+                }
+
+                auto* udp_payload = reinterpret_cast<uint8_t*>(udp_header + 1);
+                auto* socks5_udp_header_ptr = reinterpret_cast<proxy::socks5_udp_header<T>*>(udp_payload);
+
+                // Reject a reply whose SOCKS5 UDP header ATYP doesn't match this relay's family
+                // (IPv6 = 4); see the IPv4 path. The bounds check above guarantees the header is
+                // fully captured. Done before any mutation.
+                if (socks5_udp_header_ptr->address_type != 4)
+                    return false;
+
                 // Swap Ethernet addresses
                 std::swap(eth_header->h_dest, eth_header->h_source);
 
                 // Swap IP addresses
                 std::swap(ip_header->ip6_dst, ip_header->ip6_src);
 
-                // Remove SOCK5 UDP header here
-                auto* udp_payload = reinterpret_cast<uint8_t*>(udp_header + 1);
-                auto* socks5_udp_header_ptr = reinterpret_cast<proxy::socks5_udp_header<T>*>(udp_payload);
-
                 ip_header->ip6_src = socks5_udp_header_ptr->dest_address;
                 udp_header->th_sport = socks5_udp_header_ptr->dest_port;
 
-                const auto udp_payload_size = static_cast<uint16_t>(ntohs(udp_header->length) - sizeof(udphdr));
-                memmove(udp_payload, udp_payload + sizeof(proxy::socks5_udp_header<T>),
-                    udp_payload_size - sizeof(proxy::socks5_udp_header<T>));
+                const auto udp_payload_size = static_cast<size_t>(udp_length - sizeof(udphdr));
+                memmove(udp_payload, udp_payload + socks5_header_size,
+                    udp_payload_size - socks5_header_size);
 
-                packet.m_Length -= sizeof(proxy::socks5_udp_header<T>);
-                ip_header->ip6_len = htons(ntohs(ip_header->ip6_len) - sizeof(proxy::socks5_udp_header<T>));
-                udp_header->length = htons(ntohs(udp_header->length) - sizeof(proxy::socks5_udp_header<T>));
+                packet.m_Length -= socks5_header_size;
+                ip_header->ip6_len = htons(ntohs(ip_header->ip6_len) - socks5_header_size);
+                udp_header->length = htons(ntohs(udp_header->length) - socks5_header_size);
 
                 // Recalculate checksum
                 net::ipv6_helper::recalculate_tcp_udp_checksum(&packet);

--- a/netlib/src/ndisapi/tcp_local_redirect.h
+++ b/netlib/src/ndisapi/tcp_local_redirect.h
@@ -206,6 +206,13 @@ namespace ndisapi
                 auto* tcp_header = reinterpret_cast<tcphdr_ptr>(reinterpret_cast<PUCHAR>(ip_header) +
                     sizeof(DWORD) * ip_header->ip_hl);
 
+                // Ensure the full TCP header lies within the captured frame before reading
+                // tcp_header fields (th_flags is at offset 13); avoids keying state on stale
+                // bytes for a short/forged IPv4 frame.
+                if (ip_header->ip_hl < 5 ||
+                    ETHER_HEADER_LENGTH + sizeof(DWORD) * ip_header->ip_hl + sizeof(tcphdr) > packet.m_Length)
+                    return false;
+
                 std::lock_guard lock(lock_);
 
                 if ((tcp_header->th_flags & (TH_SYN | TH_ACK)) == TH_SYN)
@@ -365,6 +372,13 @@ namespace ndisapi
                 // This is TCP packet, get TCP header pointer
                 auto* tcp_header = reinterpret_cast<tcphdr_ptr>(reinterpret_cast<PUCHAR>(ip_header) +
                     sizeof(DWORD) * ip_header->ip_hl);
+
+                // Ensure the full TCP header lies within the captured frame before reading
+                // tcp_header fields (th_flags is at offset 13); avoids keying state on stale
+                // bytes for a short/forged IPv4 frame.
+                if (ip_header->ip_hl < 5 ||
+                    ETHER_HEADER_LENGTH + sizeof(DWORD) * ip_header->ip_hl + sizeof(tcphdr) > packet.m_Length)
+                    return false;
 
                 std::lock_guard lock(lock_);
 

--- a/netlib/src/net/ipv6_helper.h
+++ b/netlib/src/net/ipv6_helper.h
@@ -43,9 +43,8 @@ namespace net
             while (true)
             {
                 // Ensure that current header is still within the packet
-                if (reinterpret_cast<const char*>(next_header) > reinterpret_cast<const char*>(ip_header) + packet_size
-                    - sizeof(
-                        ipv6ext))
+                if (reinterpret_cast<const char*>(next_header) + sizeof(ipv6ext) >
+                    reinterpret_cast<const char*>(ip_header) + packet_size)
                 {
                     return { nullptr, next_proto };
                 }
@@ -57,8 +56,8 @@ namespace net
                 {
                     const auto frag = reinterpret_cast<const ipv6ext_frag*>(next_header);
 
-                    if (reinterpret_cast<const char*>(frag) > reinterpret_cast<const char*>(ip_header) + packet_size -
-                        sizeof(ipv6ext_frag))
+                    if (reinterpret_cast<const char*>(frag) + sizeof(ipv6ext_frag) >
+                        reinterpret_cast<const char*>(ip_header) + packet_size)
                     {
                         return { nullptr, next_proto };
                     }

--- a/netlib/src/net/ipv6_helper.h
+++ b/netlib/src/net/ipv6_helper.h
@@ -57,24 +57,18 @@ namespace net
                 {
                     const auto frag = reinterpret_cast<const ipv6ext_frag*>(next_header);
 
-                    // If this isn't the FIRST fragment, there won't be a TCP/UDP header anyway
-                    if ((frag->ip6_offlg & 0xFC) != 0)
+                    if (reinterpret_cast<const char*>(frag) > reinterpret_cast<const char*>(ip_header) + packet_size -
+                        sizeof(ipv6ext_frag))
                     {
-                        // The offset is non-zero
-                        next_proto = frag->ip6_next;
-
                         return { nullptr, next_proto };
                     }
 
-                    // Otherwise it's either an entire segment or the first fragment
                     next_proto = frag->ip6_next;
-
-                    // Return next octet following the fragmentation header
-                    next_header = reinterpret_cast<const ipv6ext*>(reinterpret_cast<const char*>(next_header) +
-                        sizeof(
-                            ipv6ext_frag));
-
-                    return { const_cast<void*>(static_cast<const void*>(next_header)), next_proto };
+                    // Transparent redirection cannot safely mutate only the first
+                    // fragment while later fragments bypass the redirect path.
+                    // Leave fragmented IPv6 traffic untouched unless a caller adds
+                    // reassembly-aware handling.
+                    return { nullptr, next_proto };
                 }
 
                 // Headers we just skip over
@@ -93,8 +87,24 @@ namespace net
                     break;
 
                 default:
-                    // No more IPv6 headers to skip
-                    return { const_cast<void*>(static_cast<const void*>(next_header)), next_proto };
+                    {
+                        // No more IPv6 headers to skip. The loop guard above only
+                        // guarantees sizeof(ipv6ext) (4) bytes past next_header, but
+                        // callers cast this to a full tcphdr/udphdr and read fields well
+                        // beyond that (e.g. TCP flags at offset 13). Reject a transport
+                        // header that is truncated within the captured frame so the packet
+                        // is passed through untouched instead of reading stale bytes past
+                        // the captured packet end.
+                        const auto* const transport = reinterpret_cast<const char*>(next_header);
+                        const auto* const packet_end = reinterpret_cast<const char*>(ip_header) + packet_size;
+                        const auto captured = static_cast<size_t>(packet_end - transport);
+                        if ((next_proto == IPPROTO_TCP && captured < sizeof(tcphdr)) ||
+                            (next_proto == IPPROTO_UDP && captured < sizeof(udphdr)))
+                        {
+                            return { nullptr, next_proto };
+                        }
+                        return { const_cast<void*>(static_cast<const void*>(next_header)), next_proto };
+                    }
                 }
             }
         }

--- a/netlib/src/proxy/socks5_common.h
+++ b/netlib/src/proxy/socks5_common.h
@@ -69,10 +69,13 @@ namespace proxy
             unsigned char* password_length_ptr = reinterpret_cast<unsigned char*>(username_reserved) + username_length;
             char* password_ptr = reinterpret_cast<char*>(password_length_ptr) + 1;
 
-            strcpy_s(username_reserved, 255, username.c_str());
+            // Copy without a NUL terminator: the RFC 1929 block carries explicit length
+            // prefixes, and strcpy_s's size argument includes the terminator (so a bound of
+            // 255 faults/truncates on a 255-char field that the length check above accepts).
+            memcpy(username_reserved, username.data(), username.length());
 
             *password_length_ptr = static_cast<unsigned char>(password.length());
-            strcpy_s(password_ptr, 255, password.c_str());
+            memcpy(password_ptr, password.data(), password.length());
 
             return (3 + static_cast<int>(username.length()) + static_cast<int>(password.length()));
         }

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -272,8 +272,16 @@ namespace proxy
                     server_socket_,
                     [this](const DWORD num_bytes, OVERLAPPED* povlp, const BOOL status)
                     {
+                        // Count this completion for the entire duration of the callback so
+                        // stop() waits for it. EVERY completion the IOCP delivers on this
+                        // shared key -- the server read AND every per-session proxy
+                        // relay/negotiate/inject completion -- is balanced exactly once:
+                        // +1 here, -1 in the guard below. (Previously only the server-read
+                        // re-post incremented, so proxy completions drove the counter
+                        // negative and stop() could stop waiting while a callback still ran.)
+                        active_iocp_operations_.fetch_add(1, std::memory_order_acquire);
+
                         // RAII guard to ensure we decrement on all exit paths (including exceptions)
-                        // Note: Counter was already incremented BEFORE the I/O operation was posted
                         struct operation_guard {
                             std::atomic<int32_t>& counter;
                             
@@ -333,42 +341,51 @@ namespace proxy
 
                         if (status && result)
                         {
-                            switch (io_context->io_operation)
+                            // The proxy socket may have released its self-reference during
+                            // teardown; a late completion then finds null and is safely ignored.
+                            if (auto proxy_socket = io_context->proxy_socket_ptr)
                             {
-                            case proxy_io_operation::relay_io_read:
-                                io_context->proxy_socket_ptr->process_receive_buffer_complete(num_bytes, io_context);
-                                break;
+                                switch (io_context->io_operation)
+                                {
+                                case proxy_io_operation::relay_io_read:
+                                    proxy_socket->process_receive_buffer_complete(num_bytes, io_context);
+                                    break;
 
-                            case proxy_io_operation::relay_io_write:
-                                io_context->proxy_socket_ptr->process_send_buffer_complete(num_bytes, io_context);
-                                break;
+                                case proxy_io_operation::relay_io_write:
+                                    proxy_socket->process_send_buffer_complete(num_bytes, io_context);
+                                    break;
 
-                            case proxy_io_operation::negotiate_io_read:
-                                io_context->proxy_socket_ptr->process_receive_negotiate_complete(num_bytes, io_context);
-                                break;
+                                case proxy_io_operation::negotiate_io_read:
+                                    proxy_socket->process_receive_negotiate_complete(num_bytes, io_context);
+                                    break;
 
-                            case proxy_io_operation::negotiate_io_write:
-                                io_context->proxy_socket_ptr->process_send_negotiate_complete(num_bytes, io_context);
-                                break;
+                                case proxy_io_operation::negotiate_io_write:
+                                    proxy_socket->process_send_negotiate_complete(num_bytes, io_context);
+                                    break;
 
-                            case proxy_io_operation::inject_io_write:
-                                T::process_inject_buffer_complete(packet_pool_, io_context);
-                                break;
+                                case proxy_io_operation::inject_io_write:
+                                    T::process_inject_buffer_complete(packet_pool_, io_context);
+                                    break;
 
-                            default: break; // NOLINT(clang-diagnostic-covered-switch-default)
+                                default: break; // NOLINT(clang-diagnostic-covered-switch-default)
+                                }
                             }
                         }
 
                         if (server_read)
                         {
+                            // The server read context does not own a session; drop the strong
+                            // reference taken in connect_to_remote_host so a finished session
+                            // is not pinned alive until the next inbound datagram replaces it.
+                            io_context->proxy_socket_ptr.reset();
+
                             DWORD flags = 0;
 
-                            // Increment counter BEFORE posting the I/O operation
-                            // This ensures stop() will wait for this operation to complete
+                            // Re-arm the server read. The completion this generates will be
+                            // counted when it is dispatched (the fetch_add at the top of this
+                            // lambda), so there is no separate counter bump here.
                             if (!end_server_)
                             {
-                                active_iocp_operations_.fetch_add(1, std::memory_order_acquire);
-
                                 if ((::WSARecvFrom(
                                     server_socket_,
                                     &server_recv_buf_,
@@ -380,8 +397,6 @@ namespace proxy
                                     &server_io_context_,
                                     nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
                                 {
-                                    // Failed to post I/O, decrement counter
-                                    active_iocp_operations_.fetch_sub(1, std::memory_order_release);
                                     result = false;
                                 }
                             }
@@ -393,9 +408,8 @@ namespace proxy
                     completion_key_ = io_key;
                     DWORD flags = 0;
 
-                    // Increment counter BEFORE posting the initial I/O operation
-                    active_iocp_operations_.fetch_add(1, std::memory_order_acquire);
-
+                    // Post the initial server read. Its completion is counted when dispatched
+                    // (the fetch_add at the top of the completion lambda), so no bump here.
                     if ((::WSARecvFrom(
                         server_socket_,
                         &server_recv_buf_,
@@ -407,8 +421,6 @@ namespace proxy
                         &server_io_context_,
                         nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
                    {
-                        // Failed to post initial I/O, decrement counter
-                        active_iocp_operations_.fetch_sub(1, std::memory_order_release);
                         closesocket(server_socket_);
                         end_server_ = true;
                         return false;
@@ -680,6 +692,16 @@ namespace proxy
             }
             else
             {
+                // Allow this AF_INET6 upstream control socket to reach IPv4 SOCKS5
+                // servers via IPv4-mapped addresses (e.g. ::ffff:127.0.0.1) by
+                // clearing IPV6_V6ONLY so the dual-stack socket accepts both families.
+                DWORD v6_only = 0;
+                if (setsockopt(socks_tcp_socket, IPPROTO_IPV6, IPV6_V6ONLY,
+                    reinterpret_cast<const char*>(&v6_only), sizeof(v6_only)) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("Failed to clear IPV6_V6ONLY on SOCKS5 control socket: {}", WSAGetLastError());
+                }
+
                 sockaddr_in6 sa_local{};
                 sa_local.sin6_family = address_type_t::af_type;
                 sa_local.sin6_port = htons(0);
@@ -701,8 +723,8 @@ namespace proxy
                 sa_service.sin_addr = socks_server_address;
                 sa_service.sin_port = htons(socks_server_port);
 
-                if (connect(socks_tcp_socket, reinterpret_cast<SOCKADDR*>(&sa_service), sizeof(sa_service)) ==
-                    SOCKET_ERROR)
+                if (!connect_with_timeout(socks_tcp_socket, reinterpret_cast<SOCKADDR*>(&sa_service),
+                    sizeof(sa_service), 5000))
                 {
                     closesocket(socks_tcp_socket);
                     return INVALID_SOCKET;
@@ -715,8 +737,8 @@ namespace proxy
                 sa_service.sin6_addr = socks_server_address;
                 sa_service.sin6_port = htons(socks_server_port);
 
-                if (connect(socks_tcp_socket, reinterpret_cast<SOCKADDR*>(&sa_service), sizeof(sa_service)) ==
-                    SOCKET_ERROR)
+                if (!connect_with_timeout(socks_tcp_socket, reinterpret_cast<SOCKADDR*>(&sa_service),
+                    sizeof(sa_service), 5000))
                 {
                     closesocket(socks_tcp_socket);
                     return INVALID_SOCKET;
@@ -727,18 +749,75 @@ namespace proxy
         }
 
         /**
+         * @brief Connects a socket with a bounded timeout.
+         *
+         * A plain blocking connect() is not bounded by SO_*TIMEO and can hang for the OS
+         * default TCP connect timeout (~21s) on a black-holed SOCKS5 server while this thread
+         * holds the server lock, stalling all UDP relay. This switches the socket to
+         * non-blocking, issues the connect, and waits with select() up to timeout_ms, then
+         * restores blocking mode for the subsequent SO_*TIMEO-bounded send/recv.
+         *
+         * @return true if the connection completed within the timeout, false otherwise.
+         */
+        static bool connect_with_timeout(const SOCKET s, const sockaddr* const addr, const int addr_len,
+                                         const DWORD timeout_ms) noexcept
+        {
+            u_long non_blocking = 1;
+            if (ioctlsocket(s, FIONBIO, &non_blocking) == SOCKET_ERROR)
+                return false;
+
+            auto succeeded = false;
+            if (connect(s, addr, addr_len) == 0)
+            {
+                succeeded = true;
+            }
+            else if (WSAGetLastError() == WSAEWOULDBLOCK)
+            {
+                fd_set write_set;
+                FD_ZERO(&write_set);
+                FD_SET(s, &write_set);
+                fd_set error_set;
+                FD_ZERO(&error_set);
+                FD_SET(s, &error_set);
+
+                timeval tv{};
+                tv.tv_sec = static_cast<long>(timeout_ms / 1000);
+                tv.tv_usec = static_cast<long>((timeout_ms % 1000) * 1000);
+
+                if (const auto sel = select(0, nullptr, &write_set, &error_set, &tv);
+                    sel > 0 && FD_ISSET(s, &write_set))
+                {
+                    auto so_error = 0;
+                    auto len = static_cast<int>(sizeof(so_error));
+                    if (getsockopt(s, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len) == 0 &&
+                        so_error == 0)
+                    {
+                        succeeded = true;
+                    }
+                }
+            }
+
+            // Restore blocking mode for the subsequent SO_*TIMEO-bounded send/recv.
+            u_long blocking = 0;
+            ioctlsocket(s, FIONBIO, &blocking);
+            return succeeded;
+        }
+
+        /**
          * @brief Performs SOCKS5 negotiation and sends the UDP ASSOCIATE command.
          *
          * This method negotiates authentication with the SOCKS5 proxy server over the provided TCP socket,
          * using either "NO AUTHENTICATION REQUIRED" or "USERNAME/PASSWORD" (RFC 1929) as needed.
          * If authentication succeeds, it sends a UDP ASSOCIATE command to the proxy and retrieves the
-         * UDP port assigned by the proxy for relaying UDP packets.
+         * UDP relay endpoint assigned by the proxy for relaying UDP packets.
          *
          * @param socks_tcp_socket The connected TCP socket to the SOCKS5 proxy server.
          * @param negotiate_ctx Unique pointer to the negotiation context, containing optional credentials.
-         * @return The UDP port assigned by the SOCKS5 proxy for UDP relay, or std::nullopt on failure.
+         * @return The UDP relay endpoint assigned by the SOCKS5 proxy, or std::nullopt on failure.
          */
-        [[nodiscard]] std::optional<uint16_t> associate_to_socks5_proxy(const SOCKET socks_tcp_socket,
+        [[nodiscard]] std::optional<net::ip_endpoint<address_type_t>> associate_to_socks5_proxy(
+            const SOCKET socks_tcp_socket,
+            const address_type_t socks_server_address,
             std::unique_ptr<negotiate_context_t>&
             negotiate_ctx) const noexcept
         {
@@ -746,8 +825,6 @@ namespace proxy
 
             socks5_ident_req<2> ident_req{};
             socks5_ident_resp ident_resp{};
-            socks5_req<address_type_t> associate_req;
-            socks5_resp<address_type_t> associate_resp;
 
             auto socks5_ident_req_size = sizeof(ident_req);
 
@@ -856,20 +933,37 @@ namespace proxy
                     "[SOCKS5]: associate_to_socks5_proxy: USERNAME/PASSWORD authentication SUCCESS");
             }
 
-            associate_req.version = 5;
-            associate_req.cmd = 3;
-            associate_req.reserved = 0;
+            // Build the UDP ASSOCIATE request. DST.ADDR/DST.PORT only advertise the
+            // address the client expects to send datagrams from; we advertise the
+            // unspecified address. The ATYP must match the family actually used on the
+            // wire: the IPv6 proxy instance reaches the (IPv4) SOCKS5 server through an
+            // IPv4-mapped upstream, so an IPv4-only server would reject an ATYP=4 request.
+            // Send ATYP=1 with a zero IPv4 address whenever the upstream is IPv4 or
+            // IPv4-mapped, and ATYP=4 only for a genuine IPv6 upstream.
+            unsigned char associate_req_buf[4 + sizeof(in6_addr) + sizeof(unsigned short)]{};
+            associate_req_buf[0] = 5; // VER
+            associate_req_buf[1] = 3; // CMD = UDP ASSOCIATE
+            associate_req_buf[2] = 0; // RSV
+            int associate_req_len;
             if constexpr (address_type_t::af_type == AF_INET)
             {
-                associate_req.address_type = 1;
+                associate_req_buf[3] = 1; // ATYP = IPv4
+                associate_req_len = 4 + 4 + static_cast<int>(sizeof(unsigned short));
             }
             else
             {
-                associate_req.address_type = 4;
+                if (IN6_IS_ADDR_V4MAPPED(static_cast<const in6_addr*>(&socks_server_address)))
+                {
+                    associate_req_buf[3] = 1; // ATYP = IPv4 (IPv4-mapped upstream)
+                    associate_req_len = 4 + 4 + static_cast<int>(sizeof(unsigned short));
+                }
+                else
+                {
+                    associate_req_buf[3] = 4; // ATYP = IPv6 (genuine IPv6 upstream)
+                    associate_req_len = 4 + static_cast<int>(sizeof(in6_addr)) + static_cast<int>(sizeof(unsigned short));
+                }
             }
-            associate_req.dest_address = address_type_t{};
-            associate_req.dest_port = 0;
-            result = send(socks_tcp_socket, reinterpret_cast<const char*>(&associate_req), sizeof(associate_req), 0);
+            result = send(socks_tcp_socket, reinterpret_cast<const char*>(associate_req_buf), associate_req_len, 0);
             if (result == SOCKET_ERROR)
             {
                 NETLIB_INFO(
@@ -878,28 +972,166 @@ namespace proxy
                 return {};
             }
 
-            result = recv(socks_tcp_socket, reinterpret_cast<char*>(&associate_resp), sizeof(associate_resp), 0);
-            if (result == SOCKET_ERROR)
+            // Read and validate the SOCKS5 UDP ASSOCIATE reply. The reply's BND.ADDR
+            // family (ATYP) is selected by the SERVER and is independent of the address
+            // family this proxy instance uses: an IPv6 proxy instance reaches the
+            // configured (IPv4) SOCKS5 server through an IPv4-mapped upstream, so the
+            // server typically replies with ATYP=1 and a 4-byte BND.ADDR. Parsing the
+            // reply as a fixed-size socks5_resp<address_type_t> (which has a 16-byte
+            // BND.ADDR for IPv6) would then read BND.PORT from the wrong offset and
+            // hand back a bogus relay port. Parse the 4-byte reply prefix, then read
+            // exactly the bytes implied by the returned ATYP and take BND.PORT from the
+            // correct position so the relay port is family-agnostic and correct.
+
+            // Blocking read of exactly 'len' bytes (recv() may return short reads on a
+            // stream socket); returns false on error or premature close.
+            const auto recv_exact = [](const SOCKET s, void* const buffer, const int len) -> bool
+            {
+                // Bound the TOTAL time spent assembling these bytes, not just each recv().
+                // SO_RCVTIMEO is a per-call timeout, so a server that drips one byte just
+                // under it could otherwise keep this loop (and the IOCP worker that holds
+                // the server lock) alive for timeout * byte-count. Hold a single absolute
+                // deadline, shrink the receive timeout toward it on every iteration, and
+                // restore the socket's default timeout before returning.
+                constexpr DWORD total_timeout_ms = 5000;
+
+                // Save the socket's configured receive timeout and restore exactly that on
+                // every exit path, since the loop below temporarily shrinks SO_RCVTIMEO
+                // toward the deadline (leaving a tiny/stale value on the shared control
+                // socket would otherwise affect any later read on it).
+                DWORD original_timeout = total_timeout_ms;
+                int original_timeout_size = static_cast<int>(sizeof(original_timeout));
+                getsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                    reinterpret_cast<char*>(&original_timeout), &original_timeout_size);
+
+                const auto restore_timeout = [s, original_timeout]
+                {
+                    setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                        reinterpret_cast<const char*>(&original_timeout), sizeof(original_timeout));
+                };
+
+                auto* const bytes = static_cast<char*>(buffer);
+                const auto deadline = GetTickCount64() + total_timeout_ms;
+                int received = 0;
+                while (received < len)
+                {
+                    const auto now = GetTickCount64();
+                    if (now >= deadline)
+                    {
+                        restore_timeout();
+                        return false;
+                    }
+
+                    auto remaining_ms = static_cast<DWORD>(deadline - now);
+                    if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                        reinterpret_cast<const char*>(&remaining_ms), sizeof(remaining_ms)) == SOCKET_ERROR)
+                    {
+                        restore_timeout();
+                        return false;
+                    }
+
+                    const auto n = recv(s, bytes + received, len - received, 0);
+                    if (n == SOCKET_ERROR || n == 0)
+                    {
+                        restore_timeout();
+                        return false;
+                    }
+                    received += n;
+                }
+
+                restore_timeout();
+                return true;
+            };
+
+            // Fixed 4-byte reply prefix: VER, REP, RSV, ATYP.
+            struct socks5_resp_prefix
+            {
+                unsigned char version;
+                unsigned char reply;
+                unsigned char reserved;
+                unsigned char address_type;
+            } resp_prefix{};
+
+            if (!recv_exact(socks_tcp_socket, &resp_prefix, sizeof(resp_prefix)))
             {
                 NETLIB_INFO(
-                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive SOCKS5 ASSOCIATE response: {}",
-                    WSAGetLastError());
+                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive SOCKS5 ASSOCIATE reply header");
                 return {};
             }
 
-            if ((associate_resp.version != 5) ||
-                (associate_resp.reply != 0))
+            if ((resp_prefix.version != 5) ||
+                (resp_prefix.reply != 0))
             {
                 NETLIB_INFO(
                     "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 ASSOCIATE has failed");
                 return {};
             }
 
-            NETLIB_INFO(
-                "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 ASSOCIATE SUCCESS port: {}",
-                ntohs(associate_resp.bind_port));
+            // Determine BND.ADDR length from the server-selected ATYP. For ATYP=3
+            // (domain) the first byte carries the name length.
+            int bnd_addr_len;
+            switch (resp_prefix.address_type)
+            {
+            case 1: // IPv4
+                bnd_addr_len = 4;
+                break;
+            case 4: // IPv6
+                bnd_addr_len = 16;
+                break;
+            case 3: // domain name
+                {
+                    unsigned char domain_len = 0;
+                    if (!recv_exact(socks_tcp_socket, &domain_len, sizeof(domain_len)))
+                    {
+                        NETLIB_INFO(
+                            "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR domain length");
+                        return {};
+                    }
+                    bnd_addr_len = domain_len;
+                }
+                break;
+            default:
+                NETLIB_INFO(
+                    "[SOCKS5]: associate_to_socks5_proxy: Unexpected BND.ADDR type {} in ASSOCIATE reply",
+                    resp_prefix.address_type);
+                return {};
+            }
 
-            return ntohs(associate_resp.bind_port);
+            // Read BND.ADDR followed by the 2-byte BND.PORT. The buffer is sized for the
+            // largest possible BND.ADDR (a 255-byte domain) plus the port.
+            unsigned char bnd_addr_and_port[255 + sizeof(unsigned short)]{};
+            if (!recv_exact(socks_tcp_socket, bnd_addr_and_port,
+                bnd_addr_len + static_cast<int>(sizeof(unsigned short))))
+            {
+                NETLIB_INFO(
+                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR/BND.PORT");
+                return {};
+            }
+
+            // BND.PORT immediately follows BND.ADDR, in network byte order. Assembling
+            // the two big-endian bytes directly yields the host-order port value.
+            const auto bind_port = static_cast<uint16_t>(
+                (static_cast<uint16_t>(bnd_addr_and_port[bnd_addr_len]) << 8) |
+                static_cast<uint16_t>(bnd_addr_and_port[bnd_addr_len + 1]));
+
+            // The UDP relay endpoint is, in every deployment ProxiFyre supports, the same
+            // host as the SOCKS5 server we connected the control socket to. Servers
+            // frequently report a BND.ADDR that is only meaningful from their own vantage
+            // point (0.0.0.0, 127.0.0.1, or an internal/NAT address), so honoring it
+            // verbatim can aim the relay at an address the client cannot reach -- and it
+            // would also turn a server-supplied address into a connect() target. We
+            // therefore relay to the address we already reached over the control
+            // connection (socks_server_address -- the IPv4-mapped upstream for the IPv6
+            // instance) and take only BND.PORT from the reply. BND.PORT was parsed at the
+            // family-correct offset above, so the relay port is correct regardless of the
+            // ATYP the server selected, and no blocking DNS lookup is needed for an
+            // ATYP=3 (domain) reply.
+            NETLIB_INFO(
+                "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 ASSOCIATE SUCCESS endpoint: {}:{}",
+                socks_server_address,
+                bind_port);
+
+            return net::ip_endpoint<address_type_t>{ socks_server_address, bind_port };
         }
 
         /**
@@ -967,8 +1199,8 @@ namespace proxy
                 return false;
             }
 
-            auto udp_port = associate_to_socks5_proxy(socks5_tcp_socket, negotiate_ctx);
-            if (!udp_port.has_value())
+            auto udp_endpoint = associate_to_socks5_proxy(socks5_tcp_socket, remote_address, negotiate_ctx);
+            if (!udp_endpoint.has_value())
             {
                 NETLIB_DEBUG(
                     "connect_to_remote_host: ASSOCIATE command has failed: {}:{}",
@@ -981,8 +1213,8 @@ namespace proxy
 
             NETLIB_DEBUG(
                 "connect_to_remote_host: UDP connect: {}:{}",
-                remote_address,
-                udp_port.value());
+                udp_endpoint->ip,
+                udp_endpoint->port);
 
             auto remote_socket = WSASocket(address_type_t::af_type, SOCK_DGRAM, IPPROTO_UDP, nullptr, 0,
                 WSA_FLAG_OVERLAPPED);
@@ -992,6 +1224,7 @@ namespace proxy
                 NETLIB_DEBUG(
                     "connect_to_remote_host: Failed to create UDP socket: {}",
                     WSAGetLastError());
+                closesocket(socks5_tcp_socket);
                 return false;
             }
 
@@ -1015,6 +1248,17 @@ namespace proxy
             }
             else
             {
+                // Dual-stack the AF_INET6 UDP relay socket so it can reach an IPv4
+                // SOCKS5 server's UDP relay endpoint via its IPv4-mapped address
+                // (the relay address mirrors the configured control address).
+                DWORD v6_only = 0;
+                if (setsockopt(remote_socket, IPPROTO_IPV6, IPV6_V6ONLY,
+                    reinterpret_cast<const char*>(&v6_only), sizeof(v6_only)) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("connect_to_remote_host: Failed to clear IPV6_V6ONLY on UDP relay socket: {}",
+                        WSAGetLastError());
+                }
+
                 sockaddr_in6 sa_local{};
                 sa_local.sin6_family = address_type_t::af_type;
                 sa_local.sin6_port = htons(0);
@@ -1037,8 +1281,8 @@ namespace proxy
             {
                 sockaddr_in sa_service{};
                 sa_service.sin_family = address_type_t::af_type;
-                sa_service.sin_addr = remote_address;
-                sa_service.sin_port = htons(udp_port.value());
+                sa_service.sin_addr = udp_endpoint->ip;
+                sa_service.sin_port = htons(udp_endpoint->port);
 
                 if (connect(remote_socket, reinterpret_cast<SOCKADDR*>(&sa_service), sizeof(sa_service)) ==
                     SOCKET_ERROR)
@@ -1055,8 +1299,8 @@ namespace proxy
             {
                 sockaddr_in6 sa_service{};
                 sa_service.sin6_family = address_type_t::af_type;
-                sa_service.sin6_addr = remote_address;
-                sa_service.sin6_port = htons(udp_port.value());
+                sa_service.sin6_addr = udp_endpoint->ip;
+                sa_service.sin6_port = htons(udp_endpoint->port);
 
                 if (connect(remote_socket, reinterpret_cast<SOCKADDR*>(&sa_service), sizeof(sa_service)) ==
                     SOCKET_ERROR)
@@ -1073,8 +1317,8 @@ namespace proxy
             auto [it, result] = proxy_sockets_.emplace(local_peer_port,
                 std::make_shared<T>(
                     socks5_tcp_socket, packet_pool_, server_socket_,
-                    recv_from_sa_, remote_socket, remote_address,
-                    udp_port.value(), std::move(negotiate_ctx),
+                    recv_from_sa_, remote_socket, udp_endpoint->ip,
+                    udp_endpoint->port, std::move(negotiate_ctx),
                     logger::log_level_, logger::log_stream_));
 
             if (result)
@@ -1095,8 +1339,8 @@ namespace proxy
                 {
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to initialize proxy socket for: {}:{} ({})",
-                        remote_address,
-                        udp_port.value(),
+                        udp_endpoint->ip,
+                        udp_endpoint->port,
                         e.what());
                     // Remove from map - the shared_ptr destructor will close the sockets
                     // that were transferred to T's constructor
@@ -1107,8 +1351,8 @@ namespace proxy
                 {
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to initialize proxy socket for: {}:{} (unknown exception)",
-                        remote_address,
-                        udp_port.value());
+                        udp_endpoint->ip,
+                        udp_endpoint->port);
                     // Remove from map - the shared_ptr destructor will close the sockets
                     proxy_sockets_.erase(it);
                     return false;
@@ -1120,8 +1364,8 @@ namespace proxy
                 closesocket(socks5_tcp_socket);
                 NETLIB_DEBUG(
                     "connect_to_remote_host: Failed to create proxy socket for: {}:{}",
-                    remote_address,
-                    udp_port.value());
+                    udp_endpoint->ip,
+                    udp_endpoint->port);
                 return false;
             }
 

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -797,9 +797,13 @@ namespace proxy
                 }
             }
 
-            // Restore blocking mode for the subsequent SO_*TIMEO-bounded send/recv.
+            // Restore blocking mode for the subsequent SO_*TIMEO-bounded send/recv. If the
+            // socket connected but cannot be put back into blocking mode, fail the connect so
+            // the caller closes it rather than issuing blocking send/recv on a still-non-blocking
+            // socket (which would spuriously return WSAEWOULDBLOCK and break negotiation).
             u_long blocking = 0;
-            ioctlsocket(s, FIONBIO, &blocking);
+            if (ioctlsocket(s, FIONBIO, &blocking) == SOCKET_ERROR)
+                return false;
             return succeeded;
         }
 

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -25,7 +25,9 @@ namespace proxy
         * - login_responded: Identification response received.
         * - password_sent: Username/password authentication sent.
         * - password_responded: Authentication response received.
-        * - connect_sent: CONNECT command sent to the proxy.
+         * - connect_reply_header: Waiting for the 4-byte CONNECT reply header.
+         * - connect_reply_domain_length: Waiting for the domain-name BND.ADDR length byte.
+         * - connect_reply_tail: Waiting for BND.ADDR/BND.PORT bytes.
         */
         enum class socks5_state : uint8_t
         {
@@ -34,7 +36,9 @@ namespace proxy
             login_responded,
             password_sent,
             password_responded,
-            connect_sent
+            connect_reply_header,
+            connect_reply_domain_length,
+            connect_reply_tail
         };
 
     public:
@@ -119,9 +123,10 @@ namespace proxy
          *   - If username/password authentication is required, validates credentials and sends the authentication request.
          *   - If no authentication is required, sends the CONNECT command to the proxy.
          * - On receiving the authentication response (password_sent state), checks for success and sends the CONNECT command.
-         * - On receiving the CONNECT response (connect_sent state), checks for success and starts data relay if successful.
+         * - On receiving the CONNECT response header, checks for success, drains the variable-length
+         *   BND.ADDR/BND.PORT fields, and starts data relay if successful.
          *
-         * @param io_size Number of bytes received (unused in this implementation).
+         * @param io_size Number of bytes received by the completed negotiation read.
          * @param io_context Pointer to the per-I/O context structure for the operation.
          */
         void process_receive_negotiate_complete(const uint32_t io_size, per_io_context_t* io_context) override
@@ -202,45 +207,7 @@ namespace proxy
                         }
                         else // NO AUTHENTICATION REQUIRED is chosen
                         {
-                            connect_request_.cmd = 1;
-                            connect_request_.reserved = 0;
-                            connect_request_.address_type = 1;
-                            connect_request_.dest_address = tcp_proxy_socket<T>::negotiate_ctx_->remote_address;
-                            connect_request_.dest_port = htons(tcp_proxy_socket<T>::negotiate_ctx_->remote_port);
-
-                            io_context_send_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_request_);
-                            io_context_send_negotiate_.wsa_buf.len = sizeof(socks5_req<T>);
-                            io_context_recv_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_response_);
-                            io_context_recv_negotiate_.wsa_buf.len = sizeof(socks5_resp<T>);
-
-                            DWORD flags = 0;
-
-                            if ((::WSASend(
-                                tcp_proxy_socket<T>::remote_socket_,
-                                &io_context_send_negotiate_.wsa_buf,
-                                1,
-                                nullptr,
-                                0,
-                                &io_context_send_negotiate_,
-                                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                            {
-                                tcp_proxy_socket<T>::close_client(false, false);
-                                return;
-                            }
-
-                            current_state_ = socks5_state::connect_sent;
-
-                            if ((::WSARecv(
-                                tcp_proxy_socket<T>::remote_socket_,
-                                &io_context_recv_negotiate_.wsa_buf,
-                                1,
-                                nullptr,
-                                &flags,
-                                &io_context_recv_negotiate_,
-                                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                            {
-                                tcp_proxy_socket<T>::close_client(true, false);
-                            }
+                            send_connect_request();
                         }
                     }
                 }
@@ -255,70 +222,199 @@ namespace proxy
                     }
                     else
                     {
-                        connect_request_.cmd = 1;
-                        connect_request_.reserved = 0;
-                        if constexpr (address_type_t::af_type == AF_INET)
-                        {
-                            connect_request_.address_type = 1; // IPv4
-                        }
-                        else
-                        {
-                            connect_request_.address_type = 4; // IPv6
-                        }
-                        connect_request_.dest_address = tcp_proxy_socket<T>::negotiate_ctx_->remote_address;
-                        connect_request_.dest_port = htons(tcp_proxy_socket<T>::negotiate_ctx_->remote_port);
-
-                        io_context_send_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_request_);
-                        io_context_send_negotiate_.wsa_buf.len = sizeof(socks5_req<T>);
-                        io_context_recv_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_response_);
-                        io_context_recv_negotiate_.wsa_buf.len = sizeof(socks5_resp<T>);
-
-                        DWORD flags = 0;
-
-                        if ((::WSASend(
-                            tcp_proxy_socket<T>::remote_socket_,
-                            &io_context_send_negotiate_.wsa_buf,
-                            1,
-                            nullptr,
-                            0,
-                            &io_context_send_negotiate_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                        {
-                            tcp_proxy_socket<T>::close_client(false, false);
-                            return;
-                        }
-
-                        current_state_ = socks5_state::connect_sent;
-
-                        if ((::WSARecv(
-                            tcp_proxy_socket<T>::remote_socket_,
-                            &io_context_recv_negotiate_.wsa_buf,
-                            1,
-                            nullptr,
-                            &flags,
-                            &io_context_recv_negotiate_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                        {
-                            tcp_proxy_socket<T>::close_client(true, false);
-                        }
+                        send_connect_request();
                     }
                 }
-                else if (current_state_ == socks5_state::connect_sent)
+                else if (current_state_ == socks5_state::connect_reply_header)
                 {
-                    if (connect_response_.reply != 0)
+                    if (!accumulate_connect_reply(io_size, &connect_response_header_, sizeof(connect_response_header_)))
+                    {
+                        return;
+                    }
+
+                    if ((connect_response_header_.version != socks5_protocol_version) ||
+                        (connect_response_header_.reply != 0))
                     {
                         // SOCKS v5 connect failed
                         tcp_proxy_socket<T>::close_client(true, false);
+                        return;
                     }
-                    else
+
+                    switch (connect_response_header_.address_type)
                     {
-                        tcp_proxy_socket<T>::start_data_relay();
+                    case 1: // IPv4
+                        if (!start_connect_reply_receive(
+                            socks5_state::connect_reply_tail,
+                            connect_response_tail_.data(),
+                            4 + sizeof(unsigned short)))
+                        {
+                            return;
+                        }
+                        break;
+
+                    case 4: // IPv6
+                        if (!start_connect_reply_receive(
+                            socks5_state::connect_reply_tail,
+                            connect_response_tail_.data(),
+                            16 + sizeof(unsigned short)))
+                        {
+                            return;
+                        }
+                        break;
+
+                    case 3: // domain name: read the one-byte length first.
+                        if (!start_connect_reply_receive(
+                            socks5_state::connect_reply_domain_length,
+                            connect_response_tail_.data(),
+                            1))
+                        {
+                            return;
+                        }
+                        break;
+
+                    default:
+                        tcp_proxy_socket<T>::close_client(true, false);
+                        break;
                     }
+                }
+                else if (current_state_ == socks5_state::connect_reply_domain_length)
+                {
+                    if (!accumulate_connect_reply(io_size, connect_response_tail_.data(), 1))
+                    {
+                        return;
+                    }
+
+                    const auto domain_length = connect_response_tail_[0];
+                    if (!start_connect_reply_receive(
+                        socks5_state::connect_reply_tail,
+                        connect_response_tail_.data() + 1,
+                        static_cast<ULONG>(domain_length + sizeof(unsigned short))))
+                    {
+                        return;
+                    }
+                }
+                else if (current_state_ == socks5_state::connect_reply_tail)
+                {
+                    if (!accumulate_connect_reply(io_size, connect_reply_buffer_, connect_reply_expected_))
+                    {
+                        return;
+                    }
+
+                    tcp_proxy_socket<T>::start_data_relay();
                 }
             }
         }
 
     private:
+        struct socks5_resp_header
+        {
+            unsigned char version = socks5_protocol_version;
+            unsigned char reply{};
+            unsigned char reserved{};
+            unsigned char address_type{};
+        };
+
+        void reset_overlapped(per_io_context_t& io_context) noexcept
+        {
+            io_context.Internal = 0;
+            io_context.InternalHigh = 0;
+            io_context.Offset = 0;
+            io_context.OffsetHigh = 0;
+            io_context.hEvent = nullptr;
+        }
+
+        [[nodiscard]] bool start_negotiate_receive(void* const buffer, const ULONG length)
+        {
+            reset_overlapped(io_context_recv_negotiate_);
+            io_context_recv_negotiate_.wsa_buf.buf = static_cast<char*>(buffer);
+            io_context_recv_negotiate_.wsa_buf.len = length;
+
+            DWORD flags = 0;
+
+            if ((::WSARecv(
+                tcp_proxy_socket<T>::remote_socket_,
+                &io_context_recv_negotiate_.wsa_buf,
+                1,
+                nullptr,
+                &flags,
+                &io_context_recv_negotiate_,
+                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                tcp_proxy_socket<T>::close_client(true, false);
+                return false;
+            }
+
+            return true;
+        }
+
+        [[nodiscard]] bool start_connect_reply_receive(const socks5_state state, void* const buffer, const ULONG length)
+        {
+            current_state_ = state;
+            connect_reply_buffer_ = static_cast<unsigned char*>(buffer);
+            connect_reply_expected_ = length;
+            connect_reply_received_ = 0;
+            return start_negotiate_receive(buffer, length);
+        }
+
+        [[nodiscard]] bool accumulate_connect_reply(const uint32_t io_size, void* const buffer, const ULONG length)
+        {
+            connect_reply_received_ += io_size;
+            if (connect_reply_received_ >= length)
+            {
+                return true;
+            }
+
+            if (!start_negotiate_receive(
+                static_cast<unsigned char*>(buffer) + connect_reply_received_,
+                length - connect_reply_received_))
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        void send_connect_request()
+        {
+            connect_request_.cmd = 1;
+            connect_request_.reserved = 0;
+            if constexpr (address_type_t::af_type == AF_INET)
+            {
+                connect_request_.address_type = 1; // IPv4
+            }
+            else
+            {
+                connect_request_.address_type = 4; // IPv6
+            }
+            connect_request_.dest_address = tcp_proxy_socket<T>::negotiate_ctx_->remote_address;
+            connect_request_.dest_port = htons(tcp_proxy_socket<T>::negotiate_ctx_->remote_port);
+
+            reset_overlapped(io_context_send_negotiate_);
+            io_context_send_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_request_);
+            io_context_send_negotiate_.wsa_buf.len = sizeof(socks5_req<T>);
+
+            if ((::WSASend(
+                tcp_proxy_socket<T>::remote_socket_,
+                &io_context_send_negotiate_.wsa_buf,
+                1,
+                nullptr,
+                0,
+                &io_context_send_negotiate_,
+                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                tcp_proxy_socket<T>::close_client(false, false);
+                return;
+            }
+
+            if (!start_connect_reply_receive(
+                socks5_state::connect_reply_header,
+                &connect_response_header_,
+                sizeof(connect_response_header_)))
+            {
+                return;
+            }
+        }
+
         /**
          * @brief Internal state and buffers for SOCKS5 negotiation and connection.
          *
@@ -328,7 +424,7 @@ namespace proxy
          * - ident_req_: Buffer for the SOCKS5 identification request (supports up to 2 methods).
          * - ident_resp_: Buffer for the SOCKS5 identification response from the proxy.
          * - connect_request_: Buffer for the SOCKS5 CONNECT command request.
-         * - connect_response_: Buffer for the SOCKS5 CONNECT command response.
+         * - connect_response_header_/tail: Buffers for the variable-length SOCKS5 CONNECT response.
          * - username_auth_: Buffer for username/password authentication as per RFC 1929.
          *
          * These members are used to manage the asynchronous negotiation and authentication
@@ -338,11 +434,23 @@ namespace proxy
         per_io_context_t io_context_recv_negotiate_{ proxy_io_operation::negotiate_io_read, nullptr, false };
         per_io_context_t io_context_send_negotiate_{ proxy_io_operation::negotiate_io_write, nullptr, false };
 
+        // Also release this class's two negotiation contexts when breaking the cycle.
+        void release_self_references() noexcept override
+        {
+            tcp_proxy_socket<T>::release_self_references();
+            io_context_recv_negotiate_.proxy_socket_ptr.reset();
+            io_context_send_negotiate_.proxy_socket_ptr.reset();
+        }
+
         socks5_state current_state_{ socks5_state::pre_login };
         socks5_ident_req<2> ident_req_{};
         socks5_ident_resp ident_resp_{};
         socks5_req<address_type_t> connect_request_;
-        socks5_resp<address_type_t> connect_response_;
+        socks5_resp_header connect_response_header_{};
+        std::array<unsigned char, 1 + socks5_username_max_length + sizeof(unsigned short)> connect_response_tail_{};
+        unsigned char* connect_reply_buffer_{ nullptr };
+        ULONG connect_reply_expected_{ 0 };
+        ULONG connect_reply_received_{ 0 };
         socks5_username_auth username_auth_{};
 
     protected:

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -203,6 +203,7 @@ namespace proxy
         /// Atomic flag indicating whether the session is ready for removal and cleanup.
         /// </summary>
         std::atomic_bool ready_for_removal_{ false };
+        bool removal_armed_ = false;  ///< Set on the first removal pass; the next pass releases the self-reference.
 
     public:
         /**
@@ -370,6 +371,21 @@ namespace proxy
          */
         void close_client()
         {
+            // Cancel pending I/O and close the sockets immediately so their queued completions
+            // drain and the handles are released, instead of waiting for a destructor that the
+            // per-I/O self-reference would otherwise prevent from ever running. Idempotent.
+            if (remote_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                CancelIoEx(reinterpret_cast<HANDLE>(remote_socket_), nullptr);  // NOLINT(performance-no-int-to-ptr)
+                closesocket(remote_socket_);
+                remote_socket_ = INVALID_SOCKET;
+            }
+            if (socks_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                CancelIoEx(reinterpret_cast<HANDLE>(socks_socket_), nullptr);  // NOLINT(performance-no-int-to-ptr)
+                closesocket(socks_socket_);
+                socks_socket_ = INVALID_SOCKET;
+            }
             ready_for_removal_.store(true);
         }
 
@@ -381,14 +397,26 @@ namespace proxy
          *
          * @return True if the socket should be removed, false otherwise.
          */
-        bool is_ready_for_removal() const
+        bool is_ready_for_removal()
         {
             using namespace std::chrono_literals;
 
-            if (ready_for_removal_.load() || (std::chrono::steady_clock::now() - timestamp_ > 5min))
-                return true;
+            if (!ready_for_removal_.load() && (std::chrono::steady_clock::now() - timestamp_ <= 5min))
+                return false;
 
-            return false;
+            // Ready (explicit close or idle timeout). Break the per-I/O self-reference cycle so
+            // the destructor can run, but only after a one-cycle grace: ensure the sockets are
+            // closed (so any pending recv is cancelled) on the first pass, then release the
+            // self-reference on the next pass once those queued completions have drained.
+            if (!removal_armed_)
+            {
+                close_client(); // idempotent: cancels pending I/O and closes the sockets
+                removal_armed_ = true;
+                return false;
+            }
+
+            io_context_recv_from_remote_.proxy_socket_ptr.reset();
+            return true;
         }
 
         /**
@@ -697,7 +725,6 @@ namespace proxy
             NETLIB_DEBUG("inject_to_local: Packet buffer allocated successfully, copying {} bytes for {}:{}",
                 length, remote_peer_address_, remote_peer_port_);
 
-            context->wsa_buf->buf->len = length;
             memmove(context->wsa_buf->buf, data, length);
             context->wsa_buf->len = length;
 
@@ -706,7 +733,7 @@ namespace proxy
 
             if ((::WSASend(
                 local_socket_,
-                &context->wsa_buf,
+                context->wsa_buf.get(),
                 1,
                 nullptr,
                 0,
@@ -800,7 +827,6 @@ namespace proxy
             NETLIB_DEBUG("inject_to_remote: Packet buffer allocated successfully, copying {} bytes for {}:{}",
                 length, remote_peer_address_, remote_peer_port_);
 
-            context->wsa_buf->buf->len = length;
             memmove(context->wsa_buf->buf, data, length);
             context->wsa_buf->len = length;
 
@@ -809,7 +835,7 @@ namespace proxy
 
             if ((::WSASend(
                 remote_socket_,
-                &context->wsa_buf,
+                context->wsa_buf.get(),
                 1,
                 nullptr,
                 0,

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -40,23 +40,42 @@ namespace proxy
         using s5_udp_proxy_server = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<net::ip_address_v4>>;
 
         /**
-         * @brief Entry stored in tcp_mapper_: redirected destination endpoint and the
-         *        steady-clock timestamp at which the mapping was created. The timestamp
-         *        is used by process_resolve_thread_proc to evict stale entries whose
-         *        SYN never produced a local proxy connection (e.g. RST/timeout).
+         * @brief Type alias for the SOCKS5 TCP proxy server specialized for IPv6.
          */
-        struct tcp_mapper_entry
+        using s5_tcp_proxy_server_v6 = tcp_proxy_server<socks5_tcp_proxy_socket<net::ip_address_v6>>;
+
+        /**
+         * @brief Type alias for the SOCKS5 UDP proxy server specialized for IPv6.
+         */
+        using s5_udp_proxy_server_v6 = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<net::ip_address_v6>>;
+
+        /**
+         * @brief Entry stored in the TCP source-port mappers: redirected destination
+         *        endpoint and the steady-clock timestamp at which the mapping was
+         *        created. The timestamp is used by process_resolve_thread_proc to evict
+         *        stale entries whose SYN never produced a local proxy connection
+         *        (e.g. RST/timeout). Templated on the address family so the IPv4 and
+         *        IPv6 mappers share a single definition.
+         */
+        template <typename AddrT>
+        struct tcp_mapper_entry_t
         {
-            net::ip_endpoint<net::ip_address_v4> endpoint;
+            net::ip_endpoint<AddrT> endpoint;
             std::chrono::steady_clock::time_point created_at;
         };
+
+        using tcp_mapper_entry = tcp_mapper_entry_t<net::ip_address_v4>;
+        using tcp_mapper_entry_v6 = tcp_mapper_entry_t<net::ip_address_v6>;
 
         /**
          * @brief Stores a mapping of TCP source ports to their original destination
          *        endpoints, stamped with the time the entry was created so stale
-         *        entries can be aged out.
+         *        entries can be aged out. Separate maps are kept per address family
+         *        because IPv4 and IPv6 connections may reuse the same source port
+         *        value independently.
          */
         std::unordered_map<uint16_t, tcp_mapper_entry> tcp_mapper_;
+        std::unordered_map<uint16_t, tcp_mapper_entry_v6> tcp_mapper_v6_;
 
         /**
          * @brief Maximum age for a tcp_mapper_ entry before it is considered stale and
@@ -105,16 +124,19 @@ namespace proxy
          * @brief Stores the set of UDP ports being mapped.
          */
         std::unordered_set<uint16_t> udp_mapper_;
+        std::unordered_set<uint16_t> udp_mapper_v6_;
 
         /**
          * @brief Mutex to synchronize access to the TCP port mapping.
          */
         std::mutex tcp_mapper_lock_;
+        std::mutex tcp_mapper_v6_lock_;
 
         /**
          * @brief Mutex to synchronize access to the UDP port mapping.
          */
         std::mutex udp_mapper_lock_;
+        std::mutex udp_mapper_v6_lock_;
 
         /**
          * @brief I/O completion port for asynchronous operations.
@@ -130,6 +152,14 @@ namespace proxy
          * @brief Vector storing pairs of unique pointers to TCP and UDP proxy servers.
          */
         std::vector<std::pair<std::unique_ptr<s5_tcp_proxy_server>, std::unique_ptr<s5_udp_proxy_server>>> proxy_servers_;
+
+        /**
+         * @brief IPv6 counterpart of proxy_servers_. Kept index-aligned with
+         *        proxy_servers_ (add_socks5_proxy() always appends to both), so a
+         *        proxy index resolved from proxy_to_names_ selects the matching
+         *        IPv4 and IPv6 proxy pair.
+         */
+        std::vector<std::pair<std::unique_ptr<s5_tcp_proxy_server_v6>, std::unique_ptr<s5_udp_proxy_server_v6>>> proxy_servers_v6_;
 
         /**
          * @brief Maps proxy indexes to their corresponding process names (sorted by proxy ID).
@@ -165,9 +195,19 @@ namespace proxy
         std::unique_ptr<ndisapi::tcp_local_redirect<net::ip_address_v4>> tcp_redirect_{ nullptr };
 
         /**
+         * @brief Unique pointer to the IPv6 TCP redirect object.
+         */
+        std::unique_ptr<ndisapi::tcp_local_redirect<net::ip_address_v6>> tcp_redirect_v6_{ nullptr };
+
+        /**
          * @brief Unique pointer to the UDP redirect object.
          */
         std::unique_ptr<ndisapi::socks5_udp_local_redirect<net::ip_address_v4>> udp_redirect_{ nullptr };
+
+        /**
+         * @brief Unique pointer to the IPv6 UDP redirect object.
+         */
+        std::unique_ptr<ndisapi::socks5_udp_local_redirect<net::ip_address_v6>> udp_redirect_v6_{ nullptr };
 
         /**
          * @brief Unique pointer to the packet filter object.
@@ -347,6 +387,48 @@ namespace proxy
             return packet_filter::packet_action{ packet_filter::packet_action::action_type::drop };
         }
 
+        /**
+         * @brief Compile-time selectors that return the TCP/UDP source-port mapper
+         *        (and its lock) for the requested address family. They let the
+         *        family-generic helpers (build_proxy_pair, process_*_packet_v6)
+         *        reference the correct member without duplicating their bodies.
+         */
+        template <typename AddrT>
+        auto& tcp_mapper_for() noexcept
+        {
+            if constexpr (std::is_same_v<AddrT, net::ip_address_v4>)
+                return tcp_mapper_;
+            else
+                return tcp_mapper_v6_;
+        }
+
+        template <typename AddrT>
+        std::mutex& tcp_mapper_lock_for() noexcept
+        {
+            if constexpr (std::is_same_v<AddrT, net::ip_address_v4>)
+                return tcp_mapper_lock_;
+            else
+                return tcp_mapper_v6_lock_;
+        }
+
+        template <typename AddrT>
+        auto& udp_mapper_for() noexcept
+        {
+            if constexpr (std::is_same_v<AddrT, net::ip_address_v4>)
+                return udp_mapper_;
+            else
+                return udp_mapper_v6_;
+        }
+
+        template <typename AddrT>
+        std::mutex& udp_mapper_lock_for() noexcept
+        {
+            if constexpr (std::is_same_v<AddrT, net::ip_address_v4>)
+                return udp_mapper_lock_;
+            else
+                return udp_mapper_v6_lock_;
+        }
+
     public:
         enum supported_protocols : uint8_t
         {
@@ -385,6 +467,14 @@ namespace proxy
             udp_redirect_ = std::make_unique<ndisapi::socks5_udp_local_redirect<net::ip_address_v4>>(
                 log_level_, log_stream);
 
+            // Initialize the IPv6 redirect objects. The lower redirect/proxy stack is
+            // fully dual-stack (templated + if constexpr), so the IPv6 path mirrors the
+            // IPv4 one: redirected IPv6 TCP/UDP egress is NAT'd to the local IPv6 proxy
+            // listeners instead of leaking out unproxied.
+            tcp_redirect_v6_ = std::make_unique<ndisapi::tcp_local_redirect<net::ip_address_v6>>(log_level_, log_stream);
+            udp_redirect_v6_ = std::make_unique<ndisapi::socks5_udp_local_redirect<net::ip_address_v6>>(
+                log_level_, log_stream);
+
             // Initialize packet filter
             packet_filter_ = std::make_unique<packet_filter>(
                 nullptr,
@@ -392,8 +482,16 @@ namespace proxy
                 {
                     auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
                     const auto destination_mac = net::mac_address(ethernet_header->h_dest);
+                    const auto ether_type = ntohs(ethernet_header->h_proto);
 
-                    if (ntohs(ethernet_header->h_proto) != ETH_P_IP)
+                    // IPv6 traffic from proxied apps would otherwise leave the machine
+                    // unproxied; route it through the parallel IPv6 path.
+                    if (ether_type == ETH_P_IPV6)
+                    {
+                        return handle_ipv6_filter(buffer, destination_mac);
+                    }
+
+                    if (ether_type != ETH_P_IP)
                     {
                         return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
                     }
@@ -540,8 +638,14 @@ namespace proxy
                     GetLastError());
             }
 
+            // IPv6 listeners that started but whose pair partner failed are stopped AFTER
+            // releasing lock_, mirroring stop()'s "never hold lock_ across a proxy stop()"
+            // discipline (a proxy's teardown path may contend for shared state).
+            std::vector<std::unique_ptr<s5_tcp_proxy_server_v6>> ipv6_disabled_tcp;
+            std::vector<std::unique_ptr<s5_udp_proxy_server_v6>> ipv6_disabled_udp;
+
             {
-                std::shared_lock lock(lock_);
+                std::unique_lock lock(lock_);
 
                 // Start thread pool
                 io_port_.start_thread_pool();
@@ -565,7 +669,58 @@ namespace proxy
                         }
                     }
                 }
+
+                // Start the IPv6 proxies (index-aligned with proxy_servers_). IPv6
+                // listeners are optional: if the OS/socket stack rejects either half
+                // of the pair, disable that IPv6 slot so later packet handling falls
+                // back to pass-through instead of redirecting to a dead local port.
+                for (auto& [tcp, udp] : proxy_servers_v6_)
+                {
+                    // Disable this IPv6 slot by moving its servers out of the shared
+                    // vector (which nulls the slot) so they can be stopped and destroyed
+                    // after lock_ is released rather than under it.
+                    const auto disable_ipv6_pair = [&]
+                    {
+                        if (tcp)
+                            ipv6_disabled_tcp.push_back(std::move(tcp));
+                        if (udp)
+                            ipv6_disabled_udp.push_back(std::move(udp));
+                    };
+
+                    if (tcp)
+                    {
+                        if (!tcp->start())
+                        {
+                            NETLIB_LOG(
+                                log_level::warning,
+                                "IPv6 TCP proxy on port {} is disabled because it failed to start.",
+                                tcp->proxy_port());
+                            disable_ipv6_pair();
+                            continue;
+                        }
+                    }
+
+                    if (udp)
+                    {
+                        if (!udp->start())
+                        {
+                            NETLIB_LOG(
+                                log_level::warning,
+                                "IPv6 UDP proxy on port {} is disabled because it failed to start.",
+                                udp->proxy_port());
+                            disable_ipv6_pair();
+                        }
+                    }
+                }
             }
+
+            // Stop any disabled IPv6 listeners without holding lock_.
+            for (auto& tcp : ipv6_disabled_tcp)
+                if (tcp)
+                    tcp->stop();
+            for (auto& udp : ipv6_disabled_udp)
+                if (udp)
+                    udp->stop();
 
             process_resolve_thread_ = std::thread(&socks_local_router::process_resolve_thread_proc, this);
 
@@ -593,15 +748,29 @@ namespace proxy
                 // same mutex, so holding lock_ across stop() can deadlock.
                 // This mirrors the pattern used in stop().
                 std::vector<std::pair<s5_tcp_proxy_server*, s5_udp_proxy_server*>> proxies_to_stop;
+                std::vector<std::pair<s5_tcp_proxy_server_v6*, s5_udp_proxy_server_v6*>> proxies_to_stop_v6;
                 {
                     std::shared_lock lock(lock_);
                     proxies_to_stop.reserve(proxy_servers_.size());
                     for (auto& [tcp, udp] : proxy_servers_)
                         proxies_to_stop.emplace_back(tcp.get(), udp.get());
+
+                    proxies_to_stop_v6.reserve(proxy_servers_v6_.size());
+                    for (auto& [tcp, udp] : proxy_servers_v6_)
+                        proxies_to_stop_v6.emplace_back(tcp.get(), udp.get());
                 }
 
                 // Stop all proxies without holding lock_.
                 for (auto& [tcp, udp] : proxies_to_stop)
+                {
+                    if (tcp)
+                        tcp->stop();
+
+                    if (udp)
+                        udp->stop();
+                }
+
+                for (auto& [tcp, udp] : proxies_to_stop_v6)
                 {
                     if (tcp)
                         tcp->stop();
@@ -684,6 +853,16 @@ namespace proxy
                 udp_redirect_->stop();  // This should join the cleanup thread
             }
 
+            if (tcp_redirect_v6_)
+            {
+                tcp_redirect_v6_->stop();  // This should join the cleanup thread
+            }
+
+            if (udp_redirect_v6_)
+            {
+                udp_redirect_v6_->stop();  // This should join the cleanup thread
+            }
+
             // Step 4: Stop all proxy servers WITHOUT holding lock_
             // CRITICAL: We must NOT hold lock_ while calling stop() or during destruction
             // because the cleanup threads inside the proxies need to acquire the same lock
@@ -703,6 +882,24 @@ namespace proxy
                 {
                     NETLIB_DEBUG("Stopping IPv4 UDP proxy #{} on port {}", i, proxy_servers_[i].second->proxy_port());
                     proxy_servers_[i].second->stop();
+                }
+            }
+
+            NETLIB_DEBUG("Stopping {} IPv6 proxy pairs", proxy_servers_v6_.size());
+
+            // Stop all IPv6 proxies without holding lock_
+            for (size_t i = 0; i < proxy_servers_v6_.size(); ++i)
+            {
+                if (proxy_servers_v6_[i].first)
+                {
+                    NETLIB_DEBUG("Stopping IPv6 TCP proxy #{} on port {}", i, proxy_servers_v6_[i].first->proxy_port());
+                    proxy_servers_v6_[i].first->stop();
+                }
+
+                if (proxy_servers_v6_[i].second)
+                {
+                    NETLIB_DEBUG("Stopping IPv6 UDP proxy #{} on port {}", i, proxy_servers_v6_[i].second->proxy_port());
+                    proxy_servers_v6_[i].second->stop();
                 }
             }
 
@@ -772,6 +969,7 @@ namespace proxy
         void set_bypass_lan() noexcept
         {
             add_lan_passover_filters_v4();
+            add_lan_passover_filters_v6();
         }
 
         /**
@@ -783,6 +981,115 @@ namespace proxy
             return packet_filter_->IsDriverLoaded();
         }
 
+    private:
+        /**
+         * @brief Builds a (TCP, UDP) SOCKS5 proxy-server pair for a single address
+         *        family, without starting them.
+         *
+         * Both the IPv4 and IPv6 paths in add_socks5_proxy() go through this single
+         * templated helper so the accept-callback logic (source-port mapper lookup,
+         * TTL eviction, negotiate-context construction) lives in one place. The correct
+         * per-family source-port mapper is selected at compile time via the
+         * *_mapper_for<AddrT>() helpers.
+         *
+         * @tparam AddrT net::ip_address_v4 or net::ip_address_v6.
+         * @param upstream The upstream SOCKS5 server endpoint the proxy connects to.
+         *        For the IPv6 instantiation this is the IPv4-mapped form of the
+         *        configured endpoint, so an IPv4 SOCKS5 server keeps working over the
+         *        proxy's dual-stack upstream socket.
+         * @param protocols Which of TCP/UDP to create.
+         * @param cred_pair Optional SOCKS5 username/password.
+         * @return Pair of unique_ptrs; either element is null when its protocol is not requested.
+         */
+        template <typename AddrT>
+        std::pair<std::unique_ptr<tcp_proxy_server<socks5_tcp_proxy_socket<AddrT>>>,
+                  std::unique_ptr<socks5_local_udp_proxy_server<socks5_udp_proxy_socket<AddrT>>>>
+        build_proxy_pair(const net::ip_endpoint<AddrT>& upstream,
+                         const supported_protocols protocols,
+                         const std::optional<std::pair<std::string, std::string>>& cred_pair)
+        {
+            using tcp_server_t = tcp_proxy_server<socks5_tcp_proxy_socket<AddrT>>;
+            using udp_server_t = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<AddrT>>;
+            using tcp_negotiate_t = typename tcp_server_t::negotiate_context_t;
+            using udp_negotiate_t = typename udp_server_t::negotiate_context_t;
+
+            auto tcp_server = (protocols == both || protocols == tcp)
+                ? std::make_unique<tcp_server_t>(
+                    0, io_port_,
+                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)
+                        -> std::tuple<AddrT, uint16_t, std::unique_ptr<tcp_negotiate_t>>
+                    {
+                        auto& mapper = tcp_mapper_for<AddrT>();
+                        std::scoped_lock lock(tcp_mapper_lock_for<AddrT>());
+
+                        if (const auto it = mapper.find(port); it != mapper.end())
+                        {
+                            // Discard stale entries whose age has exceeded the TTL.
+                            // Eviction is performed asynchronously by the resolver
+                            // thread and may be delayed, so validate age at lookup
+                            // time to avoid misrouting a new connection on a reused
+                            // source port.
+                            if (std::chrono::steady_clock::now() - it->second.created_at > tcp_mapper_entry_ttl_)
+                            {
+                                NETLIB_LOG(log_level::warning,
+                                    "TCP Redirect entry for port {} was stale (age exceeded TTL); discarding.",
+                                    port);
+                                mapper.erase(it);
+                                return std::make_tuple(AddrT{}, 0, nullptr);
+                            }
+
+                            NETLIB_LOG(log_level::info,
+                                "TCP Redirect entry was found for the {} : {} is {}",
+                                std::string{ address }, port, it->second.endpoint.to_string());
+
+                            auto remote_address = it->second.endpoint.ip;
+                            auto remote_port = it->second.endpoint.port;
+
+                            mapper.erase(it);
+
+                            return std::make_tuple(upstream.ip, upstream.port,
+                                std::make_unique<tcp_negotiate_t>(
+                                    remote_address, remote_port,
+                                    cred_pair ? std::optional(cred_pair.value().first) : std::nullopt,
+                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt));
+                        }
+
+                        return std::make_tuple(AddrT{}, 0, nullptr);
+                    }, log_level_, log_stream_)
+                : nullptr;
+
+            auto udp_server = (protocols == both || protocols == udp)
+                ? std::make_unique<udp_server_t>(
+                    0, io_port_,
+                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)
+                        -> std::tuple<AddrT, uint16_t, std::unique_ptr<udp_negotiate_t>>
+                    {
+                        auto& mapper = udp_mapper_for<AddrT>();
+                        std::scoped_lock lock(udp_mapper_lock_for<AddrT>());
+
+                        if (const auto it = mapper.find(port); it != mapper.end())
+                        {
+                            NETLIB_LOG(log_level::info,
+                                "UDP Redirect entry was found for the {} : {}",
+                                std::string{ address }, port);
+
+                            mapper.erase(it);
+
+                            return std::make_tuple(upstream.ip, upstream.port,
+                                std::make_unique<udp_negotiate_t>(
+                                    AddrT{}, 0,
+                                    cred_pair ? std::optional(cred_pair.value().first) : std::nullopt,
+                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt));
+                        }
+
+                        return std::make_tuple(AddrT{}, 0, nullptr);
+                    }, log_level_, log_stream_)
+                : nullptr;
+
+            return { std::move(tcp_server), std::move(udp_server) };
+        }
+
+    public:
         /**
          * Add a SOCKS5 proxy and optionally starts it.
          * @param endpoint string representing the endpoint of the SOCKS5 proxy server.
@@ -863,127 +1170,116 @@ namespace proxy
 
             try
             {
-                // Create TCP and UDP proxy server objects and start them if required
+                // Create the IPv4 proxy-server pair first; this is the historical,
+                // required path. The IPv6 pair is best-effort below so IPv4 proxy
+                // registration still works on hosts where IPv6 sockets are disabled.
+                auto [socks_tcp_proxy_server, socks_udp_proxy_server] =
+                    build_proxy_pair<net::ip_address_v4>(proxy_endpoint.value(), protocols, cred_pair);
 
-                auto socks_tcp_proxy_server = (protocols == both || protocols == tcp)
-                                                  ? std::make_unique<s5_tcp_proxy_server>(
-                                                      0, io_port_, [this, endpoint = proxy_endpoint.value(), cred_pair](
-                                                      const net::ip_address_v4 address, const uint16_t port)->
-                                                      std::tuple<net::ip_address_v4, uint16_t, std::unique_ptr<
-                                                                     s5_tcp_proxy_server::negotiate_context_t>>
-                                                      {
-                                                          std::scoped_lock lock(tcp_mapper_lock_);
+                std::unique_ptr<s5_tcp_proxy_server_v6> socks_tcp_proxy_server_v6;
+                std::unique_ptr<s5_udp_proxy_server_v6> socks_udp_proxy_server_v6;
 
-                                                          if (const auto it = tcp_mapper_.find(port); it != tcp_mapper_.
-                                                              end())
-                                                          {
-                                                              // Discard stale entries whose age has exceeded the TTL.
-                                                              // Eviction is performed asynchronously by the resolver
-                                                              // thread and may be delayed, so validate age at lookup
-                                                              // time to avoid misrouting a new connection on a reused
-                                                              // source port.
-                                                              if (std::chrono::steady_clock::now() - it->second.created_at
-                                                                  > tcp_mapper_entry_ttl_)
-                                                              {
-                                                                  NETLIB_LOG(log_level::warning,
-                                                                            "TCP Redirect entry for port {} was stale (age exceeded TTL); discarding.",
-                                                                            port);
-                                                                  tcp_mapper_.erase(it);
-                                                                  return std::make_tuple(net::ip_address_v4{}, 0, nullptr);
-                                                              }
+                try
+                {
+                    // The IPv6 path connects to the IPv4-mapped form of the configured
+                    // upstream over a dual-stack socket, so existing IPv4 SOCKS5
+                    // endpoints (e.g. 127.0.0.1:1080) keep working while IPv6
+                    // destinations are proxied instead of leaking.
+                    // Build the IPv4-mapped IPv6 form of the configured (IPv4) upstream
+                    // directly from its octets rather than via "::ffff:" + string parsing,
+                    // which would silently yield :: on a parse failure under NDEBUG.
+                    in6_addr mapped_upstream{};
+                    mapped_upstream.u.Byte[10] = 0xff;
+                    mapped_upstream.u.Byte[11] = 0xff;
+                    const in_addr upstream_v4 = proxy_endpoint.value().ip;
+                    memcpy(&mapped_upstream.u.Byte[12], &upstream_v4, sizeof(upstream_v4));
+                    const net::ip_endpoint<net::ip_address_v6> upstream_v6{
+                        net::ip_address_v6{ mapped_upstream },
+                        proxy_endpoint.value().port
+                    };
 
-                                                              NETLIB_LOG(log_level::info,
-                                                                        "TCP Redirect entry was found for the {} : {} is {} : {}",
-                                                                        address, port, net::ip_address_v4{it->second.endpoint.ip}, it->second.endpoint.port);
-
-                                                              auto remote_address = it->second.endpoint.ip;
-                                                              auto remote_port = it->second.endpoint.port;
-
-                                                              tcp_mapper_.erase(it);
-
-                                                              return std::make_tuple(endpoint.ip, endpoint.port,
-                                                                  std::make_unique<
-                                                                      s5_tcp_proxy_server::negotiate_context_t>(
-                                                                      remote_address, remote_port,
-                                                                      cred_pair
-                                                                          ? std::optional(cred_pair.value().first)
-                                                                          : std::nullopt,
-                                                                      cred_pair
-                                                                          ? std::optional(cred_pair.value().second)
-                                                                          : std::nullopt));
-                                                          }
-
-                                                          return std::make_tuple(net::ip_address_v4{}, 0, nullptr);
-                                                      }, log_level_, log_stream_)
-                                                  : nullptr;
-
-                auto socks_udp_proxy_server = (protocols == both || protocols == udp)
-                                                  ? std::make_unique<s5_udp_proxy_server>(
-                                                      0, io_port_, [this, endpoint = proxy_endpoint.value(), cred_pair](
-                                                      const net::ip_address_v4 address, const uint16_t port)->
-                                                      std::tuple<net::ip_address_v4, uint16_t, std::unique_ptr<
-                                                                     s5_udp_proxy_server::negotiate_context_t>>
-                                                      {
-                                                          std::scoped_lock lock(udp_mapper_lock_);
-
-                                                          if (const auto it = udp_mapper_.find(port); it != udp_mapper_.
-                                                              end())
-                                                          {
-                                                              NETLIB_LOG(log_level::info,
-                                                                        "UDP Redirect entry was found for the {} : {}",
-                                                                        address, port);
-
-                                                              udp_mapper_.erase(it);
-
-                                                              return std::make_tuple(endpoint.ip, endpoint.port,
-                                                                  std::make_unique<
-                                                                      s5_udp_proxy_server::negotiate_context_t>(
-                                                                      net::ip_address_v4{}, 0,
-                                                                      cred_pair
-                                                                          ? std::optional(cred_pair.value().first)
-                                                                          : std::nullopt,
-                                                                      cred_pair
-                                                                          ? std::optional(cred_pair.value().second)
-                                                                          : std::nullopt));
-                                                          }
-
-                                                          return std::make_tuple(net::ip_address_v4{}, 0, nullptr);
-                                                      }, log_level_, log_stream_)
-                                                  : nullptr;
+                    auto proxy_pair_v6 = build_proxy_pair<net::ip_address_v6>(upstream_v6, protocols, cred_pair);
+                    socks_tcp_proxy_server_v6 = std::move(proxy_pair_v6.first);
+                    socks_udp_proxy_server_v6 = std::move(proxy_pair_v6.second);
+                }
+                catch (const std::exception& e)
+                {
+                    NETLIB_LOG(log_level::warning,
+                        "IPv6 SOCKS5 proxy listeners for {} are disabled: {}",
+                        endpoint, e.what());
+                }
+                catch (...)
+                {
+                    NETLIB_LOG(log_level::warning,
+                        "IPv6 SOCKS5 proxy listeners for {} are disabled: unknown error",
+                        endpoint);
+                }
 
                 if (start) // optionally start proxies
                 {
-                    // If successful in starting the servers, log the local listening ports
-                    if (socks_tcp_proxy_server)
+                    // IPv4 listeners are required: on failure return nullopt and let
+                    // the local unique_ptrs tear down (their destructors stop any listener
+                    // that already started), so the add fails atomically.
+                    const auto start_listener = [&endpoint, this](auto& server, const char* family,
+                                                                  const char* proto) -> bool
                     {
-                        if (!socks_tcp_proxy_server->start())
+                        if (!server)
+                            return true;
+
+                        if (!server->start())
                         {
-                            NETLIB_LOG(log_level::error, "Failed to start TCP SOCKS5 proxy {}", endpoint);
-                            return {};
+                            NETLIB_LOG(log_level::error, "Failed to start {} {} SOCKS5 proxy {}", family, proto, endpoint);
+                            return false;
                         }
 
                         NETLIB_LOG(log_level::info,
-                                  "Local TCP proxy for {} is listening port: {}", endpoint, socks_tcp_proxy_server->proxy_port());
+                            "Local {} {} proxy for {} is listening port: {}", family, proto, endpoint, server->proxy_port());
+                        return true;
+                    };
+
+                    if (!start_listener(socks_tcp_proxy_server, "IPv4", "TCP")) return {};
+                    if (!start_listener(socks_udp_proxy_server, "IPv4", "UDP")) return {};
+
+                    const auto disable_ipv6_listeners = [&]
+                    {
+                        if (socks_tcp_proxy_server_v6)
+                            socks_tcp_proxy_server_v6->stop();
+                        if (socks_udp_proxy_server_v6)
+                            socks_udp_proxy_server_v6->stop();
+
+                        socks_tcp_proxy_server_v6.reset();
+                        socks_udp_proxy_server_v6.reset();
+                    };
+
+                    if (!start_listener(socks_tcp_proxy_server_v6, "IPv6", "TCP"))
+                    {
+                        disable_ipv6_listeners();
                     }
-
-                    if (socks_udp_proxy_server)
+                    else if (!start_listener(socks_udp_proxy_server_v6, "IPv6", "UDP"))
                     {
-                        if (!socks_udp_proxy_server->start())
-                        {
-                            NETLIB_LOG(log_level::error, "Failed to start UDP SOCKS5 proxy {}", endpoint);
-                            return {};
-                        }
-
-                        NETLIB_LOG(log_level::info,
-                                  "Local UDP proxy for {} is listening port: {}", endpoint, socks_udp_proxy_server->proxy_port());
+                        disable_ipv6_listeners();
                     }
                 }
 
-                // Lock the mutex to safely add the proxy servers to the shared data structure
+                // Lock the mutex to safely add the proxy servers to the shared data
+                // structures. proxy_servers_ and proxy_servers_v6_ are appended together
+                // so they stay index-aligned (the returned index addresses both).
                 std::scoped_lock lock(lock_);
+
+                // Reserve capacity on BOTH vectors up front so the two appends below
+                // are exception-atomic: reserve() is the only step here that can throw
+                // (std::bad_alloc on reallocation), while the subsequent emplace_back of
+                // moved unique_ptrs is noexcept once capacity is guaranteed. If either
+                // reserve throws, neither vector has grown, preserving the index-alignment
+                // invariant (a half-completed append would otherwise permanently skew the
+                // vectors and silently leave IPv6 unproxied for later proxies).
+                proxy_servers_.reserve(proxy_servers_.size() + 1);
+                proxy_servers_v6_.reserve(proxy_servers_v6_.size() + 1);
 
                 proxy_servers_.emplace_back(
                     std::move(socks_tcp_proxy_server), std::move(socks_udp_proxy_server));
+                proxy_servers_v6_.emplace_back(
+                    std::move(socks_tcp_proxy_server_v6), std::move(socks_udp_proxy_server_v6));
 
                 return proxy_servers_.size() - 1; // Return the index of the added proxy server
             }
@@ -1181,11 +1477,28 @@ namespace proxy
             if (process->id == ::GetCurrentProcessId())
                 return false;
 
+            // Matches a configured executable name (one without a path separator) against the
+            // process's bare name. Anchored to the whole filename -- an exact match, or the
+            // entry as the filename stem immediately followed by an extension -- so a short
+            // pattern can't match an unrelated process (e.g. "NOTE" matching "EVILNOTE.EXE").
+            // Inputs are already uppercased by the caller. Path-form entries (containing a
+            // separator) still use substring matching against the full path.
+            const auto name_matches = [](const std::wstring& name, const std::wstring& entry)
+            {
+                if (entry.empty())
+                    return false;
+                if (name == entry)
+                    return true;
+                return name.size() > entry.size()
+                    && name.compare(0, entry.size(), entry) == 0
+                    && name[entry.size()] == L'.';
+            };
+
             // Check exclusion list
             for (const auto& excluded_entry : excluded_list_) {
                 if ((excluded_entry.find(L'\\') != std::wstring::npos || excluded_entry.find(L'/') != std::wstring::npos)
                     ? (process->path_name.find(excluded_entry) != std::wstring::npos)
-                    : (process->name.find(excluded_entry) != std::wstring::npos)
+                    : name_matches(process->name, excluded_entry)
                     ) {
                     process->excluded = true;
                     return false; // Excluded
@@ -1194,7 +1507,7 @@ namespace proxy
 
             return (app.find(L'\\') != std::wstring::npos || app.find(L'/') != std::wstring::npos)
                     ? (process->path_name.find(app) != std::wstring::npos)
-                    : (process->name.find(app) != std::wstring::npos);
+                    : name_matches(process->name, app);
         }
 
         /**
@@ -1213,7 +1526,7 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_servers_[proxy_id].first
+                    return proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].first
                         ? std::optional(proxy_servers_[proxy_id].first->proxy_port())
                         : std::nullopt;
                 }
@@ -1239,7 +1552,7 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_servers_[proxy_id].second
+                    return proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].second
                         ? std::optional(proxy_servers_[proxy_id].second->proxy_port())
                         : std::nullopt;
                 }
@@ -1281,6 +1594,82 @@ namespace proxy
             // Checks each proxy server to see if the given port number is being used.
             // Returns true if any server is using the port, false otherwise.
             return std::ranges::any_of(std::as_const(proxy_servers_), [port](auto& proxy)
+            {
+                if (proxy.second && proxy.second->proxy_port() == port)
+                    return true;
+                return false;
+            });
+        }
+
+        /**
+         * IPv6 counterpart of get_proxy_port_tcp(). Indexes proxy_servers_v6_, which is
+         * kept index-aligned with proxy_servers_, so the same proxy_to_names_ mapping
+         * selects the matching IPv6 proxy.
+         */
+        std::optional<uint16_t> get_proxy_port_tcp_v6(const std::shared_ptr<iphelper::network_process>& process)
+        {
+            if (!process) return {};
+
+            std::shared_lock lock(lock_);
+
+            for (const auto& [proxy_id, process_pattern] : proxy_to_names_)
+            {
+                if (match_app_name(process_pattern, process))
+                {
+                    return proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].first
+                        ? std::optional(proxy_servers_v6_[proxy_id].first->proxy_port())
+                        : std::nullopt;
+                }
+            }
+
+            return {};
+        }
+
+        /**
+         * IPv6 counterpart of get_proxy_port_udp(). See get_proxy_port_tcp_v6().
+         */
+        std::optional<uint16_t> get_proxy_port_udp_v6(const std::shared_ptr<iphelper::network_process>& process)
+        {
+            if (!process) return {};
+
+            std::shared_lock lock(lock_);
+
+            for (const auto& [proxy_id, process_pattern] : proxy_to_names_)
+            {
+                if (match_app_name(process_pattern, process))
+                {
+                    return proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].second
+                        ? std::optional(proxy_servers_v6_[proxy_id].second->proxy_port())
+                        : std::nullopt;
+                }
+            }
+
+            return {};
+        }
+
+        /**
+         * IPv6 counterpart of is_tcp_proxy_port(): checks the IPv6 TCP proxy listeners.
+         */
+        bool is_tcp_proxy_port_v6(const uint16_t port)
+        {
+            std::shared_lock lock(lock_);
+
+            return std::ranges::any_of(std::as_const(proxy_servers_v6_), [port](auto& proxy)
+            {
+                if (proxy.first && proxy.first->proxy_port() == port)
+                    return true;
+                return false;
+            });
+        }
+
+        /**
+         * IPv6 counterpart of is_udp_proxy_port(): checks the IPv6 UDP proxy listeners.
+         */
+        bool is_udp_proxy_port_v6(const uint16_t port)
+        {
+            std::shared_lock lock(lock_);
+
+            return std::ranges::any_of(std::as_const(proxy_servers_v6_), [port](auto& proxy)
             {
                 if (proxy.second && proxy.second->proxy_port() == port)
                     return true;
@@ -1486,6 +1875,257 @@ namespace proxy
         }
 
         /**
+         * @brief Dispatches an IPv6 frame from the packet-filter callback.
+         *
+         * Mirrors the IPv4 dispatch in the constructor's filter callback: locates the
+         * transport header (skipping IPv6 extension headers), passes broadcast/multicast
+         * UDP through untouched, and routes TCP/UDP to the IPv6 process handlers. When a
+         * handler cannot resolve the owning process inline, the frame is queued for
+         * deferred resolution.
+         *
+         * @param buffer The intermediate buffer describing the IPv6 frame.
+         * @param destination_mac Destination MAC, used to skip broadcast/multicast UDP.
+         * @return The packet action to apply.
+         */
+        packet_filter::packet_action handle_ipv6_filter(ndisapi::intermediate_buffer& buffer,
+                                                        const net::mac_address& destination_mac)
+        {
+            log_packet_to_pcap(buffer);
+
+            auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
+            auto* const ip_header = reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
+
+            const auto [transport, protocol] =
+                net::ipv6_helper::find_transport_header(ip_header, buffer.m_Length - ETHER_HEADER_LENGTH);
+
+            if (transport == nullptr)
+            {
+                // No usable transport header: either a fragmented IPv6 datagram (which
+                // this build deliberately does not rewrite, to avoid corrupting a
+                // partially-rewritten datagram) or an unsupported extension chain. Such
+                // traffic is passed through UNPROXIED, so a proxied app's fragmented IPv6
+                // egress leaks its real source address. Warn once so the limitation is
+                // visible at runtime (see README, IPv6 fragmentation note).
+                static std::atomic_flag fragment_passthrough_warned;
+                if (!fragment_passthrough_warned.test_and_set(std::memory_order_relaxed))
+                {
+                    NETLIB_LOG(log_level::warning,
+                        "Fragmented or unsupported IPv6 packet passed through unproxied; "
+                        "fragmented IPv6 traffic is not redirected to the SOCKS5 proxy.");
+                }
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+            }
+
+            if (protocol == IPPROTO_UDP)
+            {
+                // skip broadcast and multicast UDP packets
+                if (destination_mac.is_broadcast() || destination_mac.is_multicast())
+                {
+                    return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+                }
+
+                if (const auto result = process_udp_packet_v6(buffer, false))
+                {
+                    return result.value();
+                }
+                return enqueue_for_deferred_resolve(buffer);
+            }
+
+            if (protocol == IPPROTO_TCP)
+            {
+                if (const auto result = process_tcp_packet_v6(buffer, false))
+                {
+                    return result.value();
+                }
+                return enqueue_for_deferred_resolve(buffer);
+            }
+
+            return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+        }
+
+        /**
+         * @brief IPv6 counterpart of process_udp_packet().
+         *
+         * Behaves identically to the IPv4 handler but parses an IPv6 header (skipping
+         * extension headers via ipv6_helper), and uses the IPv6 process lookup, mapper,
+         * proxy-port lookup, and redirect objects. See process_udp_packet() for the
+         * postponed/return-value contract.
+         */
+        std::optional<packet_filter::packet_action> process_udp_packet_v6(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        {
+            auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
+            auto* const ip_header = reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
+
+            const auto [transport, protocol] =
+                net::ipv6_helper::find_transport_header(ip_header, buffer.m_Length - ETHER_HEADER_LENGTH);
+
+            if (transport == nullptr || protocol != IPPROTO_UDP)
+            {
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+            }
+
+            const auto* const udp_header = static_cast<udphdr_ptr>(transport);
+
+            // If the destination port is 53 (DNS), allow the packet to pass through
+            // without redirection (mirrors the IPv4 path).
+            if (ntohs(udp_header->th_dport) == 53)
+            {
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+            }
+
+            // If the packet is from a known proxy port, process for server-to-client redirection
+            if (is_udp_proxy_port_v6(ntohs(udp_header->th_sport)))
+            {
+                if (udp_redirect_v6_->process_server_to_client_packet(buffer))
+                {
+                    log_packet_to_pcap(buffer);
+                    return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
+                }
+            }
+
+            auto process = process_lookup_v6_.
+                lookup_process_for_udp<false>(net::ip_endpoint<net::ip_address_v6>{
+                ip_header->ip6_src, ntohs(udp_header->th_sport)
+            });
+
+            if (!process)
+            {
+                if (postponed)
+                {
+                    process = process_lookup_v6_.
+                        lookup_process_for_udp<true>(net::ip_endpoint<net::ip_address_v6>{
+                        ip_header->ip6_src, ntohs(udp_header->th_sport)
+                    });
+                }
+                else
+                {
+                    return std::nullopt;
+                }
+            }
+
+            if (process->excluded || process->bypass_udp)
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+
+            if (const auto port = process->udp_proxy_port ? process->udp_proxy_port : get_proxy_port_udp_v6(process); port.has_value())
+            {
+                if (udp_redirect_v6_->is_new_endpoint(buffer))
+                {
+                    std::scoped_lock lock(udp_mapper_v6_lock_);
+                    udp_mapper_v6_.insert(ntohs(udp_header->th_sport));
+
+                    NETLIB_LOG(log_level::info,
+                        "Redirecting UDP6 {} : {} -> {} : {}",
+                        std::string{ net::ip_address_v6{ip_header->ip6_src} }, ntohs(udp_header->th_sport),
+                        std::string{ net::ip_address_v6{ip_header->ip6_dst} }, ntohs(udp_header->th_dport));
+                }
+
+                if (udp_redirect_v6_->process_client_to_server_packet(buffer, htons(port.value())))
+                {
+                    log_packet_to_pcap(buffer);
+                    return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
+                }
+            }
+            else
+            {
+                process->bypass_udp = true;
+            }
+
+            return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+        }
+
+        /**
+         * @brief IPv6 counterpart of process_tcp_packet().
+         *
+         * Behaves identically to the IPv4 handler but parses an IPv6 header (skipping
+         * extension headers via ipv6_helper), and uses the IPv6 process lookup, mapper,
+         * proxy-port lookup, and redirect objects. See process_tcp_packet() for the
+         * postponed/return-value contract.
+         */
+        std::optional<packet_filter::packet_action> process_tcp_packet_v6(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        {
+            auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
+            auto* const ip_header = reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
+
+            const auto [transport, protocol] =
+                net::ipv6_helper::find_transport_header(ip_header, buffer.m_Length - ETHER_HEADER_LENGTH);
+
+            if (transport == nullptr || protocol != IPPROTO_TCP)
+            {
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+            }
+
+            const auto* const tcp_header = static_cast<tcphdr_ptr>(transport);
+
+            // If the packet is from a known proxy port, process for server-to-client redirection
+            if (is_tcp_proxy_port_v6(ntohs(tcp_header->th_sport)))
+            {
+                if (tcp_redirect_v6_->process_server_to_client_packet(buffer))
+                {
+                    log_packet_to_pcap(buffer);
+                    return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
+                }
+            }
+
+            auto process = process_lookup_v6_.
+                lookup_process_for_tcp<false>(net::ip_session<net::ip_address_v6>{
+                ip_header->ip6_src, ip_header->ip6_dst, ntohs(tcp_header->th_sport),
+                    ntohs(tcp_header->th_dport)
+            });
+
+            if (!process)
+            {
+                if (postponed)
+                {
+                    process = process_lookup_v6_.
+                        lookup_process_for_tcp<true>(net::ip_session<net::ip_address_v6>{
+                        ip_header->ip6_src, ip_header->ip6_dst, ntohs(tcp_header->th_sport),
+                            ntohs(tcp_header->th_dport)
+                    });
+                }
+                else
+                {
+                    return std::nullopt;
+                }
+            }
+
+            if (process->excluded || process->bypass_tcp)
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+
+            if (const auto port = process->tcp_proxy_port ? process->tcp_proxy_port : get_proxy_port_tcp_v6(process); port.has_value())
+            {
+                // If this is a SYN packet (connection initiation), map the source port to the destination endpoint
+                if ((tcp_header->th_flags & (TH_SYN | TH_ACK)) == TH_SYN)
+                {
+                    std::scoped_lock lock(tcp_mapper_v6_lock_);
+                    tcp_mapper_v6_[ntohs(tcp_header->th_sport)] =
+                        tcp_mapper_entry_v6{
+                            net::ip_endpoint(net::ip_address_v6(ip_header->ip6_dst),
+                                ntohs(tcp_header->th_dport)),
+                            std::chrono::steady_clock::now()
+                        };
+
+                    NETLIB_LOG(log_level::info,
+                        "Redirecting TCP6: {} : {} -> {} : {}",
+                        std::string{ net::ip_address_v6{ip_header->ip6_src} }, ntohs(tcp_header->th_sport),
+                        std::string{ net::ip_address_v6{ip_header->ip6_dst} }, ntohs(tcp_header->th_dport));
+                }
+
+                // Attempt to process the packet for client-to-server redirection
+                if (tcp_redirect_v6_->process_client_to_server_packet(buffer, htons(port.value())))
+                {
+                    log_packet_to_pcap(buffer);
+                    return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
+                }
+            }
+            else
+            {
+                process->bypass_tcp = true;
+            }
+
+            return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
+        }
+
+        /**
          * @brief Logs a single packet to the pcap logger.
          *
          * This function logs a single packet to the pcap logger if it is available.
@@ -1623,16 +2263,34 @@ namespace proxy
                     now - last_sweep >= maintenance_interval)
                 {
                     last_sweep = now;
-                    std::scoped_lock lock(tcp_mapper_lock_);
-                    for (auto it = tcp_mapper_.begin(); it != tcp_mapper_.end();)
                     {
-                        if (now - it->second.created_at > tcp_mapper_entry_ttl_)
+                        std::scoped_lock lock(tcp_mapper_lock_);
+                        for (auto it = tcp_mapper_.begin(); it != tcp_mapper_.end();)
                         {
-                            it = tcp_mapper_.erase(it);
+                            if (now - it->second.created_at > tcp_mapper_entry_ttl_)
+                            {
+                                it = tcp_mapper_.erase(it);
+                            }
+                            else
+                            {
+                                ++it;
+                            }
                         }
-                        else
+                    }
+
+                    // Same TTL sweep for the IPv6 TCP mapper.
+                    {
+                        std::scoped_lock lock(tcp_mapper_v6_lock_);
+                        for (auto it = tcp_mapper_v6_.begin(); it != tcp_mapper_v6_.end();)
                         {
-                            ++it;
+                            if (now - it->second.created_at > tcp_mapper_entry_ttl_)
+                            {
+                                it = tcp_mapper_v6_.erase(it);
+                            }
+                            else
+                            {
+                                ++it;
+                            }
                         }
                     }
                 }
@@ -1721,6 +2379,7 @@ namespace proxy
 
                 // Actualize process lookup before processing
                 process_lookup_v4_.actualize(true, true);
+                process_lookup_v6_.actualize(true, true);
 
                 while (!local_queue.empty())
                 {
@@ -1728,6 +2387,74 @@ namespace proxy
                     local_queue.pop();
 
                     auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer_ptr->m_IBuffer);
+
+                    // Dispatch on EtherType first: IPv6 packets carry an IPv6
+                    // header (with optional extension headers) rather than an
+                    // iphdr, so reading iphdr::ip_p for them would misparse.
+                    if (const auto ether_type = ntohs(ethernet_header->h_proto);
+                        ether_type == ETH_P_IPV6)
+                    {
+                        const auto* const ip_header =
+                            reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
+                        const auto [transport_header, protocol] =
+                            net::ipv6_helper::find_transport_header(
+                                ip_header, buffer_ptr->m_Length - ETHER_HEADER_LENGTH);
+
+                        if (transport_header == nullptr)
+                        {
+                            // Non-initial fragment or malformed/unsupported chain:
+                            // nothing actionable was deferred, so pass it through.
+                            to_adapters.push_back(std::move(buffer_ptr));
+                            continue;
+                        }
+
+                        if (protocol == IPPROTO_UDP)
+                        {
+                            if (const auto result = process_udp_packet_v6(*buffer_ptr, true);
+                                result && result->action == packet_filter::packet_action::action_type::pass)
+                            {
+                                to_adapters.push_back(std::move(buffer_ptr));
+                            }
+                            else if (result && result->action == packet_filter::packet_action::action_type::revert)
+                            {
+                                to_mstcp.push_back(std::move(buffer_ptr));
+                            }
+                            else
+                            {
+                                // Invariant: a postponed packet always yields a result. If a
+                                // future change ever breaks it, fail safe by passing the packet
+                                // through rather than silently dropping it in a release build.
+                                assert(false && "process_udp_packet_v6 should always return a result for postponed packets");
+                                to_adapters.push_back(std::move(buffer_ptr));
+                            }
+                        }
+                        else if (protocol == IPPROTO_TCP)
+                        {
+                            if (const auto result = process_tcp_packet_v6(*buffer_ptr, true);
+                                result && result->action == packet_filter::packet_action::action_type::pass)
+                            {
+                                to_adapters.push_back(std::move(buffer_ptr));
+                            }
+                            else if (result && result->action == packet_filter::packet_action::action_type::revert)
+                            {
+                                to_mstcp.push_back(std::move(buffer_ptr));
+                            }
+                            else
+                            {
+                                // Fail safe (see above): pass through instead of dropping.
+                                assert(false && "process_tcp_packet_v6 should always return a result for postponed packets");
+                                to_adapters.push_back(std::move(buffer_ptr));
+                            }
+                        }
+                        else
+                        {
+                            // Unexpected (only TCP/UDP are queued): pass through, don't drop.
+                            assert(false && "Only TCP/UDP packets should be queued for deferred processing");
+                            to_adapters.push_back(std::move(buffer_ptr));
+                        }
+
+                        continue;
+                    }
 
                     if (const auto* const ip_header = reinterpret_cast<iphdr_ptr>(ethernet_header + 1);
                         ip_header->ip_p == IPPROTO_UDP)
@@ -1743,8 +2470,10 @@ namespace proxy
                         }
                         else
                         {
-                            // Should always have a result for postponed packets
+                            // Should always have a result for postponed packets; if not,
+                            // fail safe by passing it through rather than dropping it.
                             assert(false && "process_udp_packet should always return a result for postponed packets");
+                            to_adapters.push_back(std::move(buffer_ptr));
                         }
                     }
                     else if (ip_header->ip_p == IPPROTO_TCP)
@@ -1760,14 +2489,18 @@ namespace proxy
                         }
                         else
                         {
-                            // Should always have a result for postponed packets
+                            // Should always have a result for postponed packets; if not,
+                            // fail safe by passing it through rather than dropping it.
                             assert(false && "process_tcp_packet should always return a result for postponed packets");
+                            to_adapters.push_back(std::move(buffer_ptr));
                         }
                     }
                     else
                     {
-                        // Only TCP/UDP packets should be queued for deferred processing
+                        // Only TCP/UDP packets should be queued for deferred processing;
+                        // pass anything unexpected through rather than dropping it.
                         assert(false && "Only TCP/UDP packets should be queued for deferred processing");
+                        to_adapters.push_back(std::move(buffer_ptr));
                     }
                 }
 
@@ -1927,6 +2660,70 @@ namespace proxy
             }
 
             NETLIB_LOG(log_level::info, "LAN bypass enabled - local network traffic will not be proxied");
+        }
+
+        /**
+        * @brief Builds and adds IPv6 pass-through filters for common local network ranges.
+        *
+        * IPv6 counterpart of add_lan_passover_filters_v4(). Because IPv6 destinations
+        * are now proxied, LAN bypass must also exempt the IPv6 local/special-purpose
+        * ranges; otherwise a matched application's link-local / ULA / multicast IPv6
+        * traffic would be redirected to the SOCKS5 proxy (which generally cannot reach
+        * those scopes) even with bypassLan enabled.
+        *
+        * Bypassed ranges:
+        * - fe80::/10  (Link-local unicast)
+        * - fc00::/7   (Unique local addresses, ULA)
+        * - ff00::/8   (Multicast)
+        */
+        void add_lan_passover_filters_v6()
+        {
+            // Local / special-purpose IPv6 ranges, in CIDR notation. Because the IPv6
+            // redirect also captures IPv4-mapped destinations (::ffff:a.b.c.d) that a
+            // dual-stack app opens to a v4 LAN host, the IPv4 private/link-local/multicast
+            // ranges are also exempted in their v4-mapped form so bypassLan covers them.
+            static constexpr std::array<const char*, 9> local_ranges{ {
+                "::1/128",                  // Loopback
+                "fe80::/10",                // Link-local unicast
+                "fc00::/7",                 // Unique local addresses (ULA)
+                "ff00::/8",                 // Multicast
+                "::ffff:10.0.0.0/104",      // IPv4-mapped 10.0.0.0/8 (private)
+                "::ffff:172.16.0.0/108",    // IPv4-mapped 172.16.0.0/12 (private)
+                "::ffff:192.168.0.0/112",   // IPv4-mapped 192.168.0.0/16 (private)
+                "::ffff:169.254.0.0/112",   // IPv4-mapped 169.254.0.0/16 (link-local)
+                "::ffff:127.0.0.0/104"      // IPv4-mapped loopback
+            } };
+
+            for (const auto* const cidr : local_ranges)
+            {
+                const auto subnet = net::ip_subnet<net::ip_address_v6>::from_cidr(cidr);
+                if (!subnet)
+                {
+                    // The ranges above are compile-time constants, so this should
+                    // never trigger; guard defensively rather than dereference a
+                    // nullopt if one is ever mistyped.
+                    NETLIB_LOG(log_level::warning, "Failed to parse IPv6 LAN bypass range '{}'; skipping.", cidr);
+                    continue;
+                }
+
+                // Allow inbound traffic originating from the local subnet
+                ndisapi::filter<net::ip_address_v6> in_filter;
+                in_filter
+                    .set_direction(ndisapi::direction_t::in)
+                    .set_action(ndisapi::action_t::pass)
+                    .set_source_address(subnet.value());
+                static_filters_.add_filter_front(in_filter);
+
+                // Allow outbound traffic destined to the local subnet
+                ndisapi::filter<net::ip_address_v6> out_filter;
+                out_filter
+                    .set_direction(ndisapi::direction_t::out)
+                    .set_action(ndisapi::action_t::pass)
+                    .set_dest_address(subnet.value());
+                static_filters_.add_filter_front(out_filter);
+            }
+
+            NETLIB_LOG(log_level::info, "IPv6 LAN bypass enabled - local IPv6 network traffic will not be proxied");
         }
     };
 }

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -323,38 +323,57 @@ namespace proxy
 
                         auto io_context = static_cast<per_io_context_t*>(povlp);
 
+                        // Acquire the socket's strong reference under a SHARED server lock so
+                        // this read is serialized with clear_thread's release_self_references(),
+                        // which resets the same shared_ptr while clear_thread holds the EXCLUSIVE
+                        // server lock_. That removes the data race on the shared_ptr and prevents
+                        // the object being released/destroyed between this read and its use; the
+                        // captured strong ref then keeps the object alive for the rest of the
+                        // callback. A relay/negotiate context whose socket already released its
+                        // self-references reads null and safely no-ops; inject_io_write contexts
+                        // are heap-owned and always carry a strong ref, so they are still handled.
+                        decltype(io_context->proxy_socket_ptr) proxy_socket;
+                        proxy_io_operation io_operation;
+                        {
+                            std::shared_lock lock(lock_);
+                            proxy_socket = io_context->proxy_socket_ptr;
+                            io_operation = io_context->io_operation;
+                        }
+                        if (!proxy_socket && io_operation != proxy_io_operation::inject_io_write)
+                            return true;
+
                         if (!status || (status && (num_bytes == 0)))
                         {
-                            if ((io_context->io_operation == proxy_io_operation::relay_io_read) ||
-                                (io_context->io_operation == proxy_io_operation::negotiate_io_read))
+                            if ((io_operation == proxy_io_operation::relay_io_read) ||
+                                (io_operation == proxy_io_operation::negotiate_io_read))
                             {
-                                io_context->proxy_socket_ptr->close_client(true, io_context->is_local);
+                                proxy_socket->close_client(true, io_context->is_local);
                                 return false;
                             }
 
                             if (!status)
                             {
-                                io_context->proxy_socket_ptr->close_client(false, io_context->is_local);
+                                proxy_socket->close_client(false, io_context->is_local);
                                 return false;
                             }
                         }
 
-                        switch (io_context->io_operation)
+                        switch (io_operation)
                         {
                         case proxy_io_operation::relay_io_read:
-                            io_context->proxy_socket_ptr->process_receive_buffer_complete(num_bytes, io_context);
+                            proxy_socket->process_receive_buffer_complete(num_bytes, io_context);
                             break;
 
                         case proxy_io_operation::relay_io_write:
-                            io_context->proxy_socket_ptr->process_send_buffer_complete(num_bytes, io_context);
+                            proxy_socket->process_send_buffer_complete(num_bytes, io_context);
                             break;
 
                         case proxy_io_operation::negotiate_io_read:
-                            io_context->proxy_socket_ptr->process_receive_negotiate_complete(num_bytes, io_context);
+                            proxy_socket->process_receive_negotiate_complete(num_bytes, io_context);
                             break;
 
                         case proxy_io_operation::negotiate_io_write:
-                            io_context->proxy_socket_ptr->process_send_negotiate_complete(num_bytes, io_context);
+                            proxy_socket->process_send_negotiate_complete(num_bytes, io_context);
                             break;
 
                         case proxy_io_operation::inject_io_write:
@@ -723,6 +742,19 @@ namespace proxy
             }
             else
             {
+                // Allow this AF_INET6 upstream socket to reach IPv4 SOCKS5 servers
+                // via IPv4-mapped addresses (e.g. ::ffff:127.0.0.1). ProxiFyre's
+                // IPv6 proxy path targets the configured (often IPv4) SOCKS5 server
+                // through its v4-mapped form, so the socket must be dual-stack.
+                DWORD v6_only = 0;
+                if (setsockopt(remote_socket, IPPROTO_IPV6, IPV6_V6ONLY,
+                    reinterpret_cast<const char*>(&v6_only), sizeof(v6_only)) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("connect_to_remote_host: Failed to clear IPV6_V6ONLY on remote socket: {}",
+                        WSAGetLastError());
+                    // Continue: a v6-only socket still works for genuine IPv6 upstreams.
+                }
+
                 sockaddr_in6 sa_local{};
                 sa_local.sin6_family = address_type_t::af_type;
                 sa_local.sin6_port = htons(0);
@@ -1010,8 +1042,10 @@ namespace proxy
                 }
             }
 
-            // cleanup on exit
-            std::shared_lock lock(lock_);
+            // cleanup on exit. Exclusive lock: this block MUTATES sock_array_events_
+            // (closes events/sockets and writes INVALID_SOCKET), so a shared (read) lock
+            // would be the wrong contract.
+            std::unique_lock lock(lock_);
 
             for (auto&& a : sock_array_events_)
             {

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -245,6 +245,13 @@ namespace proxy
         per_io_context_t io_context_send_to_remote_{ proxy_io_operation::relay_io_write, nullptr, false };
 
         /**
+         * @brief Set on the first is_ready_for_removal() pass that sees both sockets closed,
+         *        so the next pass (a full cleanup cycle later) releases the self-references.
+         *        The grace lets any still-queued IOCP completion drain first.
+         */
+        bool removal_armed_ = false;
+
+        /**
          * @brief Indicates whether Nagle's algorithm is disabled for the remote socket.
          *
          * When true, disables Nagle's algorithm (TCP_NODELAY) to reduce latency for small packets.
@@ -753,6 +760,21 @@ namespace proxy
          *       The 1-hour safety timeout prevents memory leaks from truly abandoned connections while
          *       allowing legitimate long-lived connections to function normally.
          */
+        /**
+         * @brief Releases the strong self-references held by this socket's per-I/O context
+         *        members, breaking the reference cycle so the object can be destroyed. Called
+         *        by is_ready_for_removal() once both sockets are closed and queued completions
+         *        have drained. Overridden by derived classes that own additional per-I/O
+         *        contexts (e.g. the SOCKS5 negotiation contexts).
+         */
+        virtual void release_self_references() noexcept
+        {
+            io_context_recv_from_local_.proxy_socket_ptr.reset();
+            io_context_recv_from_remote_.proxy_socket_ptr.reset();
+            io_context_send_to_local_.proxy_socket_ptr.reset();
+            io_context_send_to_remote_.proxy_socket_ptr.reset();
+        }
+
         bool is_ready_for_removal()
         {
             using namespace std::chrono_literals;
@@ -784,6 +806,22 @@ namespace proxy
                     remote_recv_buf_.len = 0;
                     local_recv_buf_.len = 0;
                 }
+
+                // Break the per-session shared_ptr cycle: each per-I/O context member holds a
+                // strong reference back to this object so it stays alive while overlapped I/O
+                // is in flight. Release those refs here so the destructor can finally run once
+                // the server drops its own reference. Wait one cleanup cycle after both sockets
+                // close (removal_armed_) before releasing: any IOCP completion still queued for
+                // this socket fires within milliseconds of closesocket(), so a full cleanup
+                // interval guarantees they have all been delivered (and safely no-op'd) first.
+                if (!removal_armed_)
+                {
+                    removal_armed_ = true;
+                    NETLIB_DEBUG("is_ready_for_removal: Sockets closed; arming removal for the next cycle");
+                    return false;
+                }
+
+                release_self_references();
 
                 NETLIB_INFO("is_ready_for_removal: Session is ready for removal - all sockets closed and buffers cleared");
                 return true;

--- a/socksify/Socksifier.cpp
+++ b/socksify/Socksifier.cpp
@@ -11,6 +11,10 @@
 /// <param name="log_level">The logging level to use.</param>
 Socksifier::Socksifier::Socksifier(LogLevel log_level)
 {
+    // Default poll interval (ms). Without this the field is 0 and log_thread() busy-spins
+    // (WaitOne(0)) until the managed side assigns LogEventInterval.
+    log_event_interval_ = 1000;
+
     unmanaged_ptr_ = socksify_unmanaged::get_instance(static_cast<log_level_mx>(log_level));
 
     log_event_ = gcnew Threading::AutoResetEvent(false);
@@ -56,6 +60,13 @@ Socksifier::Socksifier::!Socksifier()
 Socksifier::Socksifier::~Socksifier()
 {
     this->!Socksifier();
+
+    // Clear the singleton so a subsequent GetInstance() (e.g. on a service restart within the
+    // same process) creates a fresh, usable instance instead of returning this disposed one
+    // (whose unmanaged core is gone), which would silently disable proxying.
+    msclr::lock l(Socksifier::typeid);
+    if (instance_ == this)
+        instance_ = nullptr;
 }
 
 /// <summary>


### PR DESCRIPTION
Fixes surfaced by a deep, multi-agent code review of the IPv6 proxying feature (the parallel IPv6 SOCKS5 stack, dual‑stack upstreams, variable‑length SOCKS5 reply parsing, and packet rewriting). All native + C++/CLI changes build clean (Release|x64, MSVC C++20 `/permissive`).

### What's here (5 themed commits)
- **`fix(ndisapi):` packet‑rewrite bounds + SOCKS5 framing** — fixes a **10‑byte OOB write** in the IPv4 UDP attach on near‑MTU datagrams and a detach memmove underflow; rejects a truncated IPv6 transport header before TCP flags/ports are read; rejects a SOCKS5 UDP reply whose ATYP mismatches the relay family (peer‑address spoofing); length‑prefixed `memcpy` for the RFC 1929 auth block (255‑char credential fault).
- **`fix(proxy):` reference‑cycle leak** — each per‑I/O context held a strong `shared_ptr` back to its socket, so the destructor never ran (leaking the object and, for UDP, socket handles). Self‑references are now released after both sockets close (one cleanup‑cycle grace); UDP `close_client()` closes handles immediately; the TCP completion lambda captures the socket ref under a **shared** server lock, serialized against the release under the **exclusive** cleanup lock — eliminating a teardown data‑race/UAF.
- **`fix(socks5):` negotiation + blocking I/O** — balances the UDP server IOCP‑op counter (could drift negative → race `stop()`), bounds the upstream `connect()` (non‑blocking 5s) and `recv_exact`, relays UDP to the control‑connection address, parses BND.PORT at the family‑correct offset, sends a family‑matching ASSOCIATE ATYP.
- **`fix(router):` IPv6 dispatch + matching + LAN bypass** — atomic per‑process cache flags, IPv4 `get_proxy_port` bounds checks, fail‑safe deferred dispatch, `::1`/IPv4‑mapped ranges in the IPv6 LAN bypass, octet‑built mapped upstream, one‑time fragmented‑IPv6‑passthrough warning, and README docs.
- **`fix(socksify):` C#/CLI wrapper** — recreate the disposed singleton on service restart (it silently disabled proxying), stop the startup log busy‑spin, warn on half‑specified credentials / unrecognized protocol tokens.

### ⚠️ Behavior change
App‑name matching is now **anchored to the whole filename** (exact, or the entry as the filename stem + extension). `"chrome"` still matches `chrome.exe`, but **substring/prefix matches no longer match** (e.g. `"msedge"` no longer matches `msedgewebview2.exe`) — use a path fragment for directory‑style matching. Path‑form entries are unchanged.