### PR TITLE
harden: production-readiness review fixes (1 Critical, 12 High, 10 Medium)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,17 @@ ProxiFyre/bin
 ProxiFyre/obj
 .vs/
 /packages/
+
+# --- Runtime configuration with secrets: NEVER commit ---
+# app-config.json contains plaintext SOCKS5 usernames/passwords. Track only the
+# placeholder app-config.sample.json (which is deliberately NOT ignored below).
+app-config.json
+**/app-config.json
+!app-config.sample.json
+
+# --- Build output trees not covered by the extension rules above ---
+/bin/
+socksify/x64/
+socksify/Win32/
+socksify/ARM64/
+*.aps

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -121,7 +121,19 @@ namespace ProxiFyre
                 }
             }
 
-            _socksify.Start();
+            // Start() propagates failure from the whole native chain (e.g. the Windows Packet
+            // Filter driver is not installed or failed to load). Do NOT ignore it: swallowing
+            // the failure leaves the Windows service in the RUNNING state while proxying nothing,
+            // silently sending configured applications' traffic direct/un-proxied. Throw so
+            // Topshelf fails the start and the SCM reports the failure.
+            if (!_socksify.Start())
+            {
+                const string message =
+                    "Failed to start the ProxiFyre proxy engine. Ensure the Windows Packet Filter " +
+                    "(NDIS lightweight filter) driver is installed and running, then restart the service.";
+                LoggerInstance.Error(message);
+                throw new InvalidOperationException(message);
+            }
 
             // Inform user that the application is running
             if (_logLevel >= LogLevel.Info)

--- a/app-config.sample.json
+++ b/app-config.sample.json
@@ -1,0 +1,14 @@
+{
+    "logLevel": "Error",
+    "bypassLan": false,
+    "proxies": [
+        {
+            "appNames": ["chrome", "firefox"],
+            "socks5ProxyEndpoint": "proxy.example.com:1080",
+            "username": "REPLACE_WITH_USERNAME_OR_LEAVE_EMPTY",
+            "password": "REPLACE_WITH_PASSWORD_OR_LEAVE_EMPTY",
+            "supportedProtocols": ["TCP", "UDP"]
+        }
+    ],
+    "excludes": []
+}

--- a/netlib/src/iphelper/network_adapter_info.h
+++ b/netlib/src/iphelper/network_adapter_info.h
@@ -1422,11 +1422,19 @@ namespace iphelper
         /// 3. Not software loopback
         /// </summary>
         /// <returns>vector of network_adapter_info</returns>
-        static std::vector<network_adapter_info> get_external_network_connections()
+        static std::vector<network_adapter_info> get_external_network_connections(bool* enumeration_succeeded = nullptr)
         {
             std::vector<network_adapter_info> ret_val;
             unsigned long dw_size = 0;
             PMIB_IF_TABLE2 mib_table = nullptr;
+
+            // Distinguish a genuine "no external adapters" result (succeeded, empty) from an
+            // enumeration FAILURE (API/allocation error). Callers that unfilter adapters based
+            // on this list must not treat a transient failure as "no adapters" (fail-open), so
+            // we default to failure and set success only once enumeration actually completes.
+            bool succeeded = false;
+            if (enumeration_succeeded)
+                *enumeration_succeeded = false;
 
             SetLastError(ERROR_SUCCESS);
 
@@ -1493,6 +1501,7 @@ namespace iphelper
                             current_address = current_address->Next;
                         }
 
+                        succeeded = true; // enumeration completed
                         break;
                     }
                     // In case of insufficient buffer size we try to recover by reallocating buffer
@@ -1510,10 +1519,19 @@ namespace iphelper
                 {
                     SetLastError(error_code);
                 }
+                else
+                {
+                    // NO_ERROR with no buffer overflow means there genuinely are no adapters
+                    // to report: an empty-but-valid result, not a failure.
+                    succeeded = true;
+                }
             }
 
             // Free interface table
             FreeMibTable(mib_table);
+
+            if (enumeration_succeeded)
+                *enumeration_succeeded = succeeded;
 
             return ret_val;
         }

--- a/netlib/src/iphelper/process_lookup.h
+++ b/netlib/src/iphelper/process_lookup.h
@@ -762,6 +762,112 @@ namespace iphelper
             return nullptr;
         }
 
