### PR TITLE
fix(proxy): drain in-flight overlapped I/O with a per-socket counter

### DIFF
--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -305,21 +305,13 @@ namespace proxy
 
                         auto io_context = static_cast<per_io_context_t*>(povlp);
 
-                        // Server shutting down: still balance this completion's io_posted() so a
-                        // completion delivered while stop() runs cannot leave outstanding_io_ stuck
-                        // non-zero, but start no new work (no connect/dispatch/re-arm) during
-                        // teardown. A per-session op carries a socket ref here; the server read
-                        // (server_io_context_) was never counted, so it is not decremented. We hold
-                        // lock_, and a counted op keeps its io_context alive, so this access is safe.
-                        if (end_server_)
-                        {
-                            if (io_context != &server_io_context_)
-                            {
-                                if (auto completing_socket = io_context->proxy_socket_ptr)
-                                    completing_socket->io_completed();
-                            }
-                            return false;
-                        }
+                        // While the server is shutting down we must still fully process each
+                        // delivered completion -- decrement its outstanding-I/O count (via io_dec
+                        // below) and release any heap per-I/O context it owns -- but must start no
+                        // NEW work (no connect, no data-relay dispatch, no recv/send re-arm). Read
+                        // this once and gate the new-work paths on it. The unconditional io_dec
+                        // guard keeps outstanding_io_ balanced without a special early return.
+                        const bool shutting_down = end_server_;
 
                         // If this is the server socket's read operation
                         if (io_context == &server_io_context_)
@@ -327,7 +319,7 @@ namespace proxy
                             // Server socket read operation complete
                             server_read = true;
 
-                            if (status && num_bytes)
+                            if (status && num_bytes && !shutting_down)
                             {
                                 do
                                 {
@@ -372,36 +364,48 @@ namespace proxy
                             io_dec_guard& operator=(io_dec_guard&&) = delete;
                         } io_dec{ completing_socket.get() };
 
-                        if (status && result)
+                        // The proxy socket may have released its self-reference during teardown; a
+                        // late completion then finds null and is safely ignored.
+                        if (auto proxy_socket = io_context->proxy_socket_ptr)
                         {
-                            // The proxy socket may have released its self-reference during
-                            // teardown; a late completion then finds null and is safely ignored.
-                            if (auto proxy_socket = io_context->proxy_socket_ptr)
+                            switch (io_context->io_operation)
                             {
-                                switch (io_context->io_operation)
-                                {
-                                case proxy_io_operation::relay_io_read:
+                            // Reads (and the no-op negotiate handlers) run a handler that posts NEW
+                            // overlapped I/O, so only dispatch them on a successful, non-teardown
+                            // completion. On an aborted read (status == false) or during shutdown
+                            // there is nothing to free -- the recv uses a member io_context -- so we
+                            // just fall through to the io_dec decrement.
+                            case proxy_io_operation::relay_io_read:
+                                if (status && result && !shutting_down)
                                     proxy_socket->process_receive_buffer_complete(num_bytes, io_context);
-                                    break;
+                                break;
 
-                                case proxy_io_operation::relay_io_write:
-                                    proxy_socket->process_send_buffer_complete(num_bytes, io_context);
-                                    break;
-
-                                case proxy_io_operation::negotiate_io_read:
+                            case proxy_io_operation::negotiate_io_read:
+                                if (status && result && !shutting_down)
                                     proxy_socket->process_receive_negotiate_complete(num_bytes, io_context);
-                                    break;
+                                break;
 
-                                case proxy_io_operation::negotiate_io_write:
+                            case proxy_io_operation::negotiate_io_write:
+                                if (status && result && !shutting_down)
                                     proxy_socket->process_send_negotiate_complete(num_bytes, io_context);
-                                    break;
+                                break;
 
-                                case proxy_io_operation::inject_io_write:
-                                    T::process_inject_buffer_complete(packet_pool_, io_context);
-                                    break;
+                            // Writes and injects own a HEAP io_context (allocated per datagram via
+                            // allocate_io_context / new). Their handler only releases that context
+                            // (and its pooled packet) and posts no new I/O, so it MUST run on EVERY
+                            // completion -- including an aborted one (status == false) flushed by
+                            // close_client()'s CancelIoEx during runtime teardown or shutdown.
+                            // Skipping it leaks the context and its buffer and keeps this socket
+                            // pinned alive via the context's strong proxy_socket_ptr.
+                            case proxy_io_operation::relay_io_write:
+                                proxy_socket->process_send_buffer_complete(num_bytes, io_context);
+                                break;
 
-                                default: break; // NOLINT(clang-diagnostic-covered-switch-default)
-                                }
+                            case proxy_io_operation::inject_io_write:
+                                T::process_inject_buffer_complete(packet_pool_, io_context);
+                                break;
+
+                            default: break; // NOLINT(clang-diagnostic-covered-switch-default)
                             }
                         }
 
@@ -481,12 +485,14 @@ namespace proxy
          *
          * This method performs a graceful shutdown by:
          * 1. Setting the end_server_ flag to signal shutdown
-         * 2. Closing the server socket, which causes pending I/O to complete with error
-         * 3. Waiting for all active IOCP operations to complete (tracked by atomic counter)
-         * 4. Joining background threads
-         * 5. Clearing resources
+         * 2. Closing the server socket, which causes the pending WSARecvFrom to complete with error
+         * 3. Cancelling each proxy socket's pending I/O (close_client) so its posted operations abort
+         * 4. Waiting for every proxy socket's overlapped I/O to drain (per-socket outstanding count)
+         *    and for all IOCP callbacks to finish
+         * 5. Releasing each socket's self-reference and clearing the map so the sockets destruct
+         * 6. Joining background threads
          *
-         * The IOCP thread pool itself is managed by io_completion_port and will be 
+         * The IOCP thread pool itself is managed by io_completion_port and will be
          * properly shut down when the completion port is destroyed.
          */
         void stop()
@@ -509,50 +515,103 @@ namespace proxy
                 server_socket_ = INVALID_SOCKET;
             }
 
-            // Step 2.5: Unregister the IOCP handler BEFORE waiting
-            if (completion_key_ != 0) {
-                (void)completion_port_.unregister_handler(completion_key_);
-                completion_key_ = 0;
-            }
+            // NOTE: the IOCP handler stays registered until AFTER the drain below. The aborted
+            // completions produced by close_client()'s CancelIoEx must still dispatch through it so
+            // they release their heap contexts and decrement each socket's outstanding_io_;
+            // unregistering here would drop those completions and the drain would never complete.
 
-            // Step 3: Close all proxy sockets FIRST to cancel their I/O operations
-            // This is CRITICAL: proxy sockets post their own I/O operations that will
-            // call back into this server's lambda, potentially after the server is destroyed.
-            // We must ensure all proxy socket I/O is cancelled before we proceed.
+            // Step 3: Cancel every proxy socket's pending I/O so its posted operations complete
+            // promptly (aborted) and stop pinning the socket. Keep the sockets in the map for now --
+            // they must stay alive until their in-flight completions have drained. Simply clearing
+            // the map does NOT destroy them: each socket's recv io_context holds a self-reference,
+            // so the destructor would never run and the handle/armed recv would leak.
             {
                 std::lock_guard lock(lock_);
                 if (!proxy_sockets_.empty())
                 {
-                    NETLIB_INFO("Closing {} proxy sockets before waiting for I/O completion", proxy_sockets_.size());
-                    // Closing the map entries will destroy the proxy sockets,
-                    // which will close their sockets and cancel any pending I/O
-                    proxy_sockets_.clear();
+                    NETLIB_INFO("Cancelling I/O on {} proxy sockets before draining", proxy_sockets_.size());
+                    for (auto& entry : proxy_sockets_)
+                    {
+                        if (entry.second)
+                            entry.second->close_client(); // idempotent: CancelIoEx + closesocket
+                    }
                 }
             }
 
-            // Step 4: Wait for all active IOCP operations to complete
-            // The socket closure ensures pending operations complete quickly.
-            // The atomic counter ensures we wait until all in-flight operations finish.
-            // Use exponential backoff to avoid busy-waiting
+            // Step 4: Wait until every proxy socket has drained all posted overlapped I/O (its
+            // per-socket outstanding count reaches zero) AND no IOCP callback is still running.
+            // The handler is still registered, so close_client()'s aborted completions dispatch,
+            // release their heap contexts, and the io_dec guard decrements the count. Gate on the
+            // per-socket count -- not just active_iocp_operations_ -- because a cancelled completion
+            // may still be queued (not yet dispatched) while active_iocp_operations_ momentarily
+            // reads zero; releasing a socket's self-reference before that completion is processed
+            // would free the io_context out from under it. Re-issue close_client() on any not-yet-
+            // drained socket each pass so a session armed concurrently with shutdown (e.g. a
+            // blocking connect that finished after end_server_ was set) is cancelled too.
+            // Exponential backoff to avoid busy-waiting.
             using namespace std::chrono_literals;
             int wait_iterations = 0;
+            bool drained_ok = false;
 
