### PR TITLE
fix(socks5-udp): release partially-constructed socket on connect setup exception

### DIFF
--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1518,7 +1518,7 @@ namespace proxy
          *
          * @param it Valid iterator into proxy_sockets_ for the failed session.
          */
-        void cleanup_failed_proxy_socket(const typename std::map<uint16_t, std::shared_ptr<T>>::iterator it)
+        void cleanup_failed_proxy_socket(const typename decltype(proxy_sockets_)::iterator it)
         {
             if (it->second)
             {

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1461,9 +1461,11 @@ namespace proxy
                         udp_endpoint->ip,
                         udp_endpoint->port,
                         e.what());
-                    // Remove from map - the shared_ptr destructor will close the sockets
-                    // that were transferred to T's constructor
-                    proxy_sockets_.erase(it);
+                    // initialize_io_contexts() may already have installed the recv self-
+                    // reference; erasing the map entry alone would not run the destructor.
+                    // Cancel I/O, break the self-reference (only once I/O has drained), and
+                    // remove the entry. See cleanup_failed_proxy_socket().
+                    cleanup_failed_proxy_socket(it);
                     return false;
                 }
                 catch (...)
@@ -1472,8 +1474,7 @@ namespace proxy
                         "connect_to_remote_host: Failed to initialize proxy socket for: {}:{} (unknown exception)",
                         udp_endpoint->ip,
                         udp_endpoint->port);
-                    // Remove from map - the shared_ptr destructor will close the sockets
-                    proxy_sockets_.erase(it);
+                    cleanup_failed_proxy_socket(it);
                     return false;
                 }
             }
@@ -1489,6 +1490,54 @@ namespace proxy
             }
 
             return result;