+        /// <summary>
+        /// Returns true and fills out_addr (network-order IPv4) if the 16-byte IPv6 address is an
+        /// IPv4-mapped address (::ffff:a.b.c.d).
+        /// </summary>
+        static bool is_v4_mapped_address(const UCHAR(&addr)[16], uint32_t& out_addr) noexcept
+        {
+            for (int i = 0; i < 10; ++i)
+                if (addr[i] != 0) return false;
+            if (addr[10] != 0xFF || addr[11] != 0xFF) return false;
+            // Copy the 4 embedded bytes as-is: they are the IPv4 address in network byte order,
+            // matching ip_address_v4's in_addr::S_un.S_addr layout on any host endianness.
+            memcpy(&out_addr, &addr[12], sizeof(out_addr));
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the 16-byte IPv6 address is the unspecified address (::).
+        /// </summary>
+        static bool is_unspecified_v6_address(const UCHAR(&addr)[16]) noexcept
+        {
+            for (int i = 0; i < 16; ++i)
+                if (addr[i] != 0) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Enumerates the AF_INET6 TCP table and folds IPv4-mapped rows into the v4 session map.
+        /// </summary>
+        /// <remarks>
+        /// Dual-stack sockets (AF_INET6 with IPV6_V6ONLY=0) that carry IPv4 traffic appear ONLY in
+        /// the AF_INET6 connection table, as IPv4-mapped (::ffff:a.b.c.d) rows -- never in the
+        /// AF_INET table. The IPv4 packet handler consults only this v4 instance, so without folding
+        /// them in their traffic cannot be attributed and leaks un-proxied. Only called from (and so
+        /// only instantiated for) the v4 instance.
+        /// </remarks>
+        void add_v4_mapped_tcp_sessions(tcp_hashtable_t& tcp_to_app)
+        {
+            DWORD size = 0;
+            if (::GetExtendedTcpTable(nullptr, &size, FALSE, AF_INET6,
+                TCP_TABLE_OWNER_MODULE_CONNECTIONS, 0) != ERROR_INSUFFICIENT_BUFFER || size == 0)
+                return;
+
+            auto buffer = std::make_unique<char[]>(size);
+            if (::GetExtendedTcpTable(buffer.get(), &size, FALSE, AF_INET6,
+                TCP_TABLE_OWNER_MODULE_CONNECTIONS, 0) != NO_ERROR)
+                return;
+
+            auto* table = reinterpret_cast<PMIB_TCP6TABLE_OWNER_MODULE>(buffer.get());
+            for (size_t i = 0; i < table->dwNumEntries; ++i)
+            {
+                uint32_t local_v4 = 0, remote_v4 = 0;
+                if (!is_v4_mapped_address(table->table[i].ucLocalAddr, local_v4) ||
+                    !is_v4_mapped_address(table->table[i].ucRemoteAddr, remote_v4))
+                    continue; // genuine IPv6 connection: handled by the v6 instance
+
+                if (auto process_ptr = process_tcp_entry_v6(&table->table[i]))
+                {
+                    // Keep a genuine AF_INET entry if one already exists for this 4-tuple.
+                    tcp_to_app.try_emplace(
+                        net::ip_session<net::ip_address_v4>(
+                            net::ip_address_v4{ local_v4 },
+                            net::ip_address_v4{ remote_v4 },
+                            ntohs(static_cast<uint16_t>(table->table[i].dwLocalPort)),
+                            ntohs(static_cast<uint16_t>(table->table[i].dwRemotePort))),
+                        std::move(process_ptr));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enumerates the AF_INET6 UDP table and folds IPv4-mapped and unspecified ([::]) rows into
+        /// the v4 endpoint map. An unspecified bind maps to the 0.0.0.0 wildcard, which the IPv4 UDP
+        /// handler already matches via its wildcard fallback. Only called from (and so only
+        /// instantiated for) the v4 instance.
+        /// </summary>
+        void add_v4_mapped_udp_endpoints(udp_hashtable_t& udp_to_app)
+        {
+            DWORD size = 0;
+            if (::GetExtendedUdpTable(nullptr, &size, FALSE, AF_INET6,
+                UDP_TABLE_OWNER_MODULE, 0) != ERROR_INSUFFICIENT_BUFFER || size == 0)
+                return;
+
+            auto buffer = std::make_unique<char[]>(size);
+            if (::GetExtendedUdpTable(buffer.get(), &size, FALSE, AF_INET6,
+                UDP_TABLE_OWNER_MODULE, 0) != NO_ERROR)
+                return;
+
+            auto* table = reinterpret_cast<PMIB_UDP6TABLE_OWNER_MODULE>(buffer.get());
+            for (size_t i = 0; i < table->dwNumEntries; ++i)
+            {
+                uint32_t local_v4 = 0;
+                const bool mapped = is_v4_mapped_address(table->table[i].ucLocalAddr, local_v4);
+                if (!mapped && !is_unspecified_v6_address(table->table[i].ucLocalAddr))
+                    continue; // genuine IPv6-only endpoint
+
+                if (auto process_ptr = process_udp_entry_v6(&table->table[i]))
+                {
+                    udp_to_app.try_emplace(
+                        net::ip_endpoint<net::ip_address_v4>(
+                            net::ip_address_v4{ mapped ? local_v4 : 0u },
+                            ntohs(static_cast<uint16_t>(table->table[i].dwLocalPort))),
+                        std::move(process_ptr));
+                }
+            }
+        }
+
         /**
          * @brief Initializes the TCP connection hash table from system state.
          *
@@ -813,6 +919,11 @@ namespace iphelper
                                     = std::move(process_ptr);
                             }
                         }
+
+                        // Fold dual-stack (IPv4-mapped) connections from the AF_INET6 table so they
+                        // are attributable by the IPv4 packet handler (they never appear in the
+                        // AF_INET table). See add_v4_mapped_tcp_sessions.
+                        add_v4_mapped_tcp_sessions(tcp_to_app);
                     }
                     else {
                         auto* table = reinterpret_cast<PMIB_TCP6TABLE_OWNER_MODULE>(table_buffer_tcp_.get());
@@ -890,6 +1001,11 @@ namespace iphelper
                                     = std::move(process_ptr);
                             }
                         }
+
+                        // Fold dual-stack (IPv4-mapped and unspecified) endpoints from the AF_INET6
+                        // table so they are attributable by the IPv4 packet handler. See
+                        // add_v4_mapped_udp_endpoints.
+                        add_v4_mapped_udp_endpoints(udp_to_app);
                     }
                     else {
                         auto* table = reinterpret_cast<PMIB_UDP6TABLE_OWNER_MODULE>(table_buffer_udp_.get());

--- a/netlib/src/ndisapi/intermediate_buffer_pool.h
+++ b/netlib/src/ndisapi/intermediate_buffer_pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/pool/object_pool.hpp>
+#include <mutex>
 
 namespace ndisapi
 {
@@ -37,7 +38,13 @@ namespace ndisapi
             /// </summary>
             /// <param name="ptr">Pointer to the intermediate_buffer object to be deleted.</param>
             void operator()(intermediate_buffer* ptr) const {
-                instance().pool_.destroy(ptr);
+                // boost::object_pool is NOT thread-safe: construct()/destroy() both mutate
+                // the shared free list. This singleton is used concurrently by the packet-
+                // filter thread (allocate) and the resolver thread (destroy), so every
+                // access must be serialized to avoid free-list/heap corruption.
+                auto& pool = instance();
+                std::lock_guard<std::mutex> lock(pool.pool_mutex_);
+                pool.pool_.destroy(ptr);
             }
         };
 
@@ -49,7 +56,13 @@ namespace ndisapi
         /// <returns>A unique_ptr to the allocated intermediate_buffer object, or nullptr if allocation fails.</returns>
         intermediate_buffer_ptr allocate() {
             try {
-                auto* raw_ptr = pool_.construct(); // This might throw
+                intermediate_buffer* raw_ptr;
+                {
+                    // Serialize with destroy() (see deleter): boost::object_pool has no
+                    // internal locking and is mutated from multiple threads here.
+                    std::lock_guard<std::mutex> lock(pool_mutex_);
+                    raw_ptr = pool_.construct(); // This might throw
+                }
                 std::fill_n(reinterpret_cast<char*>(raw_ptr), offsetof(_INTERMEDIATE_BUFFER, m_IBuffer), 0);
                 return intermediate_buffer_ptr(raw_ptr, deleter{});
             }
@@ -96,6 +109,9 @@ namespace ndisapi
             : pool_(initial_size) {
         }
 
+        // Declared before pool_ so it is destroyed after it (members are torn down in
+        // reverse declaration order). Guards every construct()/destroy() on pool_.
+        std::mutex pool_mutex_;
         boost::object_pool<intermediate_buffer> pool_; ///< The pool of intermediate_buffer objects.
     };
 }

--- a/netlib/src/ndisapi/tcp_local_redirect.h
+++ b/netlib/src/ndisapi/tcp_local_redirect.h
@@ -222,15 +222,25 @@ namespace ndisapi
                         timestamp_endpoint{
                             tcp_header->th_dport,
                             std::chrono::steady_clock::now()
-                        }); !result)
-                        return false;
-
-                    NETLIB_INFO(
-                        "NEW TCP: {}:{} -> {}:{}",
-                        std::string{ T{ip_header->ip_src} },
-                        ntohs(tcp_header->th_sport),
-                        std::string{ T{ip_header->ip_dst} },
-                        ntohs(tcp_header->th_dport));
+                        }); result)
+                    {
+                        NETLIB_INFO(
+                            "NEW TCP: {}:{} -> {}:{}",
+                            std::string{ T{ip_header->ip_src} },
+                            ntohs(tcp_header->th_sport),
+                            std::string{ T{ip_header->ip_dst} },
+                            ntohs(tcp_header->th_dport));
+                    }
+                    else
+                    {
+                        // A SYN whose {dst, src-port} key already exists is a SYN RETRANSMISSION
+                        // for a connection we are already redirecting (the local listener has not
+                        // finished the handshake yet, so the client retransmits). Returning false
+                        // here would make the caller PASS the retransmit to the real destination --
+                        // an unproxied leak of a connection we own. Refresh the timestamp and fall
+                        // through to rewrite this SYN to the local proxy, exactly like the first one.
+                        it->second.second = std::chrono::steady_clock::now();
+                    }
                 }
                 else
                 {
@@ -294,15 +304,22 @@ namespace ndisapi
                         timestamp_endpoint{
                             tcp_header->th_dport,
                             std::chrono::steady_clock::now()
-                        }); !result)
-                        return false;
-
-                    NETLIB_INFO(
-                        "NEW TCP: {}:{} -> {}:{}",
-                        std::string{ T{ip_header->ip6_src} },
-                        ntohs(tcp_header->th_sport),
-                        std::string{ T{ip_header->ip6_dst} },
-                        ntohs(tcp_header->th_dport));
+                        }); result)
+                    {
+                        NETLIB_INFO(
+                            "NEW TCP: {}:{} -> {}:{}",
+                            std::string{ T{ip_header->ip6_src} },
+                            ntohs(tcp_header->th_sport),
+                            std::string{ T{ip_header->ip6_dst} },
+                            ntohs(tcp_header->th_dport));
+                    }
+                    else
+                    {
+                        // SYN retransmission for a connection we already redirect (see the IPv4
+                        // path): refresh the timestamp and rewrite it to the local proxy instead
+                        // of leaking the retransmit to the real destination.
+                        it->second.second = std::chrono::steady_clock::now();
+                    }
                 }
                 else
                 {

--- a/netlib/src/net/ipv6_helper.h
+++ b/netlib/src/net/ipv6_helper.h
@@ -155,7 +155,10 @@ namespace net
             }
             else if (protocol == IPPROTO_UDP && udp_header != nullptr)
             {
-                udp_header->th_sum = checksum;
+                // RFC 768 / RFC 8200: a UDP checksum that computes to 0 must be transmitted as
+                // 0xFFFF. Over IPv6 a zero UDP checksum is illegal and receivers MUST drop the
+                // datagram, so emitting 0 here would make proxied UDP silently disappear.
+                udp_header->th_sum = (checksum != 0) ? checksum : static_cast<uint16_t>(0xFFFF);
             }
             else if (protocol == IPPROTO_ICMPV6 && icmp_header != nullptr)
             {

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1,5 +1,13 @@
 #pragma once
 
+// SIO_UDP_CONNRESET normally comes from <mstcpip.h>, but this header-only file relies on the
+// project's master include order and the macro is not reliably visible here across SDKs. Provide
+// the standard fallback definition; _WSAIOW/IOC_VENDOR are from <winsock2.h>, which is always
+// included ahead of this file.
+#ifndef SIO_UDP_CONNRESET
+#define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
+#endif
+
 namespace proxy
 {
     /**
@@ -301,7 +309,9 @@ namespace proxy
                         auto result = true;
                         auto server_read = false;
 
-                        std::lock_guard lock(lock_);
+                        // unique_lock (not lock_guard): connect_to_remote_host() releases and
+                        // re-acquires this around its blocking SOCKS5 negotiation (see H2 there).
+                        std::unique_lock lock(lock_);
 
                         auto io_context = static_cast<per_io_context_t*>(povlp);
 
@@ -323,7 +333,7 @@ namespace proxy
                             {
                                 do
                                 {
-                                    if (false == connect_to_remote_host(io_context))
+                                    if (false == connect_to_remote_host(io_context, lock))
                                     {
                                         result = false;
                                         break;
@@ -687,6 +697,21 @@ namespace proxy
             if (server_socket_ == static_cast<SOCKET>(INVALID_SOCKET))
             {
                 return false;
+            }
+
+            // Disable SIO_UDP_CONNRESET. Without this, a prior datagram that elicited an ICMP
+            // port-unreachable from a since-closed local peer makes the NEXT WSARecvFrom complete
+            // with WSAECONNRESET, which would tear down the server read loop and stop proxying all
+            // UDP. UDP is connectionless, so this "connection reset" is spurious -- suppress it.
+            {
+                BOOL new_behavior = FALSE;
+                DWORD bytes_returned = 0;
+                if (WSAIoctl(server_socket_, SIO_UDP_CONNRESET, &new_behavior, sizeof(new_behavior),
+                    nullptr, 0, &bytes_returned, nullptr, nullptr) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("create_server_socket: failed to disable SIO_UDP_CONNRESET: {}",
+                        WSAGetLastError());
+                }
             }
 
             if constexpr (address_type_t::af_type == AF_INET)
@@ -1272,7 +1297,7 @@ namespace proxy
          *                   On success, its proxy_socket_ptr is set to the active proxy socket.
          * @return True if the relay session was established or already exists, false on failure.
          */
-        bool connect_to_remote_host(per_io_context_t* io_context)
+        bool connect_to_remote_host(per_io_context_t* io_context, std::unique_lock<std::mutex>& lock)
         {
             uint16_t local_peer_port = 0;
             address_type_t local_peer_address{};
@@ -1308,6 +1333,18 @@ namespace proxy
                 remote_address,
                 remote_port);
 
+            // H2: the SOCKS5 TCP connect + ASSOCIATE below is fully blocking (connect_with_timeout
+            // up to ~5s, then several blocking send/recv each bounded only by a ~5s timeout), so it
+            // can hold lock_ for 10s+. Under lock_ that freezes EVERY other UDP completion for this
+            // proxy plus clear_thread and stop(). Release lock_ across the blocking negotiation and
+            // relay-socket setup. This is safe: the server read is serialized (recv_from_sa_ and
+            // server_receive_buffer_ are not re-armed until after this returns), the new session is
+            // not yet in proxy_sockets_ so no other completion can touch it, and our completion's
+            // active_iocp_operations_ guard is still held so stop() cannot tear the server down
+            // underneath us. We re-acquire lock_ and re-check end_server_ before publishing. Every
+            // early return below re-acquires lock_ first: the caller relies on it being held.
+            lock.unlock();
+
             auto socks5_tcp_socket = connect_to_socks5_proxy(remote_address, remote_port);
             if (socks5_tcp_socket == INVALID_SOCKET)
             {
@@ -1315,6 +1352,7 @@ namespace proxy
                     "connect_to_remote_host: Failed to connect to SOCKS5 proxy: {}:{}",
                     remote_address,
                     remote_port);
+                lock.lock();
                 return false;
             }
 
@@ -1327,6 +1365,7 @@ namespace proxy
                     remote_port);
 
                 closesocket(socks5_tcp_socket);
+                lock.lock();
                 return false;
             }
 
@@ -1344,7 +1383,21 @@ namespace proxy
                     "connect_to_remote_host: Failed to create UDP socket: {}",
                     WSAGetLastError());
                 closesocket(socks5_tcp_socket);
+                lock.lock();
                 return false;
+            }
+
+            // Suppress spurious WSAECONNRESET on the relay socket too (see create_server_socket):
+            // an ICMP port-unreachable from the SOCKS5 UDP relay must not kill this relay's reads.
+            {
+                BOOL new_behavior = FALSE;
+                DWORD bytes_returned = 0;
+                if (WSAIoctl(remote_socket, SIO_UDP_CONNRESET, &new_behavior, sizeof(new_behavior),
+                    nullptr, 0, &bytes_returned, nullptr, nullptr) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("connect_to_remote_host: failed to disable SIO_UDP_CONNRESET on relay socket: {}",
+                        WSAGetLastError());
+                }
             }
 
             if constexpr (address_type_t::af_type == AF_INET)
