### PR TITLE
docs(readme): correct appNames matching semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ LogLevel can have one of the following values which define the detail of the log
 
 - A **name** entry (no slashes) matches the executable's filename, **anchored** to the whole name.  
   - `firefox` or `firefox.exe` both match `firefox.exe`.  
-  - It matches the exact name, or the name followed by an extension — so `firefox` matches `firefox.exe` but **not** `NewFirefox.exe` (a short pattern won't match an unrelated executable).  
+  - It matches the exact name, or the name followed by an extension such as `.exe` — so `firefox` matches `firefox.exe` but **not** `NewFirefox.exe` (a short pattern won't match an unrelated executable).  
 - If the pattern contains **slashes or backslashes**, it is treated as a **pathname** and matched as a substring of the process's full path.  
   - This allows targeting an entire folder (useful for UWP apps).  
   - Example: `C:\\Program Files\\WindowsApps\\ROBLOXCORPORATION.ROBLOX`  
-- An **empty string** (`""`) is a **catch-all** that matches every process not listed in `excludes`. Use it for a default/fallback proxy — and list it **last**, since proxies are matched in order and a catch-all shadows any proxy defined after it.
+- An **empty string** (`""`) is a **catch-all** that matches every process not already matched by a prior proxy and not listed in `excludes`. Use it for a default/fallback proxy — and place this proxy **last** in the `proxies` list, since proxies are matched in order and a catch-all shadows any proxy defined after it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ LogLevel can have one of the following values which define the detail of the log
 
 ### appNames
 
-- The application name can be a **partial** or **full name** of the executable.  
-  - Example: `firefox` or `firefox.exe` will both match the Firefox browser.  
-  - Any application containing that substring will also match, e.g., `NewFirefox.exe`.  
-- If the pattern contains **slashes or backslashes**, it is treated as a **pathname**.  
+- A **name** entry (no slashes) matches the executable's filename, **anchored** to the whole name.  
+  - `firefox` or `firefox.exe` both match `firefox.exe`.  
+  - It matches the exact name, or the name followed by an extension — so `firefox` matches `firefox.exe` but **not** `NewFirefox.exe` (a short pattern won't match an unrelated executable).  
+- If the pattern contains **slashes or backslashes**, it is treated as a **pathname** and matched as a substring of the process's full path.  
   - This allows targeting an entire folder (useful for UWP apps).  
-  - Example: `C:\\Program Files\\WindowsApps\\ROBLOXCORPORATION.ROBLOX`
+  - Example: `C:\\Program Files\\WindowsApps\\ROBLOXCORPORATION.ROBLOX`  
+- An **empty string** (`""`) is a **catch-all** that matches every process not listed in `excludes`. Use it for a default/fallback proxy — and list it **last**, since proxies are matched in order and a catch-all shadows any proxy defined after it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ LogLevel can have one of the following values which define the detail of the log
 
 ### appNames
 
-- A **name** entry (no slashes) matches the executable's filename, **anchored** to the whole name.  
+- A **name** entry (one that contains neither `/` nor `\`) matches the executable's filename, **anchored** to the whole name.  
   - `firefox` or `firefox.exe` both match `firefox.exe`.  
   - It matches the exact name, or the name followed by an extension such as `.exe` — so `firefox` matches `firefox.exe` but **not** `NewFirefox.exe` (a short pattern won't match an unrelated executable).  
 - If the pattern contains **slashes or backslashes**, it is treated as a **pathname** and matched as a substring of the process's full path.  


### PR DESCRIPTION
Corrects the `appNames` documentation, which still described **substring** matching (`any application containing that substring will also match, e.g. NewFirefox.exe`). Matching was changed to **anchored** filename matching in #144, so that description is now wrong.

Updated to document:
- **Anchored name matching** — exact name, or name + extension. `firefox` matches `firefox.exe` but **not** `NewFirefox.exe`.
- **Path entries** (with a separator) match as a substring of the full path.
- The **empty-string `""` catch-all** — matches every non-excluded process; should be listed last since a catch-all shadows any proxy defined after it.

Docs-only; targets the v2.3.0 release.