### PR TITLE
fix: restore empty-string appName as the match-all catch-all

### DIFF
--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -202,17 +202,22 @@ namespace ProxiFyre
                     throw new InvalidOperationException(message);
                 }
 
-                // Drop null/blank application names so they are never marshalled
-                // to the unmanaged layer, where marshal_as<std::wstring> throws
-                // on a null String^.
+                // Drop null and whitespace-only application names (a null String^ throws in
+                // marshal_as<std::wstring>, and "   " is a typo that matches nothing), but PRESERVE
+                // an explicit empty string "": it is the catch-all that matches EVERY process (see
+                // match_app_name in the native router), so it must reach the unmanaged layer. A
+                // plain IsNullOrWhiteSpace would strip "" too and silently disable that catch-all.
                 if (proxy.AppNames == null)
                     proxy.AppNames = new List<string>();
                 else
-                    proxy.AppNames.RemoveAll(string.IsNullOrWhiteSpace);
+                    proxy.AppNames.RemoveAll(s => s == null || (s.Length > 0 && string.IsNullOrWhiteSpace(s)));
 
                 if (proxy.AppNames.Count == 0)
                     LoggerInstance.Warn(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
+                else if (proxy.AppNames.Contains(string.Empty))
+                    LoggerInstance.Info(
+                        $"Proxy '{proxy.Socks5ProxyEndpoint}' has an empty application name; it will match ALL processes (catch-all) except excluded ones.");
 
                 // Warn on unrecognized protocol tokens: SupportedProtocolsParse only counts
                 // "TCP"/"UDP" and ignores anything else, defaulting to BOTH only when neither

--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -210,14 +210,26 @@ namespace ProxiFyre
                 if (proxy.AppNames == null)
                     proxy.AppNames = new List<string>();
                 else
-                    proxy.AppNames.RemoveAll(s => s == null || (s.Length > 0 && string.IsNullOrWhiteSpace(s)));
+                    // Remove null and whitespace-only entries but keep "": IsNullOrWhiteSpace is
+                    // already true for null/""/whitespace, so `s != string.Empty && IsNullOrWhiteSpace(s)`
+                    // drops null and "   " while preserving the "" catch-all.
+                    proxy.AppNames.RemoveAll(s => s != string.Empty && string.IsNullOrWhiteSpace(s));
 
                 if (proxy.AppNames.Count == 0)
                     LoggerInstance.Warn(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has no application names; it will not match any process.");
                 else if (proxy.AppNames.Contains(string.Empty))
+                {
                     LoggerInstance.Info(
                         $"Proxy '{proxy.Socks5ProxyEndpoint}' has an empty application name; it will match ALL processes (catch-all) except excluded ones.");
+
+                    // Proxies are matched in configuration order and the first match wins, so a
+                    // catch-all shadows every proxy listed after it. Warn if it is not last.
+                    if (!ReferenceEquals(proxy, settings.Proxies[settings.Proxies.Count - 1]))
+                        LoggerInstance.Warn(
+                            $"Proxy '{proxy.Socks5ProxyEndpoint}' is a catch-all but is not the last configured proxy; " +
+                            "proxies listed after it will be shadowed and never matched. Move it to the end of \"proxies\".");
+                }
 
                 // Warn on unrecognized protocol tokens: SupportedProtocolsParse only counts
                 // "TCP"/"UDP" and ignores anything else, defaulting to BOTH only when neither

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1535,6 +1535,14 @@ namespace proxy
                 }
             }
 
+            // An empty app pattern is the catch-all: match ANY process not excluded above. This
+            // restores the long-standing behavior (before matching was anchored) where a substring
+            // find("") matched every process, letting an appNames entry of "" act as a default /
+            // fallback proxy for all remaining traffic. Non-empty names keep the anchored matching
+            // above (so a short pattern still can't match an unrelated process).
+            if (app.empty())
+                return true;
+
             return (app.find(L'\\') != std::wstring::npos || app.find(L'/') != std::wstring::npos)
                     ? (process->path_name.find(app) != std::wstring::npos)
                     : name_matches(process->name, app);

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1483,8 +1483,14 @@ namespace proxy
          * - If the pattern/exclusion entry contains path separators ("/" or "\\"), it matches against the process's full path_name
          * - If the pattern/exclusion entry contains no path separators, it matches against the process's name only
          *
-         * The pattern matching is performed case-insensitively using substring matching.
-         * The function automatically excludes the current process (by process ID) to prevent self-matching.
+         * Matching semantics:
+         *   - A NAME entry (no path separator) matches the process's bare name ANCHORED to the
+         *     whole filename: an exact match, or the entry as the filename stem immediately followed
+         *     by '.' (so a short pattern like "NOTE" does not match "EVILNOTE.EXE").
+         *   - A PATH entry (contains '/' or '\\') matches as a SUBSTRING against the full path.
+         *   - An EMPTY entry ("") is the CATCH-ALL: it matches ANY process not in the exclusion list.
+         * Comparisons are effectively case-insensitive because inputs are already upper-cased by the
+         * caller. The function automatically excludes the current process (by PID) to prevent self-matching.
          *
          * @param app The application name or pattern to check against the process details.
          *            Can be either a simple process name (e.g., "notepad.exe") or a path-based pattern (e.g., "C:\\Windows\\System32\\notepad.exe").


### PR DESCRIPTION
## Problem

A proxy configured with `"appNames": [""]` used to be a **catch-all** that matched every process. It stopped working — it now logs `has no application names; it will not match any process` and matches nothing.

## Root cause (both pre-date #148)

The empty-string catch-all worked because matching used a substring `find`, and `find("")` returns `0` (matches everything). Two prior hardening changes each broke it independently:

- **#142** added `AppNames.RemoveAll(string.IsNullOrWhiteSpace)` in `Program.cs` — strips `""` before it reaches the native layer, leaving an empty list.
- **#144** replaced substring matching with anchored `name_matches()`, whose `entry.empty()` branch returns `false`.

## Fix

- **`socks_local_router::match_app_name`** — after the exclusion checks, treat an empty `app` pattern as the catch-all (`return true` = match any non-excluded process). Non-empty names keep #144's anchored matching (so a short pattern still can't match an unrelated process, e.g. `NOTE` → `EVILNOTE.EXE`), and empty **exclude** entries still match nothing (`name_matches` is unchanged).
- **`Program.cs`** — strip only `null` and whitespace-only app names (a `null String^` throws in `marshal_as<std::wstring>`), but **preserve** an explicit `""` so the catch-all reaches the unmanaged layer. Logs an info line when a catch-all proxy is configured.

With the reporter's config, `chrome` → its proxy, everything else (except excluded `firefox`) → the `[""]` catch-all proxy, as before.

**Build:** clean, Debug x64, 0 errors / 0 warnings (incl. Code Analysis).