-            while (active_iocp_operations_.load(std::memory_order_acquire) > 0)
+            while (true)
             {
-                if (constexpr int max_wait_iterations = 100; ++wait_iterations > max_wait_iterations)
+                bool drained = true;
                 {
-                    // Log warning if we're taking too long
-                    NETLIB_WARNING("Timeout waiting for IOCP operations to complete. Active operations: {}",
-                    active_iocp_operations_.load(std::memory_order_relaxed));
+                    std::lock_guard lock(lock_);
+                    for (auto& entry : proxy_sockets_)
+                    {
+                        if (entry.second && entry.second->outstanding_io() != 0)
+                        {
+                            drained = false;
+                            entry.second->close_client(); // idempotent; cancels late-armed sessions
+                        }
+                    }
+                }
+
+                if (drained && active_iocp_operations_.load(std::memory_order_acquire) == 0)
+                {
+                    drained_ok = true;
                     break;
                 }
-             
+
+                if (constexpr int max_wait_iterations = 100; ++wait_iterations > max_wait_iterations)
+                {
+                    NETLIB_ERROR("Timeout waiting for proxy socket I/O to drain (active operations: {}); "
+                        "leaving sessions pinned to avoid freeing in-flight io_contexts",
+                        active_iocp_operations_.load(std::memory_order_relaxed));
+                    break;
+                }
+
                 // Exponential backoff: 1ms, 2ms, 4ms, 8ms, ... up to 100ms
                 const auto wait_time = std::min(1ms * (1 << std::min(wait_iterations / 10, 6)), 100ms);
                 std::this_thread::sleep_for(wait_time);
             }
 
-            // Step 5: Join background threads
+            // Step 5: All completions have now been processed (or we timed out), so unregister the
+            // IOCP handler -- no further completion will dispatch into this server.
+            if (completion_key_ != 0)
+            {
+                (void)completion_port_.unregister_handler(completion_key_);
+                completion_key_ = 0;
+            }
+
+            // Step 6: Only if the drain completed do we break each socket's self-reference and clear
+            // the map so the sockets (and their already-released heap I/O contexts) destruct. If the
+            // drain timed out, some overlapped op is still outstanding; releasing/clearing now would
+            // free an io_context that a still-queued completion could dereference, so we deliberately
+            // leak those sessions instead (a bounded, shutdown-only leak) rather than risk a UAF.
+            if (drained_ok)
+            {
+                std::lock_guard lock(lock_);
+                for (auto& entry : proxy_sockets_)
+                {
+                    if (entry.second)
+                        entry.second->release_self_reference();
+                }
+                proxy_sockets_.clear();
+            }
+
+            // Step 7: Join background threads
             if (proxy_server_.joinable())
             {
                 proxy_server_.join();

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -301,13 +301,25 @@ namespace proxy
                         auto result = true;
                         auto server_read = false;
 
-                        // Check if server is shutting down
-                        if (end_server_)
-                            return false;
-
                         std::lock_guard lock(lock_);
 
                         auto io_context = static_cast<per_io_context_t*>(povlp);
+
+                        // Server shutting down: still balance this completion's io_posted() so a
+                        // completion delivered while stop() runs cannot leave outstanding_io_ stuck
+                        // non-zero, but start no new work (no connect/dispatch/re-arm) during
+                        // teardown. A per-session op carries a socket ref here; the server read
+                        // (server_io_context_) was never counted, so it is not decremented. We hold
+                        // lock_, and a counted op keeps its io_context alive, so this access is safe.
+                        if (end_server_)
+                        {
+                            if (io_context != &server_io_context_)
+                            {
+                                if (auto completing_socket = io_context->proxy_socket_ptr)
+                                    completing_socket->io_completed();
+                            }
+                            return false;
+                        }
 
                         // If this is the server socket's read operation
                         if (io_context == &server_io_context_)

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -507,8 +507,10 @@ namespace proxy
             end_server_ = true;
 
             // Step 2: Close server socket
-            // This causes any pending WSARecvFrom to complete immediately with an error.
-            // When IOCP threads wake up, they'll see end_server_ == true and return false.
+            // This causes the pending WSARecvFrom to complete with an error. Note the completion
+            // lambda's bool return is ignored by io_completion_port; shutdown is enforced by the
+            // end_server_ gate (which suppresses new work inside the lambda) and by unregistering
+            // the handler after the drain below.
             if (server_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
             {
                 closesocket(server_socket_);

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -339,6 +339,27 @@ namespace proxy
                             }
                         }
 
+                        // Balance the io_posted() done when a per-session overlapped op was
+                        // posted. This completion is a real delivery -- success OR failure: an
+                        // aborted recv/send flushed by close_client()'s CancelIoEx during teardown
+                        // arrives here with status == false. It must therefore decrement the owning
+                        // proxy socket's outstanding-I/O count exactly once on every exit path,
+                        // independent of status/result and of whether we dispatch below; trapping
+                        // the decrement inside "if (status && result)" would leak the count on every
+                        // torn-down session and the socket would never become removable. Server-read
+                        // completions ride server_io_context_, which no proxy socket ever counted, so
+                        // they are excluded. The strong ref keeps the socket alive until decrement.
+                        std::shared_ptr<T> completing_socket = server_read ? nullptr : io_context->proxy_socket_ptr;
+                        struct io_dec_guard {
+                            T* s;
+                            explicit io_dec_guard(T* sock) : s(sock) {}
+                            ~io_dec_guard() { if (s) s->io_completed(); }
+                            io_dec_guard(const io_dec_guard&) = delete;
+                            io_dec_guard(io_dec_guard&&) = delete;
+                            io_dec_guard& operator=(const io_dec_guard&) = delete;
+                            io_dec_guard& operator=(io_dec_guard&&) = delete;
+                        } io_dec{ completing_socket.get() };
+
                         if (status && result)
                         {
                             // The proxy socket may have released its self-reference during

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1461,9 +1461,11 @@ namespace proxy
                         udp_endpoint->ip,
                         udp_endpoint->port,
                         e.what());
-                    // Remove from map - the shared_ptr destructor will close the sockets
-                    // that were transferred to T's constructor
-                    proxy_sockets_.erase(it);
+                    // initialize_io_contexts() may already have installed the recv self-
+                    // reference; erasing the map entry alone would not run the destructor.
+                    // Cancel I/O, break the self-reference (only once I/O has drained), and
+                    // remove the entry. See cleanup_failed_proxy_socket().
+                    cleanup_failed_proxy_socket(it);
                     return false;
                 }
                 catch (...)
@@ -1472,8 +1474,7 @@ namespace proxy
                         "connect_to_remote_host: Failed to initialize proxy socket for: {}:{} (unknown exception)",
                         udp_endpoint->ip,
                         udp_endpoint->port);
-                    // Remove from map - the shared_ptr destructor will close the sockets
-                    proxy_sockets_.erase(it);
+                    cleanup_failed_proxy_socket(it);
                     return false;
                 }
             }
@@ -1489,6 +1490,54 @@ namespace proxy
             }
 
             return result;