@@ -1362,6 +1415,7 @@ namespace proxy
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to bind UDP socket: {}",
                         WSAGetLastError());
+                    lock.lock();
                     return false;
                 }
             }
@@ -1391,6 +1445,7 @@ namespace proxy
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to bind UDP socket: {}",
                         WSAGetLastError());
+                    lock.lock();
                     return false;
                 }
             }
@@ -1411,6 +1466,7 @@ namespace proxy
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to connect UDP socket: {}",
                         WSAGetLastError());
+                    lock.lock();
                     return false;
                 }
             }
@@ -1429,8 +1485,34 @@ namespace proxy
                     NETLIB_DEBUG(
                         "connect_to_remote_host: Failed to connect UDP socket: {}",
                         WSAGetLastError());
+                    lock.lock();
                     return false;
                 }
+            }
+
+            // Re-acquire lock_ to publish the session (see the lock.unlock() above). From here on
+            // proxy_sockets_ and the server members are accessed under the lock again.
+            lock.lock();
+
+            // stop() may have set end_server_ during the unlocked window. It is currently blocked in
+            // its drain loop waiting on our active_iocp_operations_ guard, so the server object is
+            // still alive -- but we must not create a NEW session during shutdown (it would only be
+            // torn down again). Abort cleanly.
+            if (end_server_.load(std::memory_order_acquire))
+            {
+                closesocket(remote_socket);
+                closesocket(socks5_tcp_socket);
+                return false;
+            }
+
+            // Server reads are serialized so no concurrent creation for this source port is expected,
+            // but guard defensively: if an entry appeared meanwhile, drop what we built and use it.
+            if (auto existing = proxy_sockets_.find(local_peer_port); existing != proxy_sockets_.end())
+            {
+                closesocket(remote_socket);
+                closesocket(socks5_tcp_socket);
+                io_context->proxy_socket_ptr = existing->second;
+                return true;
             }
 
             auto [it, result] = proxy_sockets_.emplace(local_peer_port,

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -133,15 +133,36 @@ namespace proxy
         {
             if (io_context->is_local == false)
             {
+                // Unlike the base handler and the relay completion handlers, this SOCKS5 override
+                // must guard the negotiation state (current_state_, ident_resp_, the negotiate
+                // io-contexts, remote_socket_) against a concurrent close_client()/stop() running
+                // on another IOCP thread. The IOCP dispatcher calls this handler WITHOUT holding
+                // lock_, so acquire it here. Every close_client() reachable from this handler uses
+                // the AlreadyLocked (<true>) form to avoid re-locking the non-recursive mutex; the
+                // lock is released before start_data_relay() (which locks internally).
+                std::unique_lock<std::mutex> lock(tcp_proxy_socket<T>::lock_);
+
                 if (current_state_ == socks5_state::login_sent)
                 {
+                    // The method-selection reply is 2 bytes but TCP may deliver it across multiple
+                    // completions. Accumulate before parsing; a short read otherwise reads a stale
+                    // ident_resp_.method (0 -> mis-parsed as NO-AUTH) and desyncs the handshake.
+                    ident_resp_received_ += io_size;
+                    if (ident_resp_received_ < sizeof(socks5_ident_resp))
+                    {
+                        static_cast<void>(start_negotiate_receive(
+                            reinterpret_cast<char*>(&ident_resp_) + ident_resp_received_,
+                            static_cast<ULONG>(sizeof(socks5_ident_resp)) - ident_resp_received_));
+                        return;
+                    }
+
                     current_state_ = socks5_state::login_responded;
 
                     if ((ident_resp_.version != 5) ||
                         (ident_resp_.method == 0xFF))
                     {
                         // SOCKS v5 identification or authentication failed
-                        tcp_proxy_socket<T>::close_client(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);
                     }
                     else
                     {
@@ -161,7 +182,7 @@ namespace proxy
                                 // [SOCKS5]: associate_to_socks5_proxy: RFC 1928: X'02' USERNAME/PASSWORD is chosen but USERNAME exceeds maximum possible length
                                 )
                             {
-                                tcp_proxy_socket<T>::close_client(true, false);
+                                tcp_proxy_socket<T>::close_client<true>(true, false);
                             }
                             else
                             {
@@ -179,18 +200,19 @@ namespace proxy
                                         &io_context_send_negotiate_.wsa_buf,
                                         &io_context_send_negotiate_) == SOCKET_ERROR)
                                     {
-                                        tcp_proxy_socket<T>::close_client(false, false);
+                                        tcp_proxy_socket<T>::close_client<true>(false, false);
                                         return;
                                     }
 
                                     current_state_ = socks5_state::password_sent;
+                                    ident_resp_received_ = 0; // reset for the 2-byte auth reply
 
                                     if (this->post_recv(
                                         tcp_proxy_socket<T>::remote_socket_,
                                         &io_context_recv_negotiate_.wsa_buf,
                                         &io_context_recv_negotiate_) == SOCKET_ERROR)
                                     {
-                                        tcp_proxy_socket<T>::close_client(true, false);
+                                        tcp_proxy_socket<T>::close_client<true>(true, false);
                                     }
                                 }
                             }
@@ -203,12 +225,22 @@ namespace proxy
                 }
                 else if (current_state_ == socks5_state::password_sent)
                 {
+                    // Accumulate the 2-byte auth reply the same way (see login_sent).
+                    ident_resp_received_ += io_size;
+                    if (ident_resp_received_ < sizeof(socks5_ident_resp))
+                    {
+                        static_cast<void>(start_negotiate_receive(
+                            reinterpret_cast<char*>(&ident_resp_) + ident_resp_received_,
+                            static_cast<ULONG>(sizeof(socks5_ident_resp)) - ident_resp_received_));
+                        return;
+                    }
+
                     current_state_ = socks5_state::password_responded;
 
                     if (ident_resp_.method != 0)
                     {
                         // SOCKS v5 identification or authentication failed
-                        tcp_proxy_socket<T>::close_client(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);
                     }
                     else
                     {
@@ -226,7 +258,7 @@ namespace proxy
                         (connect_response_header_.reply != 0))
                     {
                         // SOCKS v5 connect failed
-                        tcp_proxy_socket<T>::close_client(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);
                         return;
                     }
 
@@ -263,7 +295,7 @@ namespace proxy
                         break;
 
                     default:
-                        tcp_proxy_socket<T>::close_client(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);
                         break;
                     }
                 }