+        }
+
+        /**
+         * @brief Rolls back a partially-constructed proxy socket on the setup-exception path.
+         *
+         * When connect_to_remote_host() throws after inserting the socket into proxy_sockets_,
+         * initialize_io_contexts() may already have installed the recv io_context's self-
+         * reference (a strong shared_ptr back to the socket -- see
+         * socks5_udp_proxy_socket::initialize_io_contexts()). Erasing the map entry drops only
+         * the map's strong reference; the self-reference would keep the object alive with its
+         * destructor -- and thus its CancelIoEx + closesocket -- never running, leaking the
+         * remote/SOCKS socket handles and any armed WSARecv.
+         *
+         * Cancel I/O and close the sockets first (close_client(), idempotent). Then break the
+         * self-reference and remove the entry immediately ONLY if no overlapped I/O could still
+         * be in flight (outstanding_io() == 0) -- e.g. an exception before start_data_relay()
+         * posted its recv. If start_data_relay() had already posted a WSARecv, close_client()'s
+         * CancelIoEx queues its aborted completion but does not deliver it synchronously, so
+         * outstanding_io() is still nonzero here: leave the socket in the map and let
+         * is_ready_for_removal() drain it and release the self-reference once the count reaches
+         * 0. Releasing the self-reference inline while that completion is outstanding would risk
+         * a use-after-free when the IOCP handler finally dereferences its proxy_socket_ptr. This
+         * mirrors the drain gate in socks5_udp_proxy_socket::is_ready_for_removal(). Runs under
+         * the caller's lock_ (connect_to_remote_host is called while the completion handler
+         * holds it), which serializes this against completions and clear_thread.
+         *
+         * @param it Valid iterator into proxy_sockets_ for the failed session.
+         */
+        void cleanup_failed_proxy_socket(const typename std::map<uint16_t, std::shared_ptr<T>>::iterator it)
+        {
+            if (it->second)
+            {
+                // Idempotent: cancels any armed WSARecv and closes remote_socket_/socks_socket_.
+                it->second->close_client();
+
+                // A still-pending recv's aborted completion has not been delivered yet, so its
+                // outstanding_io() count is nonzero. Keep the socket in the map so the normal
+                // drain path (is_ready_for_removal()) releases the self-reference after the
+                // completion arrives; releasing it here would be a use-after-free.
+                if (it->second->outstanding_io() != 0)
+                    return;
+
+                // No overlapped I/O in flight: safe to break the self-reference cycle so the
+                // destructor can run once the map entry is erased below.
+                it->second->release_self_reference();
+            }
+
+            proxy_sockets_.erase(it);
         }
 
         /**

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -344,8 +344,10 @@ namespace proxy
                         // For a counted relay/negotiate completion proxy_socket is always non-null
                         // here (the early-return above drops null relay/negotiate contexts, and a
                         // self-reference cannot have been released while the count is non-zero), so
-                        // the guard always decrements it. inject_io_write is currently unreachable
-                        // dead code; the null-tolerant guard is only a defensive no-op.
+                        // the guard always decrements it. inject_io_write is currently unused, but
+                        // its heap context now carries a real shared_from_this() ref, so if revived
+                        // the guard would find a non-null proxy_socket and correctly balance the
+                        // inline io_posted(); the null tolerance is only a defensive fallback.
                         using io_dec_socket_t = decltype(proxy_socket.get());
                         struct io_dec_guard {
                             io_dec_socket_t s;

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -857,13 +857,12 @@ namespace proxy
                 // Break the per-session shared_ptr cycle: each per-I/O context member holds a
                 // strong reference back to this object so it stays alive while overlapped I/O
                 // is in flight. Release those refs here so the destructor can finally run once
-                // the server drops its own reference. Wait one cleanup cycle after both sockets
-                // close (removal_armed_) before releasing: any IOCP completion still queued for
-                // this socket fires within milliseconds of closesocket(), so a full cleanup
-                // interval guarantees they have all been delivered (and safely no-op'd) first.
-                // Wait until every overlapped I/O we posted has completed before releasing the
-                // self-references: a nonzero count means a completion could still reference our
-                // io_context members after they (and this object) are freed.
+                // the server drops its own reference. The deterministic gate is the outstanding_io_
+                // counter below: a nonzero count means a completion could still reference our
+                // io_context members after they (and this object) are freed, so we must not release
+                // until it reaches zero. The one-cycle removal_armed_ grace that follows is kept as
+                // a secondary belt-and-suspenders barrier (it used to be the sole, timing-based
+                // guarantee before the counter existed).
                 if (outstanding_io_.load(std::memory_order_acquire) != 0)
                 {
                     NETLIB_DEBUG("is_ready_for_removal: Sockets closed but I/O still outstanding; waiting to drain.");


### PR DESCRIPTION
## Problem

`socks5_local_udp_proxy_server::connect_to_remote_host()` inserts the new `socks5_udp_proxy_socket` into `proxy_sockets_`, then calls `initialize_io_contexts()` — which installs the recv io_context's **self-reference** (`io_context_recv_from_remote_.proxy_socket_ptr = shared_from_this()`, a strong `shared_ptr` back to the socket) — before `associate_to_completion_port()` / `start()` / `start_data_relay()`.

If any step **after** `initialize_io_contexts()` throws, both `catch` blocks only did:

```cpp
proxy_sockets_.erase(it);
```

That drops the map's strong reference, but the recv io_context's self-reference is still set and keeps the object alive. Its destructor — and therefore its `CancelIoEx` + `closesocket` on `remote_socket_`/`socks_socket_` — never runs. Result: **leaked socket handles plus a possibly-armed `WSARecv` that never gets cancelled**.

This is a pre-existing bug that only triggers on the error path during session setup.

## Fix

Route both catch blocks through a new helper, `cleanup_failed_proxy_socket(it)`:

1. `close_client()` — idempotent `CancelIoEx` + `closesocket`, cancelling any armed recv and releasing the handles.
2. Break the self-reference (`release_self_reference()`) and `erase()` the map entry **only if** no overlapped I/O could still be in flight (`outstanding_io() == 0`) — e.g. an exception thrown before `start_data_relay()` posted its recv.
3. If `start_data_relay()` had already posted a `WSARecv`, `close_client()`'s `CancelIoEx` **queues** the aborted completion but does not deliver it synchronously, so `outstanding_io()` is still nonzero. In that case the socket is **left in the map** for `is_ready_for_removal()` to drain and release the self-reference once the completion arrives — releasing it inline would risk a use-after-free when the IOCP handler dereferences `proxy_socket_ptr`.

### Why the `outstanding_io() == 0` gate is sound here

`connect_to_remote_host()` is invoked while the completion handler already holds `lock_`, and the handler decrements `outstanding_io_` (via its `io_dec` guard) and drops its strong ref **under that same lock**, after all `io_context` accesses. So this cleanup is serialized against completions and `clear_thread`, and the check mirrors the exact drain gate used by `socks5_udp_proxy_socket::is_ready_for_removal()`.

## Scope

Stacked on `per-socket-io-counter` (PR #145) because the fix uses `outstanding_io()` / `release_self_reference()`, which are introduced there. The bug itself is independent of #145 and was discovered during its review.

## Validation

Builds clean (only the pre-existing `C4101 'e' unreferenced local` warning in `io_completion_port.h`):

```
MSBuild.exe socksify\socksify.vcxproj /t:Build /p:Configuration=Release /p:Platform=x64
```