### PR TITLE
fix: pre-release hardening for v2.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,9 @@ jobs:
           path: 'bin\\exe\\${{ matrix.platform }}\\${{ matrix.build_configuration }}\\ProxiFyre-${{ github.ref_name }}-${{ matrix.platform }}.zip'
 
   upload-release:
-    if: ${{ always() }}
+    # Only publish when EVERY matrix build (x86/x64/ARM64) succeeded. Without this gate the job
+    # ran on `always()`, so a single failed platform build would publish a partial release that is
+    # missing an architecture's zip -- and `skipIfReleaseExists` then blocks a retry from fixing it.
     needs: build-and-package
     runs-on: windows-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ LogLevel can have one of the following values which define the detail of the log
 The `excludes` section lets you define processes that should **bypass the proxy**.  
 This is useful when you want a global proxy setup but keep certain apps (like browsers, local dev tools, or games) unproxied.
 
+Unlike `appNames`, exclusion entries match by **substring** (a name is matched against the process's filename, a path-form entry against the full path) — so `chrome` also excludes `chrome_proxy.exe`. Exclusion is deliberately permissive so an app you meant to keep direct is not accidentally proxied.
+
 Example:
 
 ```json

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1539,7 +1539,7 @@ namespace proxy
             // cannot match every process.
             for (const auto& excluded_entry : excluded_list_) {
                 if (!excluded_entry.empty() &&
-                    ((excluded_entry.find(L'\\') != std::wstring::npos || excluded_entry.find(L'/') != std::wstring::npos)
+                    ((excluded_entry.find_first_of(L"\\/") != std::wstring::npos)
                         ? (process->path_name.find(excluded_entry) != std::wstring::npos)
                         : (process->name.find(excluded_entry) != std::wstring::npos))
                     ) {

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -1530,11 +1530,18 @@ namespace proxy
                     && name[entry.size()] == L'.';
             };
 
-            // Check exclusion list
+            // Check exclusion list. Excludes use SUBSTRING matching for BOTH name and path forms.
+            // An exclusion is a safety / bypass rule ("keep this app OUT of the proxy"), so it must
+            // be permissive -- matching more processes rather than fewer -- to avoid accidentally
+            // routing traffic the user meant to keep direct (a real risk when combined with a ""
+            // catch-all proxy). This preserves the pre-v2.3.0 behavior; appName matching above stays
+            // anchored (where being precise is the safe direction). An empty entry is ignored so it
+            // cannot match every process.
             for (const auto& excluded_entry : excluded_list_) {
-                if ((excluded_entry.find(L'\\') != std::wstring::npos || excluded_entry.find(L'/') != std::wstring::npos)
-                    ? (process->path_name.find(excluded_entry) != std::wstring::npos)
-                    : name_matches(process->name, excluded_entry)
+                if (!excluded_entry.empty() &&
+                    ((excluded_entry.find(L'\\') != std::wstring::npos || excluded_entry.find(L'/') != std::wstring::npos)
+                        ? (process->path_name.find(excluded_entry) != std::wstring::npos)
+                        : (process->name.find(excluded_entry) != std::wstring::npos))
                     ) {
                     process->excluded = true;
                     return false; // Excluded

--- a/netlib/src/winsys/io_completion_port.h
+++ b/netlib/src/winsys/io_completion_port.h
@@ -354,7 +354,7 @@ namespace netlib::winsys
                     {
                         state->callback(num_bytes, overlapped_ptr, ok);
                     }
-                    catch (const std::exception& e)
+                    catch ([[maybe_unused]] const std::exception& e)
                     {
 #ifdef _DEBUG
                         try

--- a/sign/sign-update-release.ps1
+++ b/sign/sign-update-release.ps1
@@ -23,12 +23,18 @@ foreach ($file in $files) {
     # Sign every shipped binary inside the extracted folder: the launcher (ProxiFyre.exe) AND the
     # native engine (socksify.dll). Signing only the .exe left the DLL that actually performs the
     # packet redirection unsigned, which undermines signature-verification / allow-listing policies.
-    $binaries = @("ProxiFyre.exe", "socksify.dll") |
-        ForEach-Object { Join-Path $extractPath $_ } |
-        Where-Object { Test-Path $_ }
-    foreach ($bin in $binaries) {
+    # Fail LOUDLY: assert each expected binary exists and abort if signtool reports an error, so a
+    # missing/partially-signed artifact is never published as a "signed" release.
+    $expectedBinaries = @("ProxiFyre.exe", "socksify.dll")
+    foreach ($name in $expectedBinaries) {
+        $bin = Join-Path $extractPath $name
+        if (-not (Test-Path $bin)) {
+            throw "Expected binary '$name' not found in '$extractPath'; aborting signing of $file."
+        }
         & signtool sign /fd sha1 /t http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $bin
+        if ($LASTEXITCODE -ne 0) { throw "signtool (SHA-1) failed for '$bin' (exit $LASTEXITCODE)." }
         & signtool sign /as /td sha256 /fd sha256 /tr http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $bin
+        if ($LASTEXITCODE -ne 0) { throw "signtool (SHA-256 append) failed for '$bin' (exit $LASTEXITCODE)." }
     }
 
     # Change to the directory of the folder to be zipped

--- a/sign/sign-update-release.ps1
+++ b/sign/sign-update-release.ps1
@@ -20,10 +20,16 @@ foreach ($file in $files) {
     $extractPath = "./" + $file -replace ".zip", ""
     Expand-Archive -Path $downloadPath -DestinationPath $extractPath -Force
 
-    # Sign the executable inside the extracted folder
-    $exePath = $extractPath + "/ProxiFyre.exe"
-    & signtool sign /fd sha1 /t http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $exePath
-    & signtool sign /as /td sha256 /fd sha256 /tr http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $exePath
+    # Sign every shipped binary inside the extracted folder: the launcher (ProxiFyre.exe) AND the
+    # native engine (socksify.dll). Signing only the .exe left the DLL that actually performs the
+    # packet redirection unsigned, which undermines signature-verification / allow-listing policies.
+    $binaries = @("ProxiFyre.exe", "socksify.dll") |
+        ForEach-Object { Join-Path $extractPath $_ } |
+        Where-Object { Test-Path $_ }
+    foreach ($bin in $binaries) {
+        & signtool sign /fd sha1 /t http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $bin
+        & signtool sign /as /td sha256 /fd sha256 /tr http://timestamp.digicert.com /n "The Anti-Cloud Corporation" $bin
+    }
 
     # Change to the directory of the folder to be zipped
     Push-Location $extractPath

--- a/socksify/AssemblyInfo.cpp
+++ b/socksify/AssemblyInfo.cpp
@@ -15,6 +15,9 @@ using namespace System::Security::Permissions;
 [assembly:AssemblyTrademarkAttribute(L"")];
 [assembly:AssemblyCultureAttribute(L"")];
 
-[assembly:AssemblyVersionAttribute("2.0.*")];
+// Keep the major.minor in sync with the release tag. (The build-revision wildcard auto-fills
+// the last two fields.) A prior release left this at 2.0.* while ProxiFyre.exe advanced, so the
+// shipped socksify.dll reported a stale version; bumped for the 2.3.x line.
+[assembly:AssemblyVersionAttribute("2.3.*")];
 
 [assembly:ComVisible(false)];


### PR DESCRIPTION
Pre-release fixes for **v2.3.0** from the deep pre-release review (0 release blockers were found; these are the quality/mechanics items worth landing before tagging). Verified: **x64 / x86 / ARM64 Release all build clean, 0 warnings.**

### 1. Restore substring matching for `excludes` (regression — High)
#144 introduced anchored name matching and applied it to the exclusion list too, so a bare-name exclude like `"svc"` stopped excluding `SVCHOST.EXE`. That silently routes traffic a user deliberately told ProxiFyre to **bypass** — dangerous when combined with a `""` catch-all proxy. Excludes are a safety/bypass rule and should be **permissive** (substring); `appNames` matching stays **anchored** (where precision is the safe direction). Empty entries are ignored so they can't match every process. Documented in the README Excludes section.

### 2. `socksify.dll` version (Medium)
`AssemblyVersion` was left at `2.0.*` while `ProxiFyre.exe` advanced, so the shipped engine DLL is mis-versioned. Bumped to `2.3.*`. _(Full `$(Version)`-from-tag injection is a better long-term fix but wants a CI test cycle; this keeps the major.minor correct for the 2.3.x line.)_

### 3. CI: gate the release publish (Medium)
`upload-release` ran on `if: always()`, so a failed platform build would publish a **partial** release (missing an arch's zip), and `skipIfReleaseExists` then blocks a retry. Removed — the default `needs:` gating publishes only when all three matrix builds succeed.

### 4. Sign `socksify.dll` (Medium)
The signing script signed only `ProxiFyre.exe`, leaving the native packet-redirection DLL **unsigned**. Now signs both binaries per extracted archive.

### 5. `C4101` warning (Low)
`catch (const std::exception& e)` used `e` only under `#ifdef _DEBUG`, so Release warned on every build. Marked `[[maybe_unused]]`.

**Not included (your calls, per the review):** excludes-anchored-vs-substring (this PR takes the substring/safe default), pcap-at-`debug` gating, tracking `RELEASE_NOTES_2.3.0.md`, and packaging `app-config.sample.json` into the zip.