@@ -290,6 +322,11 @@ namespace proxy
                         return;
                     }
 
+                    // start_data_relay() locks lock_ internally (via close_client on its error
+                    // paths), so release our lock first to avoid re-locking the non-recursive
+                    // mutex. This is the terminal action of the handler; no shared negotiation
+                    // state is touched afterwards.
+                    lock.unlock();
                     tcp_proxy_socket<T>::start_data_relay();
                 }
             }
@@ -324,7 +361,8 @@ namespace proxy
                 &io_context_recv_negotiate_.wsa_buf,
                 &io_context_recv_negotiate_) == SOCKET_ERROR)
             {
-                tcp_proxy_socket<T>::close_client(true, false);
+                // Only reached from process_receive_negotiate_complete, which holds lock_.
+                tcp_proxy_socket<T>::close_client<true>(true, false);
                 return false;
             }
 
@@ -382,7 +420,8 @@ namespace proxy
                 &io_context_send_negotiate_.wsa_buf,
                 &io_context_send_negotiate_) == SOCKET_ERROR)
             {
-                tcp_proxy_socket<T>::close_client(false, false);
+                // Only reached from process_receive_negotiate_complete, which holds lock_.
+                tcp_proxy_socket<T>::close_client<true>(false, false);
                 return;
             }
 