+        }
+
+        /**
+         * @brief Rolls back a partially-constructed proxy socket on the setup-exception path.
+         *
+         * When connect_to_remote_host() throws after inserting the socket into proxy_sockets_,
+         * initialize_io_contexts() may already have installed the recv io_context's self-
+         * reference (a strong shared_ptr back to the socket -- see
+         * socks5_udp_proxy_socket::initialize_io_contexts()). Erasing the map entry drops only
+         * the map's strong reference; the self-reference would keep the object alive with its
+         * destructor -- and thus its CancelIoEx + closesocket -- never running, leaking the
+         * remote/SOCKS socket handles and any armed WSARecv.
+         *
+         * Cancel I/O and close the sockets first (close_client(), idempotent). Then break the
+         * self-reference and remove the entry immediately ONLY if no overlapped I/O could still
+         * be in flight (outstanding_io() == 0) -- e.g. an exception before start_data_relay()
+         * posted its recv. If start_data_relay() had already posted a WSARecv, close_client()'s
+         * CancelIoEx queues its aborted completion but does not deliver it synchronously, so
+         * outstanding_io() is still nonzero here: leave the socket in the map and let
+         * is_ready_for_removal() drain it and release the self-reference once the count reaches
+         * 0. Releasing the self-reference inline while that completion is outstanding would risk
+         * a use-after-free when the IOCP handler finally dereferences its proxy_socket_ptr. This
+         * mirrors the drain gate in socks5_udp_proxy_socket::is_ready_for_removal(). Runs under
+         * the caller's lock_ (connect_to_remote_host is called while the completion handler
+         * holds it), which serializes this against completions and clear_thread.
+         *
+         * @param it Valid iterator into proxy_sockets_ for the failed session.
+         */
+        void cleanup_failed_proxy_socket(const typename decltype(proxy_sockets_)::iterator it)
+        {
+            if (it->second)
+            {
+                // Idempotent: cancels any armed WSARecv and closes remote_socket_/socks_socket_.
+                it->second->close_client();
+
+                // A still-pending recv's aborted completion has not been delivered yet, so its
+                // outstanding_io() count is nonzero. Keep the socket in the map so the normal
+                // drain path (is_ready_for_removal()) releases the self-reference after the
+                // completion arrives; releasing it here would be a use-after-free.
+                if (it->second->outstanding_io() != 0)
+                    return;
+
+                // No overlapped I/O in flight: safe to break the self-reference cycle so the
+                // destructor can run once the map entry is erased below.
+                it->second->release_self_reference();
+            }
+
+            proxy_sockets_.erase(it);
         }
 
         /**

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -587,6 +587,27 @@ namespace proxy
                 std::this_thread::sleep_for(wait_time);
             }
 
+            // Step 4b: Regardless of how the drain loop exited, make sure no IOCP callback is still
+            // executing before we proceed. A worker inside the completion lambda has captured `this`
+            // (it touches lock_, end_server_, packet_pool_, server_io_context_ and decrements
+            // active_iocp_operations_ on the way out), so unregistering the handler and returning
+            // from stop() while active_iocp_operations_ > 0 risks a use-after-free of the server if
+            // the object is then destroyed. On the happy path this is already zero (it is part of
+            // the break condition above); on the timeout path we still wait here. Lambdas are
+            // bounded work, so this reliably reaches zero; bound it as a last resort.
+            for (int active_wait = 0;
+                 active_iocp_operations_.load(std::memory_order_acquire) != 0;
+                 ++active_wait)
+            {
+                if (active_wait > 200)
+                {
+                    NETLIB_ERROR("IOCP callbacks still active ({}) after drain; proceeding may be unsafe",
+                        active_iocp_operations_.load(std::memory_order_relaxed));
+                    break;
+                }
+                std::this_thread::sleep_for(std::min(1ms * (1 << std::min(active_wait / 10, 6)), 100ms));
+            }
+
             // Step 5: All completions have now been processed (or we timed out), so unregister the
             // IOCP handler -- no further completion will dispatch into this server.
             if (completion_key_ != 0)

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -311,7 +311,7 @@ namespace proxy
                         // NEW work (no connect, no data-relay dispatch, no recv/send re-arm). Read
                         // this once and gate the new-work paths on it. The unconditional io_dec
                         // guard keeps outstanding_io_ balanced without a special early return.
-                        const bool shutting_down = end_server_;
+                        const bool shutting_down = end_server_.load(std::memory_order_acquire);
 
                         // If this is the server socket's read operation
                         if (io_context == &server_io_context_)

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -414,13 +414,17 @@ namespace proxy
         per_io_context_t io_context_recv_negotiate_{ proxy_io_operation::negotiate_io_read, nullptr, false };
         per_io_context_t io_context_send_negotiate_{ proxy_io_operation::negotiate_io_write, nullptr, false };
 
-        // Also release this class's two negotiation contexts when breaking the cycle.
+    public:
+        // Also release this class's two negotiation contexts when breaking the cycle. Public (like
+        // the base override) so the owning server's stop() can break the reference cycle at shutdown.
         void release_self_references() noexcept override
         {
             tcp_proxy_socket<T>::release_self_references();
             io_context_recv_negotiate_.proxy_socket_ptr.reset();
             io_context_send_negotiate_.proxy_socket_ptr.reset();
         }
+
+    private:
 
         socks5_state current_state_{ socks5_state::pre_login };
         socks5_ident_req<2> ident_req_{};

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -174,16 +174,10 @@ namespace proxy
                                     io_context_recv_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&ident_resp_);
                                     io_context_recv_negotiate_.wsa_buf.len = sizeof(socks5_ident_resp);
 
-                                    DWORD flags = 0;
-
-                                    if ((::WSASend(
+                                    if (this->post_send(
                                         tcp_proxy_socket<T>::remote_socket_,
                                         &io_context_send_negotiate_.wsa_buf,
-                                        1,
-                                        nullptr,
-                                        0,
-                                        &io_context_send_negotiate_,
-                                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                                        &io_context_send_negotiate_) == SOCKET_ERROR)
                                     {
                                         tcp_proxy_socket<T>::close_client(false, false);
                                         return;
@@ -191,14 +185,10 @@ namespace proxy
 
                                     current_state_ = socks5_state::password_sent;
 
-                                    if ((::WSARecv(
+                                    if (this->post_recv(
                                         tcp_proxy_socket<T>::remote_socket_,
                                         &io_context_recv_negotiate_.wsa_buf,
-                                        1,
-                                        nullptr,
-                                        &flags,
-                                        &io_context_recv_negotiate_,
-                                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                                        &io_context_recv_negotiate_) == SOCKET_ERROR)
                                     {
                                         tcp_proxy_socket<T>::close_client(true, false);
                                     }
@@ -329,16 +319,10 @@ namespace proxy
             io_context_recv_negotiate_.wsa_buf.buf = static_cast<char*>(buffer);
             io_context_recv_negotiate_.wsa_buf.len = length;
 
-            DWORD flags = 0;
-
-            if ((::WSARecv(
+            if (this->post_recv(
                 tcp_proxy_socket<T>::remote_socket_,
                 &io_context_recv_negotiate_.wsa_buf,
-                1,
-                nullptr,
-                &flags,
-                &io_context_recv_negotiate_,
-                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                &io_context_recv_negotiate_) == SOCKET_ERROR)
             {
                 tcp_proxy_socket<T>::close_client(true, false);
                 return false;
@@ -393,14 +377,10 @@ namespace proxy
             io_context_send_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&connect_request_);
             io_context_send_negotiate_.wsa_buf.len = sizeof(socks5_req<T>);
 
-            if ((::WSASend(
+            if (this->post_send(
                 tcp_proxy_socket<T>::remote_socket_,
                 &io_context_send_negotiate_.wsa_buf,
-                1,
-                nullptr,
-                0,
-                &io_context_send_negotiate_,
-                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                &io_context_send_negotiate_) == SOCKET_ERROR)
             {
                 tcp_proxy_socket<T>::close_client(false, false);
                 return;
@@ -509,18 +489,12 @@ namespace proxy
                     io_context_recv_negotiate_.wsa_buf.buf = reinterpret_cast<char*>(&ident_resp_);
                     io_context_recv_negotiate_.wsa_buf.len = sizeof(socks5_ident_resp);
 
-                    DWORD flags = 0;
-
                     NETLIB_DEBUG("Sending SOCKS5 identification request ({} bytes)", socks5_ident_req_size);
 
-                    if ((::WSASend(
+                    if (this->post_send(
                         tcp_proxy_socket<T>::remote_socket_,
                         &io_context_send_negotiate_.wsa_buf,
-                        1,
-                        nullptr,
-                        0,
-                        &io_context_send_negotiate_,
-                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        &io_context_send_negotiate_) == SOCKET_ERROR)
                     {
                         const auto error = WSAGetLastError();
                         NETLIB_ERROR("Failed to send SOCKS5 identification request: WSA error {}", error);
@@ -531,14 +505,10 @@ namespace proxy
                     current_state_ = socks5_state::login_sent;
                     NETLIB_DEBUG("SOCKS5 identification request sent, waiting for response");
 
-                    if ((::WSARecv(
+                    if (this->post_recv(
                         tcp_proxy_socket<T>::remote_socket_,
                         &io_context_recv_negotiate_.wsa_buf,
-                        1,
-                        nullptr,
-                        &flags,
-                        &io_context_recv_negotiate_,
-                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        &io_context_recv_negotiate_) == SOCKET_ERROR)
                     {
                         const auto error = WSAGetLastError();
                         NETLIB_ERROR("Failed to receive SOCKS5 identification response: WSA error {}", error);

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -205,6 +205,15 @@ namespace proxy
         std::atomic_bool ready_for_removal_{ false };
         bool removal_armed_ = false;  ///< Set on the first removal pass; the next pass releases the self-reference.
 
+        /// <summary>
+        /// Count of overlapped I/O operations posted on this socket that have not yet completed.
+        /// Incremented (io_posted) immediately before each WSARecv/WSASend/WSASendTo and decremented
+        /// (io_completed) once per completion, and on a synchronous post failure. is_ready_for_removal()
+        /// releases the self-reference only when this is zero -- a genuine "no completion can still
+        /// reference our io_context member" guarantee rather than a wall-clock grace.
+        /// </summary>
+        std::atomic<long> outstanding_io_{ 0 };
+
     public:
         /**
          * @brief Constructs a SOCKS5 UDP proxy socket instance.
@@ -389,6 +398,52 @@ namespace proxy
             ready_for_removal_.store(true);
         }
 
+        // Overlapped-I/O accounting. io_posted() is called immediately before every WSARecv/
+        // WSASend/WSASendTo post on this socket; io_completed() is called once per completion (from
+        // the server IOCP handler) and on a synchronous post failure. See outstanding_io_.
+        void io_posted() noexcept { outstanding_io_.fetch_add(1, std::memory_order_acq_rel); }
+        void io_completed() noexcept { outstanding_io_.fetch_sub(1, std::memory_order_acq_rel); }
+
+        // Post an overlapped WSARecv/WSASend/WSASendTo with I/O accounting: count the op before
+        // posting and undo the count if the post fails synchronously (no completion will arrive).
+        // Returns SOCKET_ERROR on a hard failure, 0 on success or ERROR_IO_PENDING. All relay/inject
+        // posts go through these so the count cannot be silently missed.
+        int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
+        {
+            io_posted();
+            DWORD flags = 0;
+            if ((::WSARecv(s, buf, 1, nullptr, &flags, ctx, nullptr) == SOCKET_ERROR) &&
+                (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                io_completed();
+                return SOCKET_ERROR;
+            }
+            return 0;
+        }
+        int post_send(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
+        {
+            io_posted();
+            if ((::WSASend(s, buf, 1, nullptr, 0, ctx, nullptr) == SOCKET_ERROR) &&
+                (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                io_completed();
+                return SOCKET_ERROR;
+            }
+            return 0;
+        }
+        int post_sendto(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx,
+            const sockaddr* to, const int tolen) noexcept
+        {
+            io_posted();
+            if ((::WSASendTo(s, buf, 1, nullptr, 0, to, tolen, ctx, nullptr) == SOCKET_ERROR) &&
+                (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                io_completed();
+                return SOCKET_ERROR;
+            }
+            return 0;
+        }
+
         /**
          * @brief Checks if the proxy socket is ready to be removed.
          *
@@ -402,6 +457,12 @@ namespace proxy
             using namespace std::chrono_literals;
 
             if (!ready_for_removal_.load() && (std::chrono::steady_clock::now() - timestamp_ <= 5min))
+                return false;
+
+            // Wait until every overlapped I/O we posted has completed before releasing the
+            // self-reference: a nonzero count means a completion could still reference our
+            // io_context member after it (and this object) are freed.
+            if (outstanding_io_.load(std::memory_order_acquire) != 0)
                 return false;
 
             // Ready (explicit close or idle timeout). Break the per-I/O self-reference cycle so
@@ -507,17 +568,19 @@ namespace proxy
                     NETLIB_DEBUG("process_receive_buffer_complete: {}:{} sending {} bytes to remote socket",
                         remote_peer_address_, remote_peer_port_, io_size);
 
-                    if ((::WSASend(
+                    if (post_send(
                         remote_socket_,
                         io_context_send_to_remote->wsa_buf.get(),
-                        1,
-                        nullptr,
-                        0,
-                        io_context_send_to_remote,
-                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        io_context_send_to_remote) == SOCKET_ERROR)
                     {
                         const auto error = WSAGetLastError();
                         NETLIB_WARNING("process_receive_buffer_complete: WSASend to remote failed with error: {}", error);
+                        // A synchronously-failed post yields no IOCP completion, so
+                        // process_send_buffer_complete() will never run to release this heap
+                        // io_context. It holds a strong shared_from_this() reference, so leaving it
+                        // would pin this socket alive forever (defeating release_self_references()).
+                        // Release it by hand, exactly as the completion path does.
+                        socks5_udp_per_io_context<T>::release_io_context(io_context_send_to_remote);
                         // Close connection to remote peer in case of error
                         close_client();
                     }
@@ -552,19 +615,21 @@ namespace proxy
                     NETLIB_DEBUG("process_receive_buffer_complete: {}:{} sending {} bytes to local socket",
                         remote_peer_address_, remote_peer_port_, io_size);
 
-                    if ((::WSASendTo(
+                    if (post_sendto(
                         local_socket_,
                         io_context_send_to_local->wsa_buf.get(),
-                        1,
-                        nullptr,
-                        0,
-                        reinterpret_cast<sockaddr*>(&local_address_sa_),
-                        (address_type_t::af_type == AF_INET) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6),
                         io_context_send_to_local,
-                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        reinterpret_cast<sockaddr*>(&local_address_sa_),
+                        (address_type_t::af_type == AF_INET) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6)) == SOCKET_ERROR)
                     {
                         const auto error = WSAGetLastError();
                         NETLIB_WARNING("process_receive_buffer_complete: WSASendTo to local failed with error: {}", error);
+                        // A synchronously-failed post yields no IOCP completion, so
+                        // process_send_buffer_complete() will never run to release this heap
+                        // io_context. It holds a strong shared_from_this() reference, so leaving it
+                        // would pin this socket alive forever (defeating release_self_references()).
+                        // Release it by hand, exactly as the completion path does.
+                        socks5_udp_per_io_context<T>::release_io_context(io_context_send_to_local);
                         // Close connection to remote peer in case of error
                         close_client();
                     }
@@ -582,11 +647,13 @@ namespace proxy
 
                 DWORD flags = 0;
 
+                io_posted();
                 auto ret = WSARecv(remote_socket_, &remote_recv_buf_, 1,
                     nullptr, &flags, &io_context_recv_from_remote_, nullptr);
 
                 if (const auto wsa_error = WSAGetLastError(); ret == SOCKET_ERROR && (ERROR_IO_PENDING != wsa_error))
                 {
+                    io_completed();
                     NETLIB_WARNING("process_receive_buffer_complete: WSARecv on remote socket failed with error: {}", wsa_error);
                     close_client();
                 }
@@ -731,14 +798,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_local: Initiating WSASend to local socket {} with {} bytes for {}:{}",
                 static_cast<int>(local_socket_), length, remote_peer_address_, remote_peer_port_);
 
-            if ((::WSASend(
-                local_socket_,
-                context->wsa_buf.get(),
-                1,
-                nullptr,
-                0,
-                context,
-                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+            if (post_send(local_socket_, context->wsa_buf.get(), context) == SOCKET_ERROR)
             {
                 const auto error = WSAGetLastError();
                 NETLIB_WARNING("inject_to_local: WSASend failed with error: {} for {}:{}",
@@ -833,14 +893,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_remote: Initiating WSASend to remote socket {} with {} bytes for {}:{}",
                 static_cast<int>(remote_socket_), length, remote_peer_address_, remote_peer_port_);
 
-            if ((::WSASend(
-                remote_socket_,
-                context->wsa_buf.get(),
-                1,
-                nullptr,
-                0,
-                context,
-                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+            if (post_send(remote_socket_, context->wsa_buf.get(), context) == SOCKET_ERROR)
             {
                 const auto error = WSAGetLastError();
                 NETLIB_WARNING("inject_to_remote: WSASend failed with error: {} for {}:{}",
@@ -922,11 +975,13 @@ namespace proxy
 
             DWORD flags = 0;
 
+            io_posted();
             auto ret = WSARecv(remote_socket_, &remote_recv_buf_, 1,
                 nullptr, &flags, &io_context_recv_from_remote_, nullptr);
 
             if (const auto wsa_error = WSAGetLastError(); ret == SOCKET_ERROR && (ERROR_IO_PENDING != wsa_error))
             {
+                io_completed();
                 NETLIB_WARNING("start_data_relay: WSARecv on remote socket failed with error: {} for {}:{}",
                     wsa_error, remote_peer_address_, remote_peer_port_);
 

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -406,8 +406,10 @@ namespace proxy
 
         // Post an overlapped WSARecv/WSASend/WSASendTo with I/O accounting: count the op before
         // posting and undo the count if the post fails synchronously (no completion will arrive).
-        // Returns SOCKET_ERROR on a hard failure, 0 on success or ERROR_IO_PENDING. All relay/inject
-        // posts go through these so the count cannot be silently missed.
+        // Returns SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise
+        // returns 0 -- the post either completed inline or is pending (ERROR_IO_PENDING) and a
+        // completion will arrive to balance the count. All relay/inject posts go through these so
+        // the count cannot be silently missed.
         int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
         {
             io_posted();

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -408,8 +408,10 @@ namespace proxy
         // posting and undo the count if the post fails synchronously (no completion will arrive).
         // Returns SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise
         // returns 0 -- the post either completed inline or is pending (ERROR_IO_PENDING) and a
-        // completion will arrive to balance the count. All relay/inject posts go through these so
-        // the count cannot be silently missed.
+        // completion will arrive to balance the count. Most relay/inject posts go through these
+        // wrappers; the two auto-ret WSARecv re-arm sites (process_receive_buffer_complete and
+        // start_data_relay) do the same io_posted()/io_completed() accounting inline. Either way
+        // every posted op is counted exactly once.
         int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
         {
             io_posted();

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -461,22 +461,26 @@ namespace proxy
             if (!ready_for_removal_.load() && (std::chrono::steady_clock::now() - timestamp_ <= 5min))
                 return false;
 
-            // Wait until every overlapped I/O we posted has completed before releasing the
-            // self-reference: a nonzero count means a completion could still reference our
-            // io_context member after it (and this object) are freed.
-            if (outstanding_io_.load(std::memory_order_acquire) != 0)
-                return false;
-
             // Ready (explicit close or idle timeout). Break the per-I/O self-reference cycle so
-            // the destructor can run, but only after a one-cycle grace: ensure the sockets are
-            // closed (so any pending recv is cancelled) on the first pass, then release the
-            // self-reference on the next pass once those queued completions have drained.
+            // the destructor can run, but only after a one-cycle grace. First pass: close the
+            // sockets so any still-armed overlapped I/O is cancelled. This MUST run before the
+            // drain gate below -- an idle session always has a WSARecv pending on the remote
+            // socket, so gating on outstanding_io_ first would return early forever and
+            // close_client() (the only thing that cancels that recv) would never run, so the
+            // I/O would never drain and the session would accumulate indefinitely.
             if (!removal_armed_)
             {
                 close_client(); // idempotent: cancels pending I/O and closes the sockets
                 removal_armed_ = true;
                 return false;
             }
+
+            // Do not release the self-reference until every overlapped I/O we posted has
+            // completed. close_client() cancelled them on the arming pass above; each aborted
+            // completion decrements outstanding_io_. A nonzero count means a completion could
+            // still reference our io_context member after it (and this object) are freed.
+            if (outstanding_io_.load(std::memory_order_acquire) != 0)
+                return false;
 
             io_context_recv_from_remote_.proxy_socket_ptr.reset();
             return true;

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -404,6 +404,16 @@ namespace proxy
         void io_posted() noexcept { outstanding_io_.fetch_add(1, std::memory_order_acq_rel); }
         void io_completed() noexcept { outstanding_io_.fetch_sub(1, std::memory_order_acq_rel); }
 
+        // Current count of overlapped I/O operations posted on this socket that have not yet
+        // completed. The server's stop() polls this for a precise per-socket drain before it
+        // releases self-references and destroys the socket.
+        [[nodiscard]] long outstanding_io() const noexcept { return outstanding_io_.load(std::memory_order_acquire); }
+
+        // Break the per-I/O self-reference (the recv context's strong ref back to this socket)
+        // so the object can finally be destroyed. Only safe once this socket's overlapped I/O
+        // has drained (outstanding_io() == 0) and no completion is in flight. Idempotent.
+        void release_self_reference() noexcept { io_context_recv_from_remote_.proxy_socket_ptr.reset(); }
+
         // Post an overlapped WSARecv/WSASend/WSASendTo with I/O accounting: count the op before
         // posting and undo the count if the post fails synchronously (no completion will arrive).
         // Returns SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise
@@ -484,7 +494,7 @@ namespace proxy
             if (outstanding_io_.load(std::memory_order_acquire) != 0)
                 return false;
 
-            io_context_recv_from_remote_.proxy_socket_ptr.reset();
+            release_self_reference();
             return true;
         }
 

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -596,7 +596,7 @@ namespace proxy
                         // A synchronously-failed post yields no IOCP completion, so
                         // process_send_buffer_complete() will never run to release this heap
                         // io_context. It holds a strong shared_from_this() reference, so leaving it
-                        // would pin this socket alive forever (defeating release_self_references()).
+                        // would pin this socket alive forever (defeating release_self_reference()).
                         // Release it by hand, exactly as the completion path does.
                         socks5_udp_per_io_context<T>::release_io_context(io_context_send_to_remote);
                         // Close connection to remote peer in case of error
@@ -645,7 +645,7 @@ namespace proxy
                         // A synchronously-failed post yields no IOCP completion, so
                         // process_send_buffer_complete() will never run to release this heap
                         // io_context. It holds a strong shared_from_this() reference, so leaving it
-                        // would pin this socket alive forever (defeating release_self_references()).
+                        // would pin this socket alive forever (defeating release_self_reference()).
                         // Release it by hand, exactly as the completion path does.
                         socks5_udp_per_io_context<T>::release_io_context(io_context_send_to_local);
                         // Close connection to remote peer in case of error

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -444,10 +444,13 @@ namespace proxy
          *
          * This method performs a graceful shutdown of the proxy server by:
          * 1. Setting the end_server_ flag to signal shutdown
-         * 2. Closing the server socket, which causes pending I/O to complete with error
-         * 3. Waiting for all active IOCP operations to complete (tracked by atomic counter)
-         * 4. Joining background threads
-         * 5. Clearing resources
+         * 2. Closing the server socket, which causes pending accept/I/O to complete with error
+         * 3. Joining the worker threads so no new session is accepted/connected during teardown
+         * 4. Cancelling each proxy socket's pending I/O (close_client) so its posted operations abort
+         * 5. Waiting for every proxy socket's overlapped I/O to drain (per-socket outstanding count)
+         *    and for all IOCP callbacks to finish, then unregistering the IOCP handler
+         * 6. Releasing each socket's self-references and clearing the vector so the sockets destruct
+         *    (skipped on drain timeout to avoid freeing an io_context under an in-flight completion)
          *
          * The IOCP thread pool itself is managed by io_completion_port and will be 
          * properly shut down when the completion port is destroyed.
@@ -476,63 +479,146 @@ namespace proxy
                 ::WSASetEvent(std::get<0>(sock_array_events_[0]));
             }
 
-            // Step 2.5: Unregister the IOCP handler BEFORE waiting
-            if (completion_key_ != 0) {
-                (void)completion_port_.unregister_handler(completion_key_);
-                completion_key_ = 0;
-            }
+            // The IOCP handler stays registered until AFTER the drain below: close_client()'s aborted
+            // completions must still dispatch through it to release and decrement outstanding_io_,
+            // exactly as in the SOCKS5 UDP server. Unregistering here (as the old code did) would drop
+            // those completions, so outstanding_io_ would never reach zero and the drain would hang.
 
-            // Step 3: Wait for all active IOCP operations to complete
-            // The socket closure ensures pending operations complete quickly.
-            // The atomic counter ensures we wait until all in-flight operations finish.
-            // Use exponential backoff to avoid busy-waiting
             using namespace std::chrono_literals;
-            int wait_iterations = 0;
 
-            while (active_iocp_operations_.load(std::memory_order_acquire) > 0)
-            {
-                if (constexpr int max_wait_iterations = 100; ++wait_iterations > max_wait_iterations)
-                {
-                    // Log warning if we're taking too long
-                    NETLIB_WARNING("Timeout waiting for IOCP operations to complete. Active operations: {}",
-                        active_iocp_operations_.load(std::memory_order_relaxed));
-                    break;
-                }
-                
-                // Exponential backoff: 1ms, 2ms, 4ms, 8ms, ... up to 100ms
-                const auto wait_time = std::min(1ms * (1 << std::min(wait_iterations / 10, 6)), 100ms);
-                std::this_thread::sleep_for(wait_time);
-            }
-
-            // Step 4: Join background threads
+            // Step 3: Quiesce the server's worker threads before tearing sessions down, so no new
+            // session is accepted/connected and no concurrent cleanup mutates proxy_sockets_ during
+            // the drain. They all exit once end_server_ is set and the server socket is closed. This
+            // matters more than on the UDP side: TCP creates sessions in connect_to_remote_host_thread_,
+            // so a socket added after the drain declared success would be freed with I/O still pending.
             if (proxy_server_.joinable())
             {
                 proxy_server_.join();
             }
-
             if (check_clients_thread_.joinable())
             {
                 check_clients_thread_.join();
             }
-
             if (connect_to_remote_host_thread_.joinable())
             {
                 connect_to_remote_host_thread_.join();
             }
 
-            // Step 5: Clear resources
-            // Now safe because:
-            // - end_server_ is true, so IOCP lambda won't process new completions
-            // - Socket is closed, so no new I/O can be initiated
-            // - We waited for all active operations to complete
-            if (!sock_array_events_.empty())
+            // Step 4: Cancel every proxy socket's pending I/O so its posted operations complete
+            // (aborted) and stop pinning the socket. Keep the sockets in the vector for now -- they
+            // must stay alive until their in-flight completions drain. Merely clearing the vector
+            // does NOT destroy them: each socket's io_context members self-reference it, so the
+            // destructor would never run and the socket handles / armed recv would leak.
             {
-                sock_array_events_.clear();
+                std::unique_lock lock(lock_);
+                for (auto& entry : proxy_sockets_)
+                {
+                    if (entry)
+                    {
+                        entry->close_client(false, true);  // close local (also closes remote)
+                        entry->close_client(false, false); // ensure remote closed if local was already invalid
+                    }
+                }
             }
 
-            if (!proxy_sockets_.empty())
+            // Step 5: Wait until every proxy socket has drained all posted overlapped I/O
+            // (outstanding_io_ == 0) AND no IOCP callback is still running. BOTH conditions are
+            // load-bearing:
+            //  (a) a cancelled completion may be queued but not yet dispatched while
+            //      active_iocp_operations_ momentarily reads zero -- so we gate on the per-socket
+            //      count too, else a still-queued completion would touch a freed io_context; and
+            //  (b) a completion that entered the lambda just before end_server_ was set can re-post
+            //      I/O (io_posted -> outstanding_io_ +1) AFTER we read that socket's count as zero.
+            //      That re-post happens strictly inside the lambda body, where active_iocp_operations_
+            //      is >= 1 (decremented only at scope exit, after the re-post), so requiring
+            //      active_iocp_operations_ == 0 keeps the combined gate closed until no lambda is
+            //      mid-dispatch. (This holds only because every re-post site runs inside the lambda.)
+            // Releasing a socket's self-references while either could still reference its io_context
+            // would free it out from under a completion. Exponential backoff to avoid busy-waiting.
+            int wait_iterations = 0;
+            bool drained_ok = false;
+
+            while (true)
             {
-                proxy_sockets_.clear();
+                bool drained = true;
+                {
+                    std::unique_lock lock(lock_);
+                    for (auto& entry : proxy_sockets_)
+                    {
+                        if (entry && entry->outstanding_io() != 0)
+                        {
+                            drained = false;
+                            entry->close_client(false, true);  // idempotent re-cancel
+                            entry->close_client(false, false);
+                        }
+                    }
+                }
+
+                if (drained && active_iocp_operations_.load(std::memory_order_acquire) == 0)
+                {
+                    drained_ok = true;
+                    break;
+                }
+
+                if (constexpr int max_wait_iterations = 100; ++wait_iterations > max_wait_iterations)
+                {
+                    NETLIB_ERROR("Timeout waiting for proxy socket I/O to drain (active operations: {}); "
+                        "leaving sessions pinned to avoid freeing in-flight io_contexts",
+                        active_iocp_operations_.load(std::memory_order_relaxed));
+                    break;
+                }
+
+                // Exponential backoff: 1ms, 2ms, 4ms, 8ms, ... up to 100ms
+                const auto wait_time = std::min(1ms * (1 << std::min(wait_iterations / 10, 6)), 100ms);
+                std::this_thread::sleep_for(wait_time);
+            }
+
+            // Step 5b: Ensure no IOCP callback is still executing (it captures `this`) before we
+            // proceed, closing the server-UAF window on the timeout path. Lambdas are bounded work,
+            // so this reliably reaches zero; bound it as a last resort.
+            for (int active_wait = 0;
+                 active_iocp_operations_.load(std::memory_order_acquire) != 0;
+                 ++active_wait)
+            {
+                if (active_wait > 200)
+                {
+                    NETLIB_ERROR("IOCP callbacks still active ({}) after drain; proceeding may be unsafe",
+                        active_iocp_operations_.load(std::memory_order_relaxed));
+                    break;
+                }
+                std::this_thread::sleep_for(std::min(1ms * (1 << std::min(active_wait / 10, 6)), 100ms));
+            }
+
+            // Step 6: All completions processed (or timed out) -- unregister the IOCP handler so no
+            // further completion dispatches into this server.
+            if (completion_key_ != 0)
+            {
+                (void)completion_port_.unregister_handler(completion_key_);
+                completion_key_ = 0;
+            }
+
+            // Step 7: Clear resources. Only if the drain completed do we break each socket's
+            // self-references and clear the vector so the sockets (and their io_contexts) destruct.
+            // If the drain timed out, some op is still outstanding; releasing/clearing then would
+            // free an io_context a still-queued completion could dereference, so we deliberately
+            // leak those sessions instead (a bounded, shutdown-only leak) rather than risk a UAF.
+            {
+                std::unique_lock lock(lock_);
+
+                if (!sock_array_events_.empty())
+                {
+                    sock_array_events_.clear();
+                }
+
+                if (drained_ok && !proxy_sockets_.empty())
+                {
+                    for (auto& entry : proxy_sockets_)
+                    {
+                        if (entry)
+                            entry->release_self_references();
+                    }
+                    proxy_sockets_.clear();
+                }
             }
 
             // Note: The IOCP thread pool itself is managed by completion_port_ and will be

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -344,8 +344,10 @@ namespace proxy
                         // For a counted relay/negotiate completion proxy_socket is always non-null
                         // here (the early-return above drops null relay/negotiate contexts, and a
                         // self-reference cannot have been released while the count is non-zero), so
-                        // the guard always decrements it. inject_io_write is currently unreachable
-                        // dead code; the null-tolerant guard is only a defensive no-op.
+                        // the guard always decrements it. inject_io_write is currently unused, but
+                        // its heap context now carries a real shared_from_this() ref, so if revived
+                        // the guard would find a non-null proxy_socket and correctly balance the
+                        // inline io_posted(); the null tolerance is only a defensive fallback.
                         using io_dec_socket_t = decltype(proxy_socket.get());
                         struct io_dec_guard {
                             io_dec_socket_t s;

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -345,9 +345,11 @@ namespace proxy
                         // Balance the io_posted() done when this overlapped op was posted: this
                         // completion is a real delivery, so decrement the socket's outstanding-I/O
                         // count exactly once on every exit path (error return, dispatch, throw).
-                        // Only relay/negotiate contexts carry a socket ref here; inject contexts are
-                        // heap-owned and are not tracked by outstanding_io_ (their proxy_socket may
-                        // even be null), so the guard is a no-op for a null socket.
+                        // For a counted relay/negotiate completion proxy_socket is always non-null
+                        // here (the early-return above drops null relay/negotiate contexts, and a
+                        // self-reference cannot have been released while the count is non-zero), so
+                        // the guard always decrements it. inject_io_write is currently unreachable
+                        // dead code; the null-tolerant guard is only a defensive no-op.
                         using io_dec_socket_t = decltype(proxy_socket.get());
                         struct io_dec_guard {
                             io_dec_socket_t s;

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -317,10 +317,6 @@ namespace proxy
                             operation_guard& operator=(operation_guard&&) = delete;
                         } guard{ active_iocp_operations_ };
 
-                        // Check if server is shutting down
-                        if (end_server_.load(std::memory_order_acquire))
-                            return false;
-
                         auto io_context = static_cast<per_io_context_t*>(povlp);
 
                         // Acquire the socket's strong reference under a SHARED server lock so
@@ -360,6 +356,14 @@ namespace proxy
                             io_dec_guard& operator=(const io_dec_guard&) = delete;
                             io_dec_guard& operator=(io_dec_guard&&) = delete;
                         } io_dec{ proxy_socket.get() };
+
+                        // Honor shutdown only after the decrement guard is armed: bailing here
+                        // (instead of before acquiring proxy_socket) still balances this
+                        // completion's io_posted() via io_dec, so a completion delivered while
+                        // stop() runs cannot leave outstanding_io_ stuck non-zero. We hold a strong
+                        // ref so io_context stays valid, and we still start no new work below.
+                        if (end_server_.load(std::memory_order_acquire))
+                            return false;
 
                         if (!status || (status && (num_bytes == 0)))
                         {

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -342,6 +342,23 @@ namespace proxy
                         if (!proxy_socket && io_operation != proxy_io_operation::inject_io_write)
                             return true;
 
+                        // Balance the io_posted() done when this overlapped op was posted: this
+                        // completion is a real delivery, so decrement the socket's outstanding-I/O
+                        // count exactly once on every exit path (error return, dispatch, throw).
+                        // Only relay/negotiate contexts carry a socket ref here; inject contexts are
+                        // heap-owned and are not tracked by outstanding_io_ (their proxy_socket may
+                        // even be null), so the guard is a no-op for a null socket.
+                        using io_dec_socket_t = decltype(proxy_socket.get());
+                        struct io_dec_guard {
+                            io_dec_socket_t s;
+                            explicit io_dec_guard(io_dec_socket_t sock) : s(sock) {}
+                            ~io_dec_guard() { if (s) s->io_completed(); }
+                            io_dec_guard(const io_dec_guard&) = delete;
+                            io_dec_guard(io_dec_guard&&) = delete;
+                            io_dec_guard& operator=(const io_dec_guard&) = delete;
+                            io_dec_guard& operator=(io_dec_guard&&) = delete;
+                        } io_dec{ proxy_socket.get() };
+
                         if (!status || (status && (num_bytes == 0)))
                         {
                             if ((io_operation == proxy_io_operation::relay_io_read) ||

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -791,6 +791,11 @@ namespace proxy
         void io_posted() noexcept { outstanding_io_.fetch_add(1, std::memory_order_acq_rel); }
         void io_completed() noexcept { outstanding_io_.fetch_sub(1, std::memory_order_acq_rel); }
 
+        // Current count of overlapped I/O operations posted on this socket that have not yet
+        // completed. The owning server's stop() polls this for a precise per-socket drain before it
+        // releases self-references and destroys the socket.
+        [[nodiscard]] long outstanding_io() const noexcept { return outstanding_io_.load(std::memory_order_acquire); }
+
         // Post an overlapped WSARecv/WSASend with I/O accounting: count the op before posting
         // and undo the count if the post fails synchronously (no completion will arrive). Returns
         // SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise returns 0 --

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -1645,7 +1645,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_local: Allocating per-I/O context for local socket {}",
                 static_cast<int>(local_socket_));
 
-            auto context = new(std::nothrow) per_io_context_t{ type, this, true };
+            auto context = new(std::nothrow) per_io_context_t{ type, this->shared_from_this(), true };
 
             if (context == nullptr)
             {
@@ -1750,7 +1750,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_remote: Allocating per-I/O context for remote socket {}",
                 static_cast<int>(remote_socket_));
 
-            auto context = new(std::nothrow) per_io_context_t{ type, this, false };
+            auto context = new(std::nothrow) per_io_context_t{ type, this->shared_from_this(), false };
 
             if (context == nullptr)
             {

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -857,13 +857,12 @@ namespace proxy
                 // Break the per-session shared_ptr cycle: each per-I/O context member holds a
                 // strong reference back to this object so it stays alive while overlapped I/O
                 // is in flight. Release those refs here so the destructor can finally run once
-                // the server drops its own reference. Wait one cleanup cycle after both sockets
-                // close (removal_armed_) before releasing: any IOCP completion still queued for
-                // this socket fires within milliseconds of closesocket(), so a full cleanup
-                // interval guarantees they have all been delivered (and safely no-op'd) first.
-                // Wait until every overlapped I/O we posted has completed before releasing the
-                // self-references: a nonzero count means a completion could still reference our
-                // io_context members after they (and this object) are freed.
+                // the server drops its own reference. The deterministic gate is the outstanding_io_
+                // counter below: a nonzero count means a completion could still reference our
+                // io_context members after they (and this object) are freed, so we must not release
+                // until it reaches zero. The one-cycle removal_armed_ grace that follows is kept as
+                // a secondary belt-and-suspenders barrier (it used to be the sole, timing-based
+                // guarantee before the counter existed).
                 if (outstanding_io_.load(std::memory_order_acquire) != 0)
                 {
                     NETLIB_DEBUG("is_ready_for_removal: Sockets closed but I/O still outstanding; waiting to drain.");

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -793,8 +793,10 @@ namespace proxy
 
         // Post an overlapped WSARecv/WSASend with I/O accounting: count the op before posting
         // and undo the count if the post fails synchronously (no completion will arrive). Returns
-        // SOCKET_ERROR on a hard failure, 0 on success or ERROR_IO_PENDING. All relay/negotiate
-        // posts go through these so the count cannot be silently missed.
+        // SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise returns 0 --
+        // the post either completed inline or is pending (ERROR_IO_PENDING) and a completion will
+        // arrive to balance the count. All relay/negotiate posts go through these so the count
+        // cannot be silently missed.
         int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
         {
             io_posted();

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -252,6 +252,16 @@ namespace proxy
         bool removal_armed_ = false;
 
         /**
+         * @brief Count of overlapped I/O operations posted on this socket that have not yet
+         *        completed. Incremented (io_posted) immediately before each WSARecv/WSASend and
+         *        decremented (io_completed) once per completion, and on a synchronous post
+         *        failure. is_ready_for_removal() releases the self-references only when this is
+         *        zero -- a genuine "no completion can still reference our io_context members"
+         *        guarantee rather than a wall-clock grace.
+         */
+        std::atomic<long> outstanding_io_{ 0 };
+
+        /**
          * @brief Indicates whether Nagle's algorithm is disabled for the remote socket.
          *
          * When true, disables Nagle's algorithm (TCP_NODELAY) to reduce latency for small packets.
@@ -775,6 +785,40 @@ namespace proxy
             io_context_send_to_remote_.proxy_socket_ptr.reset();
         }
 
+        // Overlapped-I/O accounting. io_posted() is called immediately before every WSARecv/
+        // WSASend post on this socket; io_completed() is called once per completion (from the
+        // server IOCP handler) and on a synchronous post failure. See outstanding_io_.
+        void io_posted() noexcept { outstanding_io_.fetch_add(1, std::memory_order_acq_rel); }
+        void io_completed() noexcept { outstanding_io_.fetch_sub(1, std::memory_order_acq_rel); }
+
+        // Post an overlapped WSARecv/WSASend with I/O accounting: count the op before posting
+        // and undo the count if the post fails synchronously (no completion will arrive). Returns
+        // SOCKET_ERROR on a hard failure, 0 on success or ERROR_IO_PENDING. All relay/negotiate
+        // posts go through these so the count cannot be silently missed.
+        int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
+        {
+            io_posted();
+            DWORD flags = 0;
+            if ((::WSARecv(s, buf, 1, nullptr, &flags, ctx, nullptr) == SOCKET_ERROR) &&
+                (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                io_completed();
+                return SOCKET_ERROR;
+            }
+            return 0;
+        }
+        int post_send(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
+        {
+            io_posted();
+            if ((::WSASend(s, buf, 1, nullptr, 0, ctx, nullptr) == SOCKET_ERROR) &&
+                (ERROR_IO_PENDING != WSAGetLastError()))
+            {
+                io_completed();
+                return SOCKET_ERROR;
+            }
+            return 0;
+        }
+
         bool is_ready_for_removal()
         {
             using namespace std::chrono_literals;
@@ -814,10 +858,19 @@ namespace proxy
                 // close (removal_armed_) before releasing: any IOCP completion still queued for
                 // this socket fires within milliseconds of closesocket(), so a full cleanup
                 // interval guarantees they have all been delivered (and safely no-op'd) first.
+                // Wait until every overlapped I/O we posted has completed before releasing the
+                // self-references: a nonzero count means a completion could still reference our
+                // io_context members after they (and this object) are freed.
+                if (outstanding_io_.load(std::memory_order_acquire) != 0)
+                {
+                    NETLIB_DEBUG("is_ready_for_removal: Sockets closed but I/O still outstanding; waiting to drain.");
+                    return false;
+                }
+
                 if (!removal_armed_)
                 {
                     removal_armed_ = true;
-                    NETLIB_DEBUG("is_ready_for_removal: Sockets closed; arming removal for the next cycle");
+                    NETLIB_DEBUG("is_ready_for_removal: Sockets closed and drained; arming removal for the next cycle");
                     return false;
                 }
 
@@ -1100,14 +1153,7 @@ namespace proxy
 
                         NETLIB_DEBUG("process_receive_buffer_complete: Sending {} bytes to remote socket", io_size);
 
-                        if ((::WSASend(
-                            remote_socket_,
-                            &remote_send_buf_,
-                            1,
-                            nullptr,
-                            0,
-                            &io_context_send_to_remote_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_send(remote_socket_, &remote_send_buf_, &io_context_send_to_remote_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_receive_buffer_complete: WSASend to remote failed: {}", error);
@@ -1157,16 +1203,7 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_receive_buffer_complete: Initiating new local receive with buffer size {}", local_recv_buf_.len);
 
-                        DWORD flags = 0;
-
-                        if ((::WSARecv(
-                            local_socket_,
-                            &local_recv_buf_,
-                            1,
-                            nullptr,
-                            &flags,
-                            &io_context_recv_from_local_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_recv(local_socket_, &local_recv_buf_, &io_context_recv_from_local_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_receive_buffer_complete: WSARecv from local failed: {}", error);
@@ -1199,14 +1236,7 @@ namespace proxy
 
                         NETLIB_DEBUG("process_receive_buffer_complete: Sending {} bytes to local socket", io_size);
 
-                        if ((::WSASend(
-                            local_socket_,
-                            &local_send_buf_,
-                            1,
-                            nullptr,
-                            0,
-                            &io_context_send_to_local_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_send(local_socket_, &local_send_buf_, &io_context_send_to_local_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_receive_buffer_complete: WSASend to local failed: {}", error);
@@ -1257,16 +1287,7 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_receive_buffer_complete: Initiating new remote receive with buffer size {}", remote_recv_buf_.len);
 
-                        DWORD flags = 0;
-
-                        if ((::WSARecv(
-                            remote_socket_,
-                            &remote_recv_buf_,
-                            1,
-                            nullptr,
-                            &flags,
-                            &io_context_recv_from_remote_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_recv(remote_socket_, &remote_recv_buf_, &io_context_recv_from_remote_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_receive_buffer_complete: WSARecv from remote failed: {}", error);
@@ -1344,8 +1365,6 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_send_buffer_complete: Remote receive buffer empty, setting up new receive");
 
-                        DWORD flags = 0;
-
                         remote_recv_buf_.buf = local_send_buf_.buf;
                         remote_recv_buf_.len = io_size;
 
@@ -1353,14 +1372,7 @@ namespace proxy
                         {
                             NETLIB_DEBUG("process_send_buffer_complete: Initiating remote receive with buffer size {}", remote_recv_buf_.len);
 
-                            if ((::WSARecv(
-                                remote_socket_,
-                                &remote_recv_buf_,
-                                1,
-                                nullptr,
-                                &flags,
-                                &io_context_recv_from_remote_,
-                                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                            if (post_recv(remote_socket_, &remote_recv_buf_, &io_context_recv_from_remote_) == SOCKET_ERROR)
                             {
                                 const auto error = WSAGetLastError();
                                 NETLIB_WARNING("process_send_buffer_complete: WSARecv on remote failed: {}", error);
@@ -1431,14 +1443,7 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_send_buffer_complete: Continuing send to local socket with {} bytes", local_send_buf_.len);
 
-                        if ((::WSASend(
-                            local_socket_,
-                            &local_send_buf_,
-                            1,
-                            nullptr,
-                            0,
-                            &io_context_send_to_local_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_send(local_socket_, &local_send_buf_, &io_context_send_to_local_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_send_buffer_complete: WSASend to local failed: {}", error);
@@ -1467,8 +1472,6 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_send_buffer_complete: Local receive buffer empty, setting up new receive");
 
-                        DWORD flags = 0;
-
                         local_recv_buf_.buf = remote_send_buf_.buf;
                         local_recv_buf_.len = io_size;
 
@@ -1476,14 +1479,7 @@ namespace proxy
                         {
                             NETLIB_DEBUG("process_send_buffer_complete: Initiating local receive with buffer size {}", local_recv_buf_.len);
 
-                            if ((::WSARecv(
-                                local_socket_,
-                                &local_recv_buf_,
-                                1,
-                                nullptr,
-                                &flags,
-                                &io_context_recv_from_local_,
-                                nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                            if (post_recv(local_socket_, &local_recv_buf_, &io_context_recv_from_local_) == SOCKET_ERROR)
                             {
                                 const auto error = WSAGetLastError();
                                 NETLIB_WARNING("process_send_buffer_complete: WSARecv on local failed: {}", error);
@@ -1554,14 +1550,7 @@ namespace proxy
                     {
                         NETLIB_DEBUG("process_send_buffer_complete: Continuing send to remote socket with {} bytes", remote_send_buf_.len);
 
-                        if ((::WSASend(
-                            remote_socket_,
-                            &remote_send_buf_,
-                            1,
-                            nullptr,
-                            0,
-                            &io_context_send_to_remote_,
-                            nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
+                        if (post_send(remote_socket_, &remote_send_buf_, &io_context_send_to_remote_) == SOCKET_ERROR)
                         {
                             const auto error = WSAGetLastError();
                             NETLIB_WARNING("process_send_buffer_complete: WSASend to remote failed: {}", error);
@@ -1680,6 +1669,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_local: Initiating WSASend to local socket {} with {} bytes",
                 static_cast<int>(local_socket_), length);
 
+            io_posted();
             if ((::WSASend(
                 local_socket_,
                 &context->wsa_buf,
@@ -1689,6 +1679,7 @@ namespace proxy
                 context,
                 nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
             {
+                io_completed();
                 const auto error = WSAGetLastError();
                 NETLIB_WARNING("inject_to_local: WSASend failed with error: {}", error);
 
@@ -1783,6 +1774,7 @@ namespace proxy
             NETLIB_DEBUG("inject_to_remote: Initiating WSASend to remote socket {} with {} bytes",
                 static_cast<int>(remote_socket_), length);
 
+            io_posted();
             if ((::WSASend(
                 remote_socket_,
                 &context->wsa_buf,
@@ -1792,6 +1784,7 @@ namespace proxy
                 context,
                 nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
             {
+                io_completed();
                 const auto error = WSAGetLastError();
                 NETLIB_WARNING("inject_to_remote: WSASend failed with error: {}", error);
 
@@ -1896,11 +1889,13 @@ namespace proxy
             NETLIB_DEBUG("start_data_relay: Initiating WSARecv on local socket {}",
                 static_cast<int>(local_socket_));
 
+            io_posted();
             auto ret = WSARecv(local_socket_, &local_recv_buf_, 1,
                 nullptr, &flags, &io_context_recv_from_local_, nullptr);
 
             if (const auto wsa_error = WSAGetLastError(); ret == SOCKET_ERROR && (ERROR_IO_PENDING != wsa_error))
             {
+                io_completed();
                 NETLIB_WARNING("start_data_relay: WSARecv on local socket failed with error: {}", wsa_error);
                 NETLIB_DEBUG("start_data_relay: Closing local client due to WSARecv failure");
 
@@ -1922,11 +1917,13 @@ namespace proxy
             NETLIB_DEBUG("start_data_relay: Initiating WSARecv on remote socket {}",
                 static_cast<int>(remote_socket_));
 
+            io_posted();
             ret = WSARecv(remote_socket_, &remote_recv_buf_, 1,
                 nullptr, &flags, &io_context_recv_from_remote_, nullptr);
 
             if (const auto wsa_error = WSAGetLastError(); ret == SOCKET_ERROR && (ERROR_IO_PENDING != wsa_error))
             {
+                io_completed();
                 NETLIB_WARNING("start_data_relay: WSARecv on remote socket failed with error: {}", wsa_error);
                 NETLIB_DEBUG("start_data_relay: Cleaning up local socket due to remote WSARecv failure");
 

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -795,8 +795,9 @@ namespace proxy
         // and undo the count if the post fails synchronously (no completion will arrive). Returns
         // SOCKET_ERROR on a synchronous hard failure (the count was undone); otherwise returns 0 --
         // the post either completed inline or is pending (ERROR_IO_PENDING) and a completion will
-        // arrive to balance the count. All relay/negotiate posts go through these so the count
-        // cannot be silently missed.
+        // arrive to balance the count. Most relay/negotiate posts go through these wrappers; a few
+        // sites (the two start_data_relay auto-ret WSARecv, and the inject_* sends) do the same
+        // io_posted()/io_completed() accounting inline. Either way every posted op is counted once.
         int post_recv(const SOCKET s, const LPWSABUF buf, const LPWSAOVERLAPPED ctx) noexcept
         {
             io_posted();

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -1645,7 +1645,20 @@ namespace proxy
             NETLIB_DEBUG("inject_to_local: Allocating per-I/O context for local socket {}",
                 static_cast<int>(local_socket_));
 
-            auto context = new(std::nothrow) per_io_context_t{ type, this->shared_from_this(), true };
+            std::shared_ptr<tcp_proxy_socket<T>> self;
+            try
+            {
+                self = this->shared_from_this();
+            }
+            catch (const std::bad_weak_ptr&)
+            {
+                // Report failure via the return value (consistent with this method) instead of
+                // letting the exception escape, mirroring initialize_io_contexts()'s handling.
+                NETLIB_ERROR("inject_to_local: shared_from_this() failed - object is not managed by shared_ptr");
+                return false;
+            }
+
+            auto context = new(std::nothrow) per_io_context_t{ type, self, true };
 
             if (context == nullptr)
             {
@@ -1750,7 +1763,20 @@ namespace proxy
             NETLIB_DEBUG("inject_to_remote: Allocating per-I/O context for remote socket {}",
                 static_cast<int>(remote_socket_));
 
-            auto context = new(std::nothrow) per_io_context_t{ type, this->shared_from_this(), false };
+            std::shared_ptr<tcp_proxy_socket<T>> self;
+            try
+            {
+                self = this->shared_from_this();
+            }
+            catch (const std::bad_weak_ptr&)
+            {
+                // Report failure via the return value (consistent with this method) instead of
+                // letting the exception escape, mirroring initialize_io_contexts()'s handling.
+                NETLIB_ERROR("inject_to_remote: shared_from_this() failed - object is not managed by shared_ptr");
+                return false;
+            }
+
+            auto context = new(std::nothrow) per_io_context_t{ type, self, false };
 
             if (context == nullptr)
             {


### PR DESCRIPTION
## Summary

Replaces the wall-clock drain grace introduced in the earlier reference-cycle leak fix with a **real per-socket in-flight-I/O counter**, so a proxy socket releases its self-references (breaking the `io_context → proxy_socket_ptr → io_context` cycle) only when **no overlapped operation can still reference its `io_context` members**. This closes the residual use-after-free / leak window where the ~1s grace could be too short (a completion still queued) or needlessly long.

### How it works
- Each `tcp_proxy_socket` and `socks5_udp_proxy_socket` gets an atomic `outstanding_io_`.
  - `io_posted()` (`+1`, `acq_rel`) runs **immediately before** every `WSARecv`/`WSASend`/`WSASendTo`.
  - `io_completed()` (`-1`) runs **exactly once per IOCP completion** — via a non-copyable/non-movable RAII `io_dec_guard` in the two server completion lambdas — and once on a **synchronous post failure** (where no completion will ever arrive).
- All relay/negotiate posts route through `post_recv` / `post_send` / `post_sendto` wrappers, which do the increment and self-undo on synchronous failure, so the count can't be silently missed. The 4 inline auto-ret `WSARecv` sites and the (dead) inject sites account by hand.
- `is_ready_for_removal()` now returns `false` while `outstanding_io_ != 0`, and keeps the existing one-cycle `removal_armed_` grace as a **second** barrier before `release_self_references()`.

### Correctness details worth reviewing
- **Aborted completions (`status == false`)**: the UDP decrement guard sits **above** the `if (status && result)` dispatch, so it also fires for the aborted recv/send completions delivered when `close_client()` does `CancelIoEx`+`closesocket` during teardown. (An earlier draft trapped it inside `status && result` — that would have left the count stuck above zero and leaked the socket; fixed.) TCP's guard is likewise above its `!status` close path.
- **Server read excluded**: the UDP server socket's own `WSARecvFrom` on `server_io_context_` is *not* a per-session op and is deliberately never counted/decremented on a proxy socket (`server_read` gate).
- **No double count / underflow**: exactly one `io_posted` per posted op; exactly one `io_completed` per completion, plus one undo per synchronous failure.

### Related leak also fixed
While auditing the same teardown path I found (and fixed) a **pre-existing** UDP leak: a synchronously-failed relay `WSASend`/`WSASendTo` left its heap `io_context_send_to_*` — which holds a strong `shared_from_this()` reference — unreleased. `process_send_buffer_complete()` (which normally calls `release_io_context()`) never runs for a failed post, so that strong ref pinned the socket alive forever, defeating `release_self_references()`. Now released by hand on the failure path, mirroring the completion path and the inject cleanup. (`outstanding_io_` itself was already balanced here — this is a distinct ref-cycle hole.)

## Verification
- Builds clean: `Release|x64`, MSVC C++20 `/permissive-` (only the pre-existing `C4101 'e' unreferenced local` in `io_completion_port.h`).
- Reviewed with a multi-agent adversarial pass (5 audit lenses → 2 independent skeptics per finding → completeness critic). No balance/UAF finding survived verification; the heap-context leak above was the critic's one real gap and is fixed.