@@ -435,6 +474,10 @@ namespace proxy
         unsigned char* connect_reply_buffer_{ nullptr };
         ULONG connect_reply_expected_{ 0 };
         ULONG connect_reply_received_{ 0 };
+        // Bytes accumulated so far for a fixed 2-byte reply (method-selection / auth). TCP may
+        // split the 2 bytes across completions; without accumulating, a 1-byte read would be
+        // parsed as a complete reply against stale ident_resp_ contents.
+        ULONG ident_resp_received_{ 0 };
         socks5_username_auth username_auth_{};
 
     protected:
@@ -507,6 +550,7 @@ namespace proxy
                     }
 
                     current_state_ = socks5_state::login_sent;
+                    ident_resp_received_ = 0; // reset for the 2-byte method-selection reply
                     NETLIB_DEBUG("SOCKS5 identification request sent, waiting for response");
 
                     if (this->post_recv(

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -620,6 +620,15 @@ namespace proxy
 
                 NETLIB_DEBUG("process_receive_buffer_complete: Allocating I/O context for local send operation");
 
+                // A zero-length datagram from the remote SOCKS5 relay must not be forwarded:
+                // allocate_io_context() only allocates a packet buffer when size != 0, so with
+                // io_size == 0 it returns a context whose wsa_buf is null and the send path
+                // below would dereference it (wsa_buf->len / memmove) and crash the process.
+                // remote_socket_ is connect()'d to the relay endpoint, so a malicious/malformed
+                // server (or a spoofed 0-byte datagram from that address) can reach this path.
+                // Skip the local send for empty datagrams and just re-arm the remote receive.
+                if (io_size > 0)
+                {
                 // Use shared_from_this() to get shared_ptr
                 if (auto* io_context_send_to_local = socks5_udp_per_io_context<T>::allocate_io_context(
                     proxy_io_operation::relay_io_write, this->shared_from_this(), true, io_size);
@@ -660,6 +669,7 @@ namespace proxy
                 {
                     NETLIB_ERROR("process_receive_buffer_complete: Failed to allocate I/O context for local send");
                 }
+                } // if (io_size > 0): empty relay datagrams fall straight through to the re-arm
 
                 NETLIB_DEBUG("process_receive_buffer_complete: Initiating new receive operation on remote socket");
 

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -458,7 +458,10 @@ namespace proxy
         {
             using namespace std::string_literals;
 
-            if (pcap_log_stream) {
+            // Test the MEMBER, not the constructor parameter: pcap_log_stream was moved-from into
+            // pcap_log_stream_ on the initializer list above, so `if (pcap_log_stream)` was always
+            // false and pcap logging was silently never enabled.
+            if (pcap_log_stream_) {
                 pcap_logger_.emplace(*pcap_log_stream_);
             }
 
@@ -597,6 +600,58 @@ namespace proxy
          * @return false if the operation was already active at the start of this function, otherwise true
          *         (even if there were errors starting the operation).
          */
+        /**
+         * @brief Rolls back a partially- or fully-started router. Used by both the packet-filter
+         *        start-failure path and start()'s exception handler. Safe on partial state: proxy
+         *        stop() and stop_thread_pool() are idempotent and the resolver join is guarded by
+         *        joinable(). Proxies are stopped OUTSIDE lock_ (proxy cleanup threads may contend
+         *        for the same mutex, so holding lock_ across a stop() can deadlock).
+         */
+        void start_failure_cleanup()
+        {
+            if (!this->cancel_notify_ip_interface_change())
+            {
+                NETLIB_LOG(
+                    log_level::error, "cancel_notify_ip_interface_change has failed, lasterror: {}",
+                    GetLastError());
+            }
+
+            std::vector<std::pair<s5_tcp_proxy_server*, s5_udp_proxy_server*>> proxies_to_stop;
+            std::vector<std::pair<s5_tcp_proxy_server_v6*, s5_udp_proxy_server_v6*>> proxies_to_stop_v6;
+            {
+                std::shared_lock lock(lock_);
+                proxies_to_stop.reserve(proxy_servers_.size());
+                for (auto& [tcp, udp] : proxy_servers_)
+                    proxies_to_stop.emplace_back(tcp.get(), udp.get());
+
+                proxies_to_stop_v6.reserve(proxy_servers_v6_.size());
+                for (auto& [tcp, udp] : proxy_servers_v6_)
+                    proxies_to_stop_v6.emplace_back(tcp.get(), udp.get());
+            }
+
+            for (auto& [tcp, udp] : proxies_to_stop)
+            {
+                if (tcp) tcp->stop();
+                if (udp) udp->stop();
+            }
+
+            for (auto& [tcp, udp] : proxies_to_stop_v6)
+            {
+                if (tcp) tcp->stop();
+                if (udp) udp->stop();
+            }
+
+            io_port_.stop_thread_pool();
+
+            is_active_.store(false);
+
+            resolver_should_exit_.store(true);
+            process_resolve_buffer_queue_cv_.notify_all();
+
+            if (process_resolve_thread_.joinable())
+                process_resolve_thread_.join();
+        }
+
         bool start()
         {
             // Serialize lifecycle operations (start/stop/add_socks5_proxy) so
@@ -618,6 +673,13 @@ namespace proxy
             resolver_should_exit_.store(false);
             resolve_queue_dropped_packets_.store(0, std::memory_order_relaxed);
             resolve_queue_alloc_failures_.store(0, std::memory_order_relaxed);
+
+            // Exception safety: any throw after the is_active_ CAS above must not escape with
+            // is_active_ still true (a half-started router that stop()/the destructor would then
+            // mishandle). Wrap the whole bring-up; the catch at the end rolls back via
+            // start_failure_cleanup(). Body indentation is left unchanged to keep the diff focused.
+            try
+            {
 
             if (!packet_filter_)
             {
@@ -730,68 +792,27 @@ namespace proxy
             {
                 NETLIB_LOG(log_level::error, "Failed to start NDIS packet filter");
 
-                // Attempt to cancel notification of IP interface changes.
-                // Log on failure but continue with cleanup either way: the
-                // packet filter never started, so proxies, the IOCP thread
-                // pool, and the resolver thread must all be torn down
-                // regardless of whether cancel_notify_ip_interface_change
-                // succeeded.
-                if (!this->cancel_notify_ip_interface_change())
-                {
-                    NETLIB_LOG(
-                        log_level::error, "cancel_notify_ip_interface_change has failed, lasterror: {}",
-                        GetLastError());
-                }
-
-                // Collect raw proxy pointers under lock_ but stop them outside
-                // the lock. Proxy cleanup threads may need to acquire the
-                // same mutex, so holding lock_ across stop() can deadlock.
-                // This mirrors the pattern used in stop().
-                std::vector<std::pair<s5_tcp_proxy_server*, s5_udp_proxy_server*>> proxies_to_stop;
-                std::vector<std::pair<s5_tcp_proxy_server_v6*, s5_udp_proxy_server_v6*>> proxies_to_stop_v6;
-                {
-                    std::shared_lock lock(lock_);
-                    proxies_to_stop.reserve(proxy_servers_.size());
-                    for (auto& [tcp, udp] : proxy_servers_)
-                        proxies_to_stop.emplace_back(tcp.get(), udp.get());
-
-                    proxies_to_stop_v6.reserve(proxy_servers_v6_.size());
-                    for (auto& [tcp, udp] : proxy_servers_v6_)
-                        proxies_to_stop_v6.emplace_back(tcp.get(), udp.get());
-                }
-
-                // Stop all proxies without holding lock_.
-                for (auto& [tcp, udp] : proxies_to_stop)
-                {
-                    if (tcp)
-                        tcp->stop();
-
-                    if (udp)
-                        udp->stop();
-                }
-
-                for (auto& [tcp, udp] : proxies_to_stop_v6)
-                {
-                    if (tcp)
-                        tcp->stop();
-
-                    if (udp)
-                        udp->stop();
-                }
-
-                // Stop the thread pool associated with the I/O completion port.
-                io_port_.stop_thread_pool();
-
-                is_active_.store(false);
-
-                // The packet filter never started in this error branch, so
-                // no callback thread can still be enqueuing — safe to
-                // signal resolver shutdown directly.
-                resolver_should_exit_.store(true);
-                process_resolve_buffer_queue_cv_.notify_all();
-
-                if (process_resolve_thread_.joinable())
-                    process_resolve_thread_.join();
+                // Everything this start() brought up must be torn down (the packet filter never
+                // started). Shared with the exception handler below.
+                start_failure_cleanup();
+            }
+            }
+            catch (const std::exception& e)
+            {
+                // Any throw after the is_active_ CAS (e.g. io_port_.start_thread_pool() ->
+                // std::system_error on thread-create failure, update_network_configuration() ->
+                // std::bad_alloc, or std::thread construction failing) would otherwise unwind with
+                // is_active_ still true, leaving a half-started router that a later stop()/destructor
+                // acts on incorrectly. Roll back to a clean inactive state, then report failure.
+                NETLIB_LOG(log_level::error, "Exception while starting the router: {}; rolled back", e.what());
+                start_failure_cleanup();
+                return false;
+            }
+            catch (...)
+            {
+                NETLIB_LOG(log_level::error, "Unknown exception while starting the router; rolled back");
+                start_failure_cleanup();
+                return false;
             }
 
             return is_active_;
@@ -1153,20 +1174,10 @@ namespace proxy
             const auto udp_in_filter = create_filter(IPPROTO_UDP, ndisapi::direction_t::in, proxy_endpoint.value().ip,
                                                      proxy_endpoint.value().port);
 
-            // Add the filters to a filter list
-            // Apply all the filters to the network traffic
-            if (protocols == both || protocols == udp)
-            {
-                static_filters_.add_filter_back(tcp_out_filter);
-                static_filters_.add_filter_back(tcp_in_filter);
-                static_filters_.add_filter_back(udp_out_filter);
-                static_filters_.add_filter_back(udp_in_filter);
-            }
-            else if (protocols == tcp)
-            {
-                static_filters_.add_filter_back(tcp_out_filter);
-                static_filters_.add_filter_back(tcp_in_filter);
-            }
+            // NOTE: the static PASS filters for the upstream endpoint are installed only AFTER
+            // the proxy pair is successfully built and (optionally) started -- see below, just
+            // before proxy_servers_ is updated. Installing them here (before build/start) leaked
+            // orphaned driver filters on every failure path.
 
             try
             {
@@ -1259,6 +1270,25 @@ namespace proxy
                     {
                         disable_ipv6_listeners();
                     }
+                }
+
+                // Install the static PASS filters for the upstream endpoint only NOW that the
+                // proxy pair has been successfully built and (if requested) started. add_filter_back
+                // commits immediately to the driver, so installing earlier leaked orphaned filters
+                // on every failure path (build_proxy_pair throwing, or a required listener failing
+                // to start and returning {}). Kept under lifecycle_lock and outside lock_, mirroring
+                // the original lock scope.
+                if (protocols == both || protocols == udp)
+                {
+                    static_filters_.add_filter_back(tcp_out_filter);
+                    static_filters_.add_filter_back(tcp_in_filter);
+                    static_filters_.add_filter_back(udp_out_filter);
+                    static_filters_.add_filter_back(udp_in_filter);
+                }
+                else if (protocols == tcp)
+                {
+                    static_filters_.add_filter_back(tcp_out_filter);
+                    static_filters_.add_filter_back(tcp_in_filter);
                 }
 
                 // Lock the mutex to safely add the proxy servers to the shared data
@@ -2543,7 +2573,24 @@ namespace proxy
         void update_network_configuration()
         {
             const auto ndis_adapters = packet_filter_->get_interface_list();
-            const auto configured_interfaces = iphelper::network_adapter_info::get_external_network_connections();
+            bool enumeration_succeeded = false;
+            const auto configured_interfaces =
+                iphelper::network_adapter_info::get_external_network_connections(&enumeration_succeeded);
+
+            // Fail SAFE, not open. An empty result is ambiguous: it can mean "no external
+            // adapters" OR that enumeration failed (transient API/allocation error, e.g. under
+            // memory pressure during a network-change storm). If we cannot trust the list, do
+            // NOT rebuild the filter set from it: an empty set would unfilter every interface
+            // and send all matched applications' traffic direct, bypassing the proxy. Keep the
+            // current filter state and let the next change notification retry.
+            if (!enumeration_succeeded)
+            {
+                NETLIB_LOG(log_level::warning,
+                    "update_network_configuration: network adapter enumeration failed; "
+                    "preserving current filter state to avoid a proxy-bypass.");
+                return;
+            }
+
             std::unordered_set<std::string> adapters_to_filter;
 
             for (const auto& adapter : configured_interfaces)
@@ -2580,11 +2627,17 @@ namespace proxy
                 }
             }
 
-            {
-                std::shared_lock lock(adapters_to_filter_lock_);
-                if (adapters_to_filter_ == adapters_to_filter)
-                    return;
-            }
+            // Serialize compare -> reprogram driver -> store as ONE atomic critical section.
+            // This function is reentrant: it runs from start() and from the NotifyIpInterfaceChange
+            // system-thread callback. Splitting the "did it change?" check from the driver
+            // reprogramming and the stored-set update lets two concurrent runs both pass the check,
+            // both drive filter/unfilter, and race their stores -- leaving adapters_to_filter_ out
+            // of sync with the actual NDIS filter state. Hold the exclusive lock across the whole
+            // decision so the stored set always reflects the last programming applied to the driver.
+            std::unique_lock lock(adapters_to_filter_lock_);
+
+            if (adapters_to_filter_ == adapters_to_filter)
+                return;
 
             for (const auto& adapter : ndis_adapters)
             {
@@ -2600,10 +2653,7 @@ namespace proxy
                 }
             }
 
-            {
-                std::unique_lock lock(adapters_to_filter_lock_);
-                adapters_to_filter_ = std::move(adapters_to_filter);
-            }
+            adapters_to_filter_ = std::move(adapters_to_filter);
         }
         
         /**

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -283,6 +283,22 @@ namespace proxy
 
             end_server_ = false;
 
+            // A prior stop() closes and INVALIDATES the listening socket, but it is created only
+            // in the constructor (create_server_socket()). The router reuses the same
+            // tcp_proxy_server objects across stop()/start() cycles, so without recreating the
+            // socket here start() would relaunch the worker threads around INVALID_SOCKET and the
+            // accept loop (WSAAccept) would exit immediately -- a "running" server that silently
+            // accepts nothing. Recreate it (and fail start() if that fails).
+            if (server_socket_ == static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                if (!create_server_socket())
+                {
+                    NETLIB_ERROR("tcp_proxy_server::start: failed to recreate the listening socket");
+                    end_server_ = true;
+                    return false;
+                }
+            }
+
             sock_array_events_.reserve(connections_array_size);
 
             sock_array_events_.push_back(std::make_tuple(WSACreateEvent(),
@@ -372,6 +388,17 @@ namespace proxy
                             if ((io_operation == proxy_io_operation::relay_io_read) ||
                                 (io_operation == proxy_io_operation::negotiate_io_read))
                             {
+                                // A graceful FIN (status == true, 0 bytes) on the DATA relay path is
+                                // a half-close: do NOT hard-close, which would CancelIoEx an in-flight
+                                // send and truncate already-received data. Drain it instead. Hard
+                                // errors (status == false) and any 0-byte negotiation read still abort
+                                // immediately.
+                                if (status && io_operation == proxy_io_operation::relay_io_read)
+                                {
+                                    proxy_socket->on_peer_read_shutdown(io_context->is_local);
+                                    return false;
+                                }
+
                                 proxy_socket->close_client(true, io_context->is_local);
                                 return false;
                             }
@@ -430,6 +457,22 @@ namespace proxy
                     end_server_ = true;
                     return false;
                 }
+            }
+            else
+            {
+                // The throwaway registration socket could not be created, so no IOCP completion
+                // handler was registered and completion_key_ is unset. Launching the workers now
+                // would produce an inert server: every session's overlapped I/O would post but
+                // never complete, so outstanding_io_ never drains and sessions pin forever. Treat
+                // this exactly like an association failure and fail start().
+                NETLIB_ERROR("tcp_proxy_server::start: failed to create IOCP registration socket");
+                if (std::get<0>(sock_array_events_[0]) != WSA_INVALID_EVENT)
+                {
+                    WSACloseEvent(std::get<0>(sock_array_events_[0]));
+                }
+                sock_array_events_.clear();
+                end_server_ = true;
+                return false;
             }
 
             proxy_server_ = std::thread(&tcp_proxy_server::start_proxy_thread, this);
@@ -896,6 +939,7 @@ namespace proxy
 
             // The client_service structure specifies the address family,
             // IP address, and port of the server to be connected to.
+            WSAEVENT tracked_event = WSA_INVALID_EVENT;
             {
                 std::scoped_lock lock(lock_);
 
@@ -930,8 +974,31 @@ namespace proxy
                     return false;
                 }
 
+                // Remember the event we just tracked so a synchronous connect() failure below can
+                // find and erase this entry (see undo_pending_entry).
+                tracked_event = std::get<0>(sock_array_events_.back());
+
                 WSASetEvent(std::get<0>(sock_array_events_[0]));
             }
+
+            // If connect() fails synchronously (below) the entry pushed above would otherwise
+            // linger forever: its event is never signaled (the socket is closed), so it
+            // permanently occupies one of the limited slots and leaks the WSAEVENT. After
+            // connections_array_size such failures the server rejects every new connection until
+            // it is restarted. Erase our entry on those paths.
+            auto undo_pending_entry = [this, tracked_event]()
+            {
+                std::scoped_lock lock(lock_);
+                for (auto it = sock_array_events_.begin(); it != sock_array_events_.end(); ++it)
+                {
+                    if (std::get<0>(*it) == tracked_event)
+                    {
+                        WSACloseEvent(std::get<0>(*it));
+                        sock_array_events_.erase(it);
+                        break;
+                    }
+                }
+            };
 
             NETLIB_DEBUG("connect_to_remote_host: Initiating connection to {}:{}", remote_ip, remote_port);
 
@@ -951,6 +1018,7 @@ namespace proxy
                         NETLIB_WARNING("connect_to_remote_host: IPv4 connect failed: {}", error);
                         shutdown(remote_socket, SD_BOTH);
                         closesocket(remote_socket);
+                        undo_pending_entry();
                         return false;
                     }
                     NETLIB_DEBUG("connect_to_remote_host: IPv4 connection in progress (WSAEWOULDBLOCK)");
@@ -975,6 +1043,7 @@ namespace proxy
                         NETLIB_WARNING("connect_to_remote_host: IPv6 connect failed: {}", error);
                         shutdown(remote_socket, SD_BOTH);
                         closesocket(remote_socket);
+                        undo_pending_entry();
                         return false;
                     }
                     else
@@ -1074,6 +1143,20 @@ namespace proxy
                 if (end_server_ == true)
                     break;
 
+                // WaitForMultipleObjects can return WAIT_FAILED (0xFFFFFFFF) -- e.g. when a handle
+                // in the array has become invalid. An INFINITE wait never returns WAIT_TIMEOUT, but
+                // guard against any out-of-range value: using it as a vector index below would be a
+                // wild out-of-bounds access. Log, back off briefly to avoid a hot spin if the
+                // condition persists, and rebuild the wait set on the next iteration.
+                if (event_index == WAIT_FAILED || event_index >= wait_events.size())
+                {
+                    NETLIB_ERROR("connect_to_remote_host_thread: wait returned invalid index {} (last error {})",
+                        static_cast<unsigned long>(event_index), GetLastError());
+                    using namespace std::chrono_literals;
+                    std::this_thread::sleep_for(100ms);
+                    continue;
+                }
+
                 if (event_index != 0)
                 {
                     std::scoped_lock lock(lock_);
@@ -1098,11 +1181,25 @@ namespace proxy
                             std::move(negotiate_ctx),
                             logger::log_level_, logger::log_stream_);
 
+                        // The socket now OWNS both handles: its destructor closes them if any step
+                        // below throws (stack-unwinding destroys `socket` before the catch runs).
+                        // Null the local copies so the catch does NOT close them a second time --
+                        // a double closesocket that, with handle recycling, could tear down an
+                        // unrelated socket. If make_shared itself had thrown we would not reach here,
+                        // and the catch would still correctly close the un-transferred handles.
+                        local_socket = INVALID_SOCKET;
+                        remote_socket = INVALID_SOCKET;
+
                         // Initialize I/O contexts - can throw std::bad_weak_ptr or std::runtime_error
                         socket->initialize_io_contexts();
 
-                        // Associate with completion port
-                        socket->associate_to_completion_port(completion_key_, completion_port_);
+                        // Associate with completion port. A false return means no completion handler
+                        // was registered (CreateIoCompletionPort failed, or completion_key_ is
+                        // invalid): the session's overlapped I/O would post but never complete, so
+                        // outstanding_io_ would never drain and the session would pin forever. Treat
+                        // it as a fatal init error so the catch tears the half-built session down.
+                        if (!socket->associate_to_completion_port(completion_key_, completion_port_))
+                            throw std::runtime_error("associate_to_completion_port failed");
 
                         // Start the socket
                         socket->start();

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -749,6 +749,64 @@ namespace proxy
         }
 
         /**
+         * @brief Handles a graceful FIN (0-byte read) on one relay direction WITHOUT tearing down
+         *        the in-flight send on the opposite socket.
+         *
+         * The previous behavior called close_client() on any 0-byte relay read, which does
+         * shutdown(SD_BOTH) + CancelIoEx() on BOTH sockets -- cancelling a WSASend still carrying
+         * already-received relay data and truncating the transfer (e.g. a close/length-delimited
+         * download whose final chunk is still in flight to the client when the server FINs).
+         *
+         * Instead, mark the session completed (so no new relay I/O is started) and let the existing
+         * drain path in process_send_buffer_complete() flush the buffered/in-flight data and then
+         * close once it has caught up. If nothing is in flight there is nothing to drain, so close
+         * immediately to avoid lingering until the idle reaper.
+         *
+         * NOTE: this preserves data integrity for the common case (a side finishes sending, then
+         * FINs). It does not implement full bidirectional half-close (a peer that half-closes its
+         * send side yet keeps reading the reverse direction); such flows still terminate cleanly
+         * with no truncation of already-received data, just without a reverse-path continuation.
+         *
+         * @param is_local true if the FIN was read on the local socket, false if on the remote.
+         */
+        void on_peer_read_shutdown(const bool is_local)
+        {
+            std::scoped_lock lock(lock_);
+
+            if (connection_status_ == connection_status::client_completed)
+                return; // already draining or closed
+
+            timestamp_ = std::chrono::steady_clock::now();
+            connection_status_ = connection_status::client_completed;
+
+            // Stop receiving from the side that FIN'd; no more data will arrive there.
+            const SOCKET fin_socket = is_local ? local_socket_ : remote_socket_;
+            if (fin_socket != static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                if (shutdown(fin_socket, SD_RECEIVE) == SOCKET_ERROR)
+                {
+                    const auto error = WSAGetLastError();
+                    NETLIB_DEBUG("on_peer_read_shutdown: shutdown(SD_RECEIVE) failed: {}", error);
+                }
+            }
+
+            // If a send is in flight in EITHER direction, let its completion
+            // (process_send_buffer_complete) flush any remaining buffered bytes and then close once
+            // caught up -- closing now would CancelIoEx that send and truncate it. Only when both
+            // directions are idle is there nothing to drain, so close immediately (otherwise the
+            // session would linger until the idle reaper).
+            if (remote_send_buf_.len == 0 && local_send_buf_.len == 0)
+            {
+                NETLIB_DEBUG("on_peer_read_shutdown: no in-flight send to drain, closing now");
+                close_client<true>(true, is_local);
+            }
+            else
+            {
+                NETLIB_DEBUG("on_peer_read_shutdown: draining in-flight send(s) before close");
+            }
+        }
+
+        /**
          * @brief Determines if the proxy session is ready for removal and performs idle cleanup.
          *
          * This method checks whether both the local and remote sockets are closed and all I/O buffers
@@ -1986,6 +2044,12 @@ namespace proxy
                 else {
                     NETLIB_DEBUG("start_data_relay: Local socket closed successfully");
                 }
+
+                // We just closed local_socket_ by hand. Invalidate it BEFORE close_client() so its
+                // remote branch (which re-checks `local_socket_ != INVALID_SOCKET`) does not close
+                // the same handle a second time -- a double closesocket that, with Windows handle
+                // recycling, could tear down an unrelated socket opened concurrently.
+                local_socket_ = INVALID_SOCKET;
 
                 NETLIB_DEBUG("start_data_relay: Closing remote client due to WSARecv failure");
                 close_client(true, false);


### PR DESCRIPTION
## Summary

Hardening fixes surfaced by a deep multi-agent code review of the SOCKS5 engine, C++/CLI bridge, and .NET service. Every finding was adversarially verified against the code before fixing.

**Build:** full solution compiles clean — Debug x64, **0 errors / 0 warnings** (`ndisapi.lib` + `socksify` + `ProxiFyre`).

## Fixes by severity

### 🔴 Critical
- **`intermediate_buffer_pool`** — serialize `boost::object_pool` `construct()`/`destroy()` with a mutex. The pool is a process-wide singleton mutated concurrently by the packet-filter thread (allocate) and the resolver thread (free) → free-list/heap corruption under normal traffic.

### 🟠 High
- **UDP null-deref** — a zero-length datagram from the SOCKS5 relay dereferenced a null `wsa_buf` (remote-triggered crash). Now skipped + re-armed.
- **UDP blocking-under-lock** — the IOCP worker held the global `lock_` across a blocking SOCKS5 connect/ASSOCIATE (~10s), freezing all UDP sessions + shutdown. Released around the negotiation; re-checks `end_server_`/map before publishing.
- **SYN-retransmit leak** — a retransmitted SYN for a tracked connection was passed to the real destination unproxied. Now redirected.
- **Dual-stack bypass** — IPv4 traffic from dual-stack (`AF_INET6`) sockets was never attributed (leaked direct). v4-mapped rows from the AF_INET6 tables are now folded into the v4 lookup tables.
- **Fail-open unfilter** — a transient adapter-enumeration failure made the router unfilter *every* adapter. Enumeration now reports success/failure and the router fails **safe** (keeps existing filters).
- **Service reports healthy while dead** — the .NET service ignored `Start()`'s failure. Now throws so the SCM reports it.
- **Secrets** — `app-config.json` (real proxy creds) was not git-ignored. Now ignored (+ `bin/` copies); a placeholder `app-config.sample.json` is tracked. ⚠️ **Rotate the previously-exposed credentials** — the ignore only prevents future leaks.
- **`tcp_proxy_server` lifecycle** — recreate the listen socket on `start()` after `stop()` (no zombie server); erase the slot on a synchronous `connect()` failure (no slot leak/DoS); bound the `WaitForMultipleObjects` result (no OOB).
- **Double-close** — invalidate `local_socket_` before `close_client()` in `start_data_relay()`.
- **Unlocked negotiation** — the SOCKS5 negotiation completion handler now holds `lock_` (raced `close_client`/`stop`), using `close_client<true>` throughout.
- **Split-lock race** — `update_network_configuration()` compare/reprogram/store is now one atomic critical section.
- **Truncated transfers (half-close)** — a graceful FIN now drains in-flight sends (via the existing `client_completed` path) instead of `CancelIoEx`-ing them. _Partial half-close: no data is truncated, but reverse-path continuation is not implemented._

### 🟡 Medium
- Fail `start()` if the IOCP registration socket can't be created; check `associate_to_completion_port()` and fix the latent double-close it exposed.
- Install static PASS filters only after the proxy is built/started (no orphaned filters on failure); make `start()` exception-safe via a shared `start_failure_cleanup()`; fix pcap logging silently never enabling (moved-from `shared_ptr`).
- Accumulate the 2-byte SOCKS5 method/auth replies before parsing (no misread on a split read).
- Disable `SIO_UDP_CONNRESET` on both UDP sockets.
- Emit a UDP/IPv6 zero checksum as `0xFFFF` per RFC 768/8200.

## Not included (follow-ups)
- **Fail-closed kill-switch** (M-errpolicy, relay `INADDR_ANY` bind, DNS-53 passthrough) — agreed posture is **fail-closed**; it's a feature needing a config toggle + drop-action + mid-run handling + tests, not a blind change.
- **Runtime smoke testing** — compiles clean, but needs the WinpkFilter driver + live proxies: TCP/UDP through a real SOCKS5 proxy, a credentialed proxy (M-2byte/H10), a large download (half-close), and a stop/start cycle.
- Zero automated tests and repo hygiene (`.bak` files, over-broad `.gitignore` globs, v4/v6 duplication) remain.