### PR TITLE
Clean up netlib packet and proxy helpers

### DIFF
--- a/netlib/src/iphelper/network_adapter_info.h
+++ b/netlib/src/iphelper/network_adapter_info.h
@@ -76,12 +76,40 @@ namespace iphelper
         }
 
         /// <summary>
+        /// Validates SOCKET_ADDRESS for safe use: non-null pointer, length within
+        /// [sizeof(sockaddr) .. sizeof(SOCKADDR_STORAGE)], and family-appropriate
+        /// minimum size (sizeof(sockaddr_in) for AF_INET, sizeof(sockaddr_in6) for AF_INET6).
+        /// </summary>
+        /// <param name="address">SOCKET_ADDRESS to validate</param>
+        /// <returns>true if the address is safe to copy, false otherwise</returns>
+        [[nodiscard]] static bool is_valid_socket_address(const SOCKET_ADDRESS& address) noexcept
+        {
+            if (address.lpSockaddr == nullptr ||
+                address.iSockaddrLength < static_cast<int>(sizeof(sockaddr)) ||
+                static_cast<size_t>(address.iSockaddrLength) > sizeof(SOCKADDR_STORAGE))
+                return false;
+
+            switch (address.lpSockaddr->sa_family)
+            {
+            case AF_INET:
+                return address.iSockaddrLength >= static_cast<int>(sizeof(sockaddr_in));
+            case AF_INET6:
+                return address.iSockaddrLength >= static_cast<int>(sizeof(sockaddr_in6));
+            default:
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Constructs ip_address_info from SOCKET_ADDRESS
         /// </summary>
         /// <param name="address"></param>
         explicit ip_address_info(const SOCKET_ADDRESS& address) : SOCKADDR_STORAGE()
         {
-            memcpy(this, address.lpSockaddr, address.iSockaddrLength);
+            if (is_valid_socket_address(address))
+            {
+                memcpy(this, address.lpSockaddr, address.iSockaddrLength);
+            }
         }
 
         /// <summary>
@@ -316,21 +344,24 @@ namespace iphelper
             auto* unicast_address = address->FirstUnicastAddress;
             while (unicast_address)
             {
-                unicast_address_list_.emplace_back(unicast_address->Address);
+                if (ip_address_info::is_valid_socket_address(unicast_address->Address))
+                    unicast_address_list_.emplace_back(unicast_address->Address);
                 unicast_address = unicast_address->Next;
             }
 
             auto* dns_address = address->FirstDnsServerAddress;
             while (dns_address)
             {
-                dns_server_address_list_.emplace_back(dns_address->Address);
+                if (ip_address_info::is_valid_socket_address(dns_address->Address))
+                    dns_server_address_list_.emplace_back(dns_address->Address);
                 dns_address = dns_address->Next;
             }
 
             auto* gateway_address = address->FirstGatewayAddress;
             while (gateway_address)
             {
-                gateway_address_list_.emplace_back(gateway_address->Address);
+                if (ip_address_info::is_valid_socket_address(gateway_address->Address))
+                    gateway_address_list_.emplace_back(gateway_address->Address);
                 gateway_address = gateway_address->Next;
             }
 
@@ -513,6 +544,25 @@ namespace iphelper
                     }
                 }
             return gateway_address_list_;
+        }
+
+        /// <summary>
+        /// Returns true if this adapter has at least one configured gateway of the given
+        /// address family (AF_INET or AF_INET6).
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="get_gateway_address_list"/>, this method does NOT trigger hardware
+        /// address resolution (<c>ResolveIpNetEntry2</c>) for Ethernet/Wi-Fi adapters. It only
+        /// inspects the gateway list populated at construction time, so it is safe to call on
+        /// hot paths that merely need to know whether an IPv4 or IPv6 default-route family is
+        /// configured - e.g. when selecting the default uplink for network-lock drop filters.
+        /// </remarks>
+        /// <param name="address_family">Address family to look for, typically <c>AF_INET</c> or <c>AF_INET6</c>.</param>
+        /// <returns>true if at least one gateway of that family is configured, false otherwise.</returns>
+        [[nodiscard]] bool has_gateway_of_family(const ADDRESS_FAMILY address_family) const noexcept
+        {
+            return std::ranges::any_of(gateway_address_list_,
+                [address_family](const ip_gateway_info& gw) noexcept { return gw.ss_family == address_family; });
         }
 
         /// <summary>
@@ -1083,10 +1133,14 @@ namespace iphelper
         }
 
         /// <summary>
-        /// Deletes routing table entries by MIB_IPFORWARD_ROW2 pointers
+        /// Deletes routing table entries by MIB_IPFORWARD_ROW2 pointers. Every row is attempted
+        /// regardless of individual failures so as much of the batch as possible gets removed,
+        /// but the thread-local GetLastError() is set to the *first* failing DeleteIpForwardEntry2
+        /// code (not the last), so callers can rely on "first failure wins" semantics.
         /// </summary>
         /// <param name="address">vector of MIB_IPFORWARD_ROW2 unique pointers</param>
-        /// <returns>true if successful, false otherwise</returns>
+        /// <returns>true if every delete succeeded, false otherwise (GetLastError() carries the
+        /// first failure's code in the false case)</returns>
         [[nodiscard]] static bool delete_routes(std::vector<std::unique_ptr<MIB_IPFORWARD_ROW2>> address)
         {
             auto status = true;
@@ -1095,10 +1149,13 @@ namespace iphelper
 
             std::ranges::for_each(address, [&status](auto&& a) noexcept
             {
-                if (const auto error_code = ::DeleteIpForwardEntry2(a.get()); NOERROR != error_code)
+                if (const auto error_code = ::DeleteIpForwardEntry2(a.get()); NO_ERROR != error_code)
                 {
-                    status = false;
-                    ::SetLastError(error_code);
+                    if (status) // only the first failing row records its error code
+                    {
+                        ::SetLastError(error_code);
+                        status = false;
+                    }
                 }
             });
 
@@ -1132,6 +1189,70 @@ namespace iphelper
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Aggregate status returned from delete_default_routes(). Separates the
+        /// "found nothing to delete" case from the "found rows but some deletes failed"
+        /// case, and surfaces the last observed DeleteIpForwardEntry2 error code without
+        /// forcing callers to consult thread-local GetLastError() (which may be clobbered
+        /// by unrelated calls between the sweep and the caller reading it).
+        /// </summary>
+        struct default_route_sweep_result  // NOLINT(clang-diagnostic-padded)
+        {
+            std::size_t deleted{ 0 };           ///< rows the sweep successfully removed
+            std::size_t failed{ 0 };            ///< rows that matched but whose DeleteIpForwardEntry2 failed
+            DWORD       last_error{ NO_ERROR }; ///< error code from the last failing DeleteIpForwardEntry2 call
+        };
+
+        /// <summary>
+        /// Deletes any default-route (prefix length 0) rows whose InterfaceLuid matches this
+        /// adapter's LUID. Narrower than reset_adapter_routes(): subnet routes and auto-generated
+        /// entries are preserved, so this is safe to call as a best-effort sweep on an adapter
+        /// that is still in active use.
+        /// </summary>
+        /// <returns>a default_route_sweep_result with per-row counts on success, or
+        /// std::nullopt when the forwarding table itself could not be queried (the
+        /// GetIpForwardTable2 error is propagated via SetLastError in that case).</returns>
+        [[nodiscard]] std::optional<default_route_sweep_result> delete_default_routes() const noexcept
+        {
+            PMIB_IPFORWARD_TABLE2 table = nullptr;
+
+            const auto error_code = GetIpForwardTable2(AF_UNSPEC, &table);
+            if (NO_ERROR != error_code)
+            {
+                SetLastError(error_code);
+                return std::nullopt;
+            }
+
+            default_route_sweep_result result{};
+            for (unsigned i = 0; i < table->NumEntries; ++i)
+            {
+                if (table->Table[i].DestinationPrefix.PrefixLength == 0 &&
+                    table->Table[i].InterfaceLuid == luid_)
+                {
+                    if (const auto delete_status = DeleteIpForwardEntry2(&table->Table[i]); delete_status == NO_ERROR)
+                    {
+                        ++result.deleted;
+                    }
+                    else
+                    {
+                        ++result.failed;
+                        result.last_error = delete_status;
+                    }
+                }
+            }
+
+            FreeMibTable(table);
+
+            // Normalise thread-local GetLastError() so ad-hoc callers that only inspect it see
+            // exactly what this sweep observed: either ERROR_SUCCESS on a clean run (including
+            // the common "nothing matched" case) or the last per-row delete failure code.
+            // Without the explicit success write, a stale unrelated error from earlier in the
+            // thread would linger and be misattributed to the sweep.
+            SetLastError(result.failed > 0 ? result.last_error : ERROR_SUCCESS);
+
+            return result;
         }
 
         /// <summary>
@@ -1445,6 +1566,9 @@ namespace iphelper
                 SetLastError(error_code);
                 return ret_val;
             }
+
+            // Pre-allocate to reduce heap reallocations during emplace_back
+            ret_val.reserve(mib_table->NumEntries);
 
             error_code = GetAdaptersAddresses(AF_UNSPEC,
                 GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
@@ -2047,7 +2171,8 @@ public:
                     dest_address.si_family = AF_INET;
                     dest_address.Ipv4.sin_family = AF_INET;
                     dest_address.Ipv4.sin_addr = ip_address;
-                    MIB_IPFORWARD_ROW2 forward_row{};
+                    MIB_IPFORWARD_ROW2 forward_row;
+                    InitializeIpForwardEntry(&forward_row);
 
                     if (const auto error_code = GetBestRoute2(nullptr, adapter.get_if_index(), nullptr, &dest_address, 0,
                         &forward_row, &best_route_address); NO_ERROR != error_code)
@@ -2078,7 +2203,8 @@ public:
                     dest_address.si_family = AF_INET6;
                     dest_address.Ipv6.sin6_family = AF_INET6;
                     dest_address.Ipv6.sin6_addr = ip_address;
-                    MIB_IPFORWARD_ROW2 forward_row{};
+                    MIB_IPFORWARD_ROW2 forward_row;
+                    InitializeIpForwardEntry(&forward_row);
 
                     if (const auto error_code = GetBestRoute2(nullptr, adapter.get_if_index(), nullptr, &dest_address, 0,
                         &forward_row, &best_route_address); NO_ERROR != error_code)

--- a/netlib/src/iphelper/process_lookup.h
+++ b/netlib/src/iphelper/process_lookup.h
@@ -11,7 +11,7 @@ namespace iphelper
      * including process ID, name, executable path, and device path. All string fields are
      * automatically converted to uppercase for consistent matching.
      */
-    struct network_process
+    struct network_process  // NOLINT(clang-diagnostic-padded)
     {
         /**
          * @brief Default constructor.
@@ -29,10 +29,10 @@ namespace iphelper
          *       device path is computed from the provided path.
          */
         network_process(const unsigned long id, std::wstring name, std::wstring path)
-            : id(id),
-            name(std::move(name)),
+            : name(std::move(name)),
             path_name(std::move(path)),
-            device_path_name(convert_to_device_path(path_name))
+            device_path_name(convert_to_device_path(path_name)),
+            id(id)
         {
             this->name = to_upper(this->name);
             this->path_name = to_upper(this->path_name);
@@ -108,10 +108,10 @@ namespace iphelper
             return upper_case;
         }
 
-        unsigned long id{};                 ///< Process ID
         std::wstring name;                  ///< Process name (uppercase)
         std::wstring path_name;             ///< Full path to executable (uppercase)
         std::wstring device_path_name;      ///< Device path version of path_name (uppercase)
+        unsigned long id{};                 ///< Process ID
         std::optional<uint16_t> tcp_proxy_port = std::nullopt; // Optional TCP proxy port if the process is associated with a proxy
         std::optional<uint16_t> udp_proxy_port = std::nullopt; // Optional UDP proxy port if the process is associated with a proxy
         // These cache flags can be set from match_app_name()/packet handlers running on
@@ -782,9 +782,7 @@ namespace iphelper
         /// </summary>
         static bool is_unspecified_v6_address(const UCHAR(&addr)[16]) noexcept
         {
-            for (int i = 0; i < 16; ++i)
-                if (addr[i] != 0) return false;
-            return true;
+            return std::ranges::all_of(addr, [](const unsigned char i) { return i == 0; });
         }
 
         /// <summary>

--- a/netlib/src/ndisapi/intermediate_buffer.h
+++ b/netlib/src/ndisapi/intermediate_buffer.h
@@ -1,15 +1,19 @@
 // ReSharper disable CppClangTidyBugproneCopyConstructorInit
 #pragma once
 
-namespace ndisapi
+namespace netlib::ndisapi
 {
     /**
      * @class intermediate_buffer
      * @brief This class is a wrapper around the _INTERMEDIATE_BUFFER structure.
      *
-     * @details It provides constructors for default initialization, copy initialization, move initialization,
-     * and initialization from _INTERMEDIATE_BUFFER. It also provides copy and move assignment operators.
-     * The class contains private helper methods for copy and move operations.
+     * @details This is a trivially copyable wrapper that provides type safety while maintaining
+     * binary compatibility with _INTERMEDIATE_BUFFER. All copy/move operations are performed
+     * using default (trivial) implementations.
+     *
+     * @note In user mode the m_hAdapter/m_qLink union is used as the adapter handle.
+     * m_qLink is kernel-only queue metadata, so user-mode copies may preserve the
+     * complete _INTERMEDIATE_BUFFER layout without maintaining list links.
      */
     class intermediate_buffer : public _INTERMEDIATE_BUFFER {
     public:
@@ -25,81 +29,42 @@ namespace ndisapi
          * @brief Destructor.
          */
         ~intermediate_buffer() = default;
+
+        /**
+         * @brief Copy constructor (defaulted for trivial copyability).
+         */
+        intermediate_buffer(const intermediate_buffer&) = default;
+
+        /**
+         * @brief Move constructor (defaulted for trivial copyability).
+         */
+        intermediate_buffer(intermediate_buffer&&) noexcept = default;
+
+        /**
+         * @brief Copy assignment operator (defaulted for trivial copyability).
+         */
+        intermediate_buffer& operator=(const intermediate_buffer&) = default;
+
+        /**
+         * @brief Move assignment operator (defaulted for trivial copyability).
+         */
+        intermediate_buffer& operator=(intermediate_buffer&&) noexcept = default;
+
         /**
          * @brief Constructor that initializes the object from a _INTERMEDIATE_BUFFER instance.
          * @param other The _INTERMEDIATE_BUFFER instance to initialize from.
          */
-        explicit intermediate_buffer(const _INTERMEDIATE_BUFFER& other) {
-            assign(other);
-        }
-        /**
-         * @brief Copy constructor.
-         * @param other The intermediate_buffer instance to copy from.
-         */
-        intermediate_buffer(const intermediate_buffer& other)
+        explicit intermediate_buffer(const _INTERMEDIATE_BUFFER& other)
+            : _INTERMEDIATE_BUFFER(other)
         {
-            assign(other);
-        }
-        /**
-         * @brief Move constructor.
-         * @param other The intermediate_buffer instance to move from.
-         */
-        intermediate_buffer(intermediate_buffer&& other) noexcept {
-            move(std::move(other));
-        }
-        /**
-         * @brief Copy assignment operator.
-         * @param other The intermediate_buffer instance to copy from.
-         * @return A reference to the current instance.
-         */
-        intermediate_buffer& operator=(const intermediate_buffer& other) {
-            if (this != &other) {
-                assign(other);
-            }
-            return *this;
-        }
-        /**
-         * @brief Move assignment operator.
-         * @param other The intermediate_buffer instance to move from.
-         * @return A reference to the current instance.
-         */
-        intermediate_buffer& operator=(intermediate_buffer&& other) noexcept {
-            if (this != &other) {
-                move(std::move(other));
-            }
-            return *this;
-        }
-    private:
-        /**
-         * @brief Helper method for copy operations.
-         * @tparam T The type of the other object (can be intermediate_buffer or _INTERMEDIATE_BUFFER).
-         * @param other The object to copy from.
-         */
-        template<typename T>
-        void assign(const T& other) {
-            m_hAdapter = other.m_hAdapter;
-            m_dwDeviceFlags = other.m_dwDeviceFlags;
-            m_Length = other.m_Length;
-            m_Flags = other.m_Flags;
-            m_8021q = other.m_8021q;
-            m_FilterID = other.m_FilterID;
-            std::copy_n(other.m_Reserved, 4, m_Reserved);
-            std::copy_n(other.m_IBuffer, other.m_Length, m_IBuffer);
-        }
-        /**
-         * @brief Helper method for move operations.
-         * @param other The object to move from.
-         */
-        void move(intermediate_buffer&& other) noexcept {
-            m_hAdapter = other.m_hAdapter;
-            m_dwDeviceFlags = other.m_dwDeviceFlags;
-            m_Length = other.m_Length;
-            m_Flags = other.m_Flags;
-            m_8021q = other.m_8021q;
-            m_FilterID = other.m_FilterID;
-            std::copy_n(other.m_Reserved, 4, m_Reserved);
-            std::copy_n(other.m_IBuffer, other.m_Length, m_IBuffer);
+            static_assert(sizeof(intermediate_buffer) == sizeof(_INTERMEDIATE_BUFFER),
+                "Size of intermediate_buffer is not the same as _INTERMEDIATE_BUFFER");
+            static_assert(std::is_trivially_copyable_v<intermediate_buffer>,
+                "intermediate_buffer must be trivially copyable");
         }
     };
-}
 
+    // Compile-time verification
+    static_assert(std::is_trivially_copyable_v<intermediate_buffer>,
+        "intermediate_buffer must be trivially copyable");
+}

--- a/netlib/src/ndisapi/intermediate_buffer_pool.h
+++ b/netlib/src/ndisapi/intermediate_buffer_pool.h
@@ -3,7 +3,7 @@
 #include <boost/pool/object_pool.hpp>
 #include <mutex>
 
-namespace ndisapi
+namespace netlib::ndisapi
 {
     /// <summary>
     /// A singleton class that manages a pool of intermediate_buffer objects.
@@ -19,6 +19,21 @@ namespace ndisapi
         /// Deleted copy assignment operator to prevent copying.
         /// </summary>
         intermediate_buffer_pool& operator=(const intermediate_buffer_pool&) = delete;
+
+        /// <summary>
+        /// Default move constructor.
+        /// </summary>
+        intermediate_buffer_pool(intermediate_buffer_pool&&) noexcept = delete;
+
+        /// <summary>
+        /// Default move assignment operator.
+        /// </summary>
+        intermediate_buffer_pool& operator=(intermediate_buffer_pool&&) noexcept = delete;
+
+        /// <summary>
+        /// Default destructor.
+        /// </summary>
+        ~intermediate_buffer_pool() = default;
 
         /// <summary>
         /// Accessor for the singleton instance.
@@ -38,13 +53,8 @@ namespace ndisapi
             /// </summary>
             /// <param name="ptr">Pointer to the intermediate_buffer object to be deleted.</param>
             void operator()(intermediate_buffer* ptr) const {
-                // boost::object_pool is NOT thread-safe: construct()/destroy() both mutate
-                // the shared free list. This singleton is used concurrently by the packet-
-                // filter thread (allocate) and the resolver thread (destroy), so every
-                // access must be serialized to avoid free-list/heap corruption.
-                auto& pool = instance();
-                std::lock_guard<std::mutex> lock(pool.pool_mutex_);
-                pool.pool_.destroy(ptr);
+                std::scoped_lock lock(instance().mutex_);
+                instance().pool_.destroy(ptr);
             }
         };
 
@@ -55,20 +65,18 @@ namespace ndisapi
         /// </summary>
         /// <returns>A unique_ptr to the allocated intermediate_buffer object, or nullptr if allocation fails.</returns>
         intermediate_buffer_ptr allocate() {
+            std::scoped_lock lock(instance().mutex_);
+            intermediate_buffer* raw_ptr;
+
             try {
-                intermediate_buffer* raw_ptr;
-                {
-                    // Serialize with destroy() (see deleter): boost::object_pool has no
-                    // internal locking and is mutated from multiple threads here.
-                    std::lock_guard<std::mutex> lock(pool_mutex_);
-                    raw_ptr = pool_.construct(); // This might throw
-                }
+                raw_ptr = pool_.construct(); // This might throw
                 std::fill_n(reinterpret_cast<char*>(raw_ptr), offsetof(_INTERMEDIATE_BUFFER, m_IBuffer), 0);
-                return intermediate_buffer_ptr(raw_ptr, deleter{});
             }
             catch (...) {
-                return nullptr; // Return a null std::unique_ptr
+                return nullptr;
             }
+
+            return intermediate_buffer_ptr(raw_ptr, deleter{});
         }
 
         /// <summary>
@@ -85,21 +93,6 @@ namespace ndisapi
             return buffer; // Return the allocated buffer or nullptr if allocation failed
         }
 
-        /// <summary>
-        /// Default destructor.
-        /// </summary>
-        ~intermediate_buffer_pool() = default;
-
-        /// <summary>
-        /// Default move constructor.
-        /// </summary>
-        intermediate_buffer_pool(intermediate_buffer_pool&&) noexcept = delete;
-
-        /// <summary>
-        /// Default move assignment operator.
-        /// </summary>
-        intermediate_buffer_pool& operator=(intermediate_buffer_pool&&) noexcept = delete;
-
     private:
         /// <summary>
         /// Private constructor for singleton.
@@ -109,9 +102,7 @@ namespace ndisapi
             : pool_(initial_size) {
         }
 
-        // Declared before pool_ so it is destroyed after it (members are torn down in
-        // reverse declaration order). Guards every construct()/destroy() on pool_.
-        std::mutex pool_mutex_;
+        std::mutex mutex_; ///< Mutex to protect the pool.
         boost::object_pool<intermediate_buffer> pool_; ///< The pool of intermediate_buffer objects.
     };
 }

--- a/netlib/src/ndisapi/intermediate_buffer_pool.h
+++ b/netlib/src/ndisapi/intermediate_buffer_pool.h
@@ -65,11 +65,13 @@ namespace netlib::ndisapi
         /// </summary>
         /// <returns>A unique_ptr to the allocated intermediate_buffer object, or nullptr if allocation fails.</returns>
         intermediate_buffer_ptr allocate() {
-            std::scoped_lock lock(instance().mutex_);
+            std::scoped_lock lock(mutex_);
             intermediate_buffer* raw_ptr;
 
             try {
                 raw_ptr = pool_.construct(); // This might throw
+                if (raw_ptr == nullptr)
+                    return nullptr;
                 std::fill_n(reinterpret_cast<char*>(raw_ptr), offsetof(_INTERMEDIATE_BUFFER, m_IBuffer), 0);
             }
             catch (...) {

--- a/netlib/src/ndisapi/queued_multi_interface_packet_filter.h
+++ b/netlib/src/ndisapi/queued_multi_interface_packet_filter.h
@@ -37,13 +37,13 @@ namespace ndisapi
         /// Number of successfully read packets in this block.
         uint32_t packets_success_{ 0 };
         /// Array of packet buffers.
-        std::array<intermediate_buffer, Size> packet_buffer_;
+        std::array<netlib::ndisapi::intermediate_buffer, Size> packet_buffer_;
         /// Array of pointers for batch reading packets.
-        std::array<intermediate_buffer*, Size> read_request_;
+        std::array<netlib::ndisapi::intermediate_buffer*, Size> read_request_;
         /// Vector of pointers to packets to be written to the adapter.
-        std::vector<intermediate_buffer*> write_adapter_request_;
+        std::vector<netlib::ndisapi::intermediate_buffer*> write_adapter_request_;
         /// Vector of pointers to packets to be written up to the protocol stack.
-        std::vector<intermediate_buffer*> write_mstcp_request_;
+        std::vector<netlib::ndisapi::intermediate_buffer*> write_mstcp_request_;
 
     public:
         /**
@@ -67,7 +67,7 @@ namespace ndisapi
          * @brief Returns the array of pointers for batch reading packets.
          * @return Const reference to the read pointer array.
          */
-        [[nodiscard]] const std::array<intermediate_buffer*, Size>& get_read_request() const
+        [[nodiscard]] const std::array<netlib::ndisapi::intermediate_buffer*, Size>& get_read_request() const
         {
             return read_request_;
         }
@@ -76,7 +76,7 @@ namespace ndisapi
          * @brief Returns the vector of pointers for writing packets to the adapter.
          * @return Reference to the write_adapter_request_ vector.
          */
-        [[nodiscard]] std::vector<intermediate_buffer*>& get_write_adapter_request()
+        [[nodiscard]] std::vector<netlib::ndisapi::intermediate_buffer*>& get_write_adapter_request()
         {
             return write_adapter_request_;
         }
@@ -85,7 +85,7 @@ namespace ndisapi
          * @brief Returns the vector of pointers for writing packets up to the protocol stack.
          * @return Reference to the write_mstcp_request_ vector.
          */
-        [[nodiscard]] std::vector<intermediate_buffer*>& get_write_mstcp_request()
+        [[nodiscard]] std::vector<netlib::ndisapi::intermediate_buffer*>& get_write_mstcp_request()
         {
             return write_mstcp_request_;
         }
@@ -95,7 +95,7 @@ namespace ndisapi
          * @param idx Index of the buffer.
          * @return Reference to the buffer at the specified index.
          */
-        intermediate_buffer& operator[](const std::size_t idx)
+        netlib::ndisapi::intermediate_buffer& operator[](const std::size_t idx)
         {
             return packet_buffer_[idx];
         }
@@ -105,7 +105,7 @@ namespace ndisapi
          * @param idx Index of the buffer.
          * @return Const reference to the buffer at the specified index.
          */
-        const intermediate_buffer& operator[](const std::size_t idx) const
+        const netlib::ndisapi::intermediate_buffer& operator[](const std::size_t idx) const
         {
             return packet_buffer_[idx];
         }
@@ -482,7 +482,7 @@ namespace ndisapi
         /// and a reference to the intermediate_buffer containing the packet data. The functor returns a
         /// packet_action struct that determines how the packet should be handled (e.g., passed, dropped, reverted).
         /// </remarks>
-        std::function<packet_action(HANDLE, intermediate_buffer&)> filter_outgoing_packet_ = nullptr;
+        std::function<packet_action(HANDLE, netlib::ndisapi::intermediate_buffer&)> filter_outgoing_packet_ = nullptr;
 
         /// <summary>incoming packet processing functor</summary>
         /// <remarks>
@@ -490,7 +490,7 @@ namespace ndisapi
         /// processing functor, it takes a handle to the adapter and a reference to the intermediate_buffer
         /// containing the packet data. It returns a packet_action struct to determine the packet's fate.
         /// </remarks>
-        std::function<packet_action(HANDLE, intermediate_buffer&)> filter_incoming_packet_ = nullptr;
+        std::function<packet_action(HANDLE, netlib::ndisapi::intermediate_buffer&)> filter_incoming_packet_ = nullptr;
 
         /// <summary>working thread running status</summary>
         /// <remarks>
@@ -974,7 +974,7 @@ namespace ndisapi
             {
                 std::ignore = packet_event_.wait(INFINITE);
                 std::ignore = packet_event_.reset_event();
-            } while (!ReadPacketsUnsorted(reinterpret_cast<PINTERMEDIATE_BUFFER*>(const_cast<intermediate_buffer**>(read_request.data())),
+            } while (!ReadPacketsUnsorted(reinterpret_cast<PINTERMEDIATE_BUFFER*>(const_cast<netlib::ndisapi::intermediate_buffer**>(read_request.data())),
                 (DWORD)read_request.size(),
                 reinterpret_cast<PDWORD>(&packet_block_ptr->get_packets_success())) &&
                 filter_state_ == filter_state::running);

--- a/netlib/src/ndisapi/socks5_udp_local_redirect.h
+++ b/netlib/src/ndisapi/socks5_udp_local_redirect.h
@@ -14,7 +14,7 @@ namespace ndisapi
     * @tparam T IP address type (net::ip_address_v4 or net::ip_address_v6).
     */
     template <net::ip_address T>
-    class socks5_udp_local_redirect : public netlib::log::logger<socks5_udp_local_redirect<T>>
+    class socks5_udp_local_redirect : public netlib::log::logger<socks5_udp_local_redirect<T>>  // NOLINT(clang-diagnostic-padded)
     {
         /// <summary>
         /// NOTE: All ports are in the network byte order
@@ -29,10 +29,6 @@ namespace ndisapi
         /// </summary>
         std::unordered_map<uint16_t, std::chrono::steady_clock::time_point> endpoints_;
         /// <summary>
-        /// Proxy port in network byte order.
-        /// </summary>
-        u_short proxy_port_{};
-        /// <summary>
         /// Mutex for synchronizing access to endpoints_.
         /// </summary>
         std::mutex lock_;
@@ -40,6 +36,10 @@ namespace ndisapi
         /// Thread for cleaning up timed-out UDP endpoints.
         /// </summary>
         std::thread cleanup_thread_;
+        /// <summary>
+        /// Proxy port in network byte order.
+        /// </summary>
+        u_short proxy_port_{};
         /// <summary>
         /// Termination flag for the cleanup_thread_.
         /// </summary>
@@ -59,7 +59,7 @@ namespace ndisapi
                     {
                         {
                             auto current_time = std::chrono::steady_clock::now();
-                            std::lock_guard lock(lock_);
+                            std::scoped_lock lock(lock_);
 
                             tools::generic::erase_if(endpoints_, endpoints_.begin(), endpoints_.end(),
                                 [&current_time, this](auto&& a)
@@ -203,7 +203,7 @@ namespace ndisapi
                     ip_header) +
                     sizeof(DWORD) * ip_header->ip_hl);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 if (const auto it = endpoints_.find(udp_header->th_sport); it
                     == endpoints_.cend())
@@ -234,7 +234,7 @@ namespace ndisapi
 
                 const auto* udp_header = static_cast<udphdr_ptr>(p_header);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 if (const auto it = endpoints_.find(udp_header->th_sport); it == endpoints_.cend())
                 {
@@ -288,7 +288,7 @@ namespace ndisapi
                 auto* udp_header = reinterpret_cast<udphdr*>(reinterpret_cast<unsigned char*>(ip_header) +
                     sizeof(DWORD) * ip_header->ip_hl);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 // existing connection
                 const auto it = endpoints_.find(udp_header->th_sport);
@@ -378,7 +378,7 @@ namespace ndisapi
 
                 auto* udp_header = static_cast<udphdr_ptr>(p_header);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 const auto it = endpoints_.find(udp_header->th_sport);
 
@@ -484,7 +484,7 @@ namespace ndisapi
                 auto* udp_header = reinterpret_cast<udphdr*>(reinterpret_cast<unsigned char*>(ip_header) +
                     sizeof(DWORD) * ip_header->ip_hl);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 const auto it = endpoints_.find(udp_header->th_dport);
 
@@ -571,7 +571,7 @@ namespace ndisapi
 
                 auto* udp_header = static_cast<udphdr_ptr>(p_header);
 
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
 
                 const auto it = endpoints_.find(udp_header->th_dport);
 

--- a/netlib/src/ndisapi/tcp_local_redirect.h
+++ b/netlib/src/ndisapi/tcp_local_redirect.h
@@ -14,7 +14,7 @@ namespace ndisapi
      * @tparam T IP address type (net::ip_address_v4 or net::ip_address_v6).
      */
     template <net::ip_address T>
-    class tcp_local_redirect : public netlib::log::logger<tcp_local_redirect<T>>
+    class tcp_local_redirect : public netlib::log::logger<tcp_local_redirect<T>>  // NOLINT(clang-diagnostic-padded)
     {
         using log_level = netlib::log::log_level;
         using logger = netlib::log::logger<tcp_local_redirect>;
@@ -27,11 +27,6 @@ namespace ndisapi
         std::unordered_map<net::ip_endpoint<T>, timestamp_endpoint> redirected_connections_;
 
         /**
-         * @brief Proxy port in network byte order.
-         */
-        u_short proxy_port_{};
-
-        /**
          * @brief Mutex for synchronizing access to redirected_connections_.
          */
         std::mutex lock_;
@@ -40,6 +35,11 @@ namespace ndisapi
          * @brief Thread for cleaning up timed-out TCP connections.
          */
         std::thread cleanup_thread_;
+
+        /**
+         * @brief Proxy port in network byte order.
+         */
+        u_short proxy_port_{};
 
         /**
          * @brief Termination flag for the cleanup_thread_.

--- a/netlib/src/net/ipv6_helper.h
+++ b/netlib/src/net/ipv6_helper.h
@@ -195,7 +195,7 @@ namespace net
             if (len > 0)
             {
                 const auto p8 = reinterpret_cast<const uint8_t*>(p16);
-                sum += ntohs(static_cast<uint16_t>(*p8) << 8); /* RFC says pad last byte */
+                sum += ntohs(static_cast<uint16_t>(*p8) << 8); /* RFC says pad last byte */  // NOLINT(clang-diagnostic-implicit-int-conversion)
             }
 
             return sum;

--- a/netlib/src/proxy/socks5_common.h
+++ b/netlib/src/proxy/socks5_common.h
@@ -75,7 +75,7 @@ namespace proxy
             memcpy(username_reserved, username.data(), username.length());
 
             *password_length_ptr = static_cast<unsigned char>(password.length());
-            memcpy(password_ptr, password.data(), password.length());
+            memcpy(password_ptr, password.data(), password.length());  // NOLINT(bugprone-not-null-terminated-result)
 
             return (3 + static_cast<int>(username.length()) + static_cast<int>(password.length()));
         }

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -20,7 +20,7 @@ namespace proxy
      * @tparam T Proxy socket implementation type.
      */
     template <typename T>
-    class socks5_local_udp_proxy_server : public netlib::log::logger<socks5_local_udp_proxy_server<T>>
+    class socks5_local_udp_proxy_server : public netlib::log::logger<socks5_local_udp_proxy_server<T>>  // NOLINT(clang-diagnostic-padded)
     {
     public:
         /**
@@ -43,7 +43,7 @@ namespace proxy
          * Alias for the negotiation context type defined by the proxy socket implementation (T).
          * Used to store authentication and session information for SOCKS5 negotiation.
          */
-        using negotiate_context_t = typename T::negotiate_context_t;
+        using negotiate_context_t = T::negotiate_context_t;
 
         /**
          * @brief Address type alias.
@@ -51,7 +51,7 @@ namespace proxy
          * Alias for the address type defined by the proxy socket implementation (T).
          * Represents an IPv4 or IPv6 address, depending on the template parameter.
          */
-        using address_type_t = typename T::address_type_t;
+        using address_type_t = T::address_type_t;
 
         /**
          * @brief Per-I/O context type alias.
@@ -59,7 +59,7 @@ namespace proxy
          * Alias for the per-I/O context type defined by the proxy socket implementation (T).
          * Used for managing asynchronous I/O operations.
          */
-        using per_io_context_t = typename T::per_io_context_t;
+        using per_io_context_t = T::per_io_context_t;
 
         /**
          * @brief Query remote peer function signature.
@@ -113,21 +113,6 @@ namespace proxy
         std::map<uint16_t, std::shared_ptr<T>> proxy_sockets_;
 
         /**
-         * @brief Indicates whether the server is terminating.
-         *
-         * Set to true when the server is stopping or has stopped.
-         */
-        std::atomic_bool end_server_{ true }; // set to true on proxy termination
-
-        /**
-         * @brief Counts the number of IOCP operations currently executing in the lambda.
-         *
-         * Incremented when entering the lambda, decremented when exiting.
-         * Used during shutdown to ensure no operations are in-flight before destroying the object.
-         */
-        std::atomic<int32_t> active_iocp_operations_{ 0 };
-
-        /**
          * @brief UDP server socket handle.
          *
          * The main socket used to receive and send UDP packets for the proxy server.
@@ -160,19 +145,14 @@ namespace proxy
         SOCKADDR_STORAGE recv_from_sa_{};
 
         /**
-         * @brief Size of the sender address structure.
-         */
-        INT recv_from_sa_size_{ sizeof(SOCKADDR_STORAGE) };
-
-        /**
-         * @brief Local UDP port number the proxy server is bound to.
-         */
-        uint16_t proxy_port_;
-
-        /**
          * @brief Reference to the I/O completion port used for asynchronous operations.
          */
         netlib::winsys::io_completion_port& completion_port_;
+
+        /**
+         * @brief Function to query remote peer information for a given local address and port.
+         */
+        std::function<query_remote_peer_t> query_remote_peer_;
 
         /**
          * @brief Completion key associated with the server socket in the I/O completion port.
@@ -180,9 +160,29 @@ namespace proxy
         ULONG_PTR completion_key_{ 0 };
 
         /**
-         * @brief Function to query remote peer information for a given local address and port.
+         * @brief Size of the sender address structure.
          */
-        std::function<query_remote_peer_t> query_remote_peer_;
+        INT recv_from_sa_size_{ sizeof(SOCKADDR_STORAGE) };
+
+        /**
+         * @brief Counts the number of IOCP operations currently executing in the lambda.
+         *
+         * Incremented when entering the lambda, decremented when exiting.
+         * Used during shutdown to ensure no operations are in-flight before destroying the object.
+         */
+        std::atomic<int32_t> active_iocp_operations_{ 0 };
+
+        /**
+         * @brief Local UDP port number the proxy server is bound to.
+         */
+        uint16_t proxy_port_;
+
+        /**
+         * @brief Indicates whether the server is terminating.
+         *
+         * Set to true when the server is stopping or has stopped.
+         */
+        std::atomic_bool end_server_{ true }; // set to true on proxy termination
 
     public:
         /**
@@ -204,9 +204,9 @@ namespace proxy
             const log_level log_level = log_level::error,
             std::shared_ptr<std::ostream> log_stream = nullptr)
             : logger(log_level, std::move(log_stream)),
-            proxy_port_(proxy_port),
             completion_port_(completion_port),
-            query_remote_peer_(query_remote_peer_fn)
+            query_remote_peer_(query_remote_peer_fn),
+            proxy_port_(proxy_port)
         {
             if (!create_server_socket())
             {
@@ -538,7 +538,7 @@ namespace proxy
             // the map does NOT destroy them: each socket's recv io_context holds a self-reference,
             // so the destructor would never run and the handle/armed recv would leak.
             {
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
                 if (!proxy_sockets_.empty())
                 {
                     NETLIB_INFO("Cancelling I/O on {} proxy sockets before draining", proxy_sockets_.size());
@@ -569,7 +569,7 @@ namespace proxy
             {
                 bool drained = true;
                 {
-                    std::lock_guard lock(lock_);
+                    std::scoped_lock lock(lock_);
                     for (auto& entry : proxy_sockets_)
                     {
                         if (entry.second && entry.second->outstanding_io() != 0)
@@ -635,7 +635,7 @@ namespace proxy
             // leak those sessions instead (a bounded, shutdown-only leak) rather than risk a UAF.
             if (drained_ok)
             {
-                std::lock_guard lock(lock_);
+                std::scoped_lock lock(lock_);
                 for (auto& entry : proxy_sockets_)
                 {
                     if (entry.second)
@@ -920,7 +920,7 @@ namespace proxy
                 FD_ZERO(&error_set);
                 FD_SET(s, &error_set);
 
-                timeval tv{};
+                timeval tv;
                 tv.tv_sec = static_cast<long>(timeout_ms / 1000);
                 tv.tv_usec = static_cast<long>((timeout_ms % 1000) * 1000);
 
@@ -1148,7 +1148,7 @@ namespace proxy
                 getsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
                     reinterpret_cast<char*>(&original_timeout), &original_timeout_size);
 
-                const auto restore_timeout = [s, original_timeout]
+                const auto restore_timeout = [s, original_timeout]  // NOLINT(clang-diagnostic-padded)
                 {
                     setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
                         reinterpret_cast<const char*>(&original_timeout), sizeof(original_timeout));
@@ -1600,7 +1600,7 @@ namespace proxy
          *
          * @param it Valid iterator into proxy_sockets_ for the failed session.
          */
-        void cleanup_failed_proxy_socket(const typename decltype(proxy_sockets_)::iterator it)
+        void cleanup_failed_proxy_socket(const decltype(proxy_sockets_)::iterator it)
         {
             if (it->second)
             {
@@ -1638,7 +1638,7 @@ namespace proxy
             while (end_server_ == false)
             {
                 {
-                    std::lock_guard lock(lock_);
+                    std::scoped_lock lock(lock_);
 
                     for (auto it = proxy_sockets_.begin(); it != proxy_sockets_.end();)
                     {

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -1,3 +1,5 @@
+// ReSharper disable CppClangTidyClangDiagnosticComma
+// ReSharper disable CppExpressionWithoutSideEffects
 #pragma once
 
 namespace proxy
@@ -162,7 +164,7 @@ namespace proxy
                         (ident_resp_.method == 0xFF))
                     {
                         // SOCKS v5 identification or authentication failed
-                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                     }
                     else
                     {
@@ -182,7 +184,7 @@ namespace proxy
                                 // [SOCKS5]: associate_to_socks5_proxy: RFC 1928: X'02' USERNAME/PASSWORD is chosen but USERNAME exceeds maximum possible length
                                 )
                             {
-                                tcp_proxy_socket<T>::close_client<true>(true, false);
+                                tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                             }
                             else
                             {
@@ -200,7 +202,7 @@ namespace proxy
                                         &io_context_send_negotiate_.wsa_buf,
                                         &io_context_send_negotiate_) == SOCKET_ERROR)
                                     {
-                                        tcp_proxy_socket<T>::close_client<true>(false, false);
+                                        tcp_proxy_socket<T>::close_client<true>(false, false);  // NOLINT(bugprone-chained-comparison)
                                         return;
                                     }
 
@@ -212,7 +214,7 @@ namespace proxy
                                         &io_context_recv_negotiate_.wsa_buf,
                                         &io_context_recv_negotiate_) == SOCKET_ERROR)
                                     {
-                                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                                        tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                                     }
                                 }
                             }
@@ -240,7 +242,7 @@ namespace proxy
                     if (ident_resp_.method != 0)
                     {
                         // SOCKS v5 identification or authentication failed
-                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                     }
                     else
                     {
@@ -258,7 +260,7 @@ namespace proxy
                         (connect_response_header_.reply != 0))
                     {
                         // SOCKS v5 connect failed
-                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                         return;
                     }
 
@@ -295,7 +297,7 @@ namespace proxy
                         break;
 
                     default:
-                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                        tcp_proxy_socket<T>::close_client<true>(true, false); // NOLINT(bugprone-chained-comparison)
                         break;
                     }
                 }
@@ -341,7 +343,7 @@ namespace proxy
             unsigned char address_type{};
         };
 
-        void reset_overlapped(per_io_context_t& io_context) noexcept
+        static void reset_overlapped(per_io_context_t& io_context) noexcept
         {
             io_context.Internal = 0;
             io_context.InternalHigh = 0;
@@ -361,8 +363,8 @@ namespace proxy
                 &io_context_recv_negotiate_.wsa_buf,
                 &io_context_recv_negotiate_) == SOCKET_ERROR)
             {
-                // Only reached from process_receive_negotiate_complete, which holds lock_.
-                tcp_proxy_socket<T>::close_client<true>(true, false);
+                // Called only from process_receive_negotiate_complete while lock_ is held.
+                tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
                 return false;
             }
 
@@ -420,8 +422,8 @@ namespace proxy
                 &io_context_send_negotiate_.wsa_buf,
                 &io_context_send_negotiate_) == SOCKET_ERROR)
             {
-                // Only reached from process_receive_negotiate_complete, which holds lock_.
-                tcp_proxy_socket<T>::close_client<true>(false, false);
+                // Called only from process_receive_negotiate_complete while lock_ is held.
+                tcp_proxy_socket<T>::close_client<true>(false, false); // NOLINT(bugprone-chained-comparison)
                 return;
             }
 
@@ -464,13 +466,6 @@ namespace proxy
         }
 
     private:
-
-        socks5_state current_state_{ socks5_state::pre_login };
-        socks5_ident_req<2> ident_req_{};
-        socks5_ident_resp ident_resp_{};
-        socks5_req<address_type_t> connect_request_;
-        socks5_resp_header connect_response_header_{};
-        std::array<unsigned char, 1 + socks5_username_max_length + sizeof(unsigned short)> connect_response_tail_{};
         unsigned char* connect_reply_buffer_{ nullptr };
         ULONG connect_reply_expected_{ 0 };
         ULONG connect_reply_received_{ 0 };
@@ -478,7 +473,13 @@ namespace proxy
         // split the 2 bytes across completions; without accumulating, a 1-byte read would be
         // parsed as a complete reply against stale ident_resp_ contents.
         ULONG ident_resp_received_{ 0 };
+        socks5_state current_state_{ socks5_state::pre_login };
+        socks5_ident_req<2> ident_req_{};
+        socks5_ident_resp ident_resp_{};
+        socks5_req<address_type_t> connect_request_;
+        socks5_resp_header connect_response_header_{};
         socks5_username_auth username_auth_{};
+        std::array<unsigned char, 1 + socks5_username_max_length + sizeof(unsigned short)> connect_response_tail_{};
 
     protected:
         /**

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -58,10 +58,10 @@ namespace proxy
          *        IPv6 mappers share a single definition.
          */
         template <typename AddrT>
-        struct tcp_mapper_entry_t
+        struct tcp_mapper_entry_t  // NOLINT(clang-diagnostic-padded)
         {
-            net::ip_endpoint<AddrT> endpoint;
             std::chrono::steady_clock::time_point created_at;
+            net::ip_endpoint<AddrT> endpoint;
         };
 
         using tcp_mapper_entry = tcp_mapper_entry_t<net::ip_address_v4>;
@@ -250,7 +250,7 @@ namespace proxy
          * This queue is used to store buffers that need to be processed by the process resolution thread.
          * Access to this queue is synchronized using process_resolve_buffer_mutex_ and process_resolve_buffer_queue_cv_.
          */
-        std::queue<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> process_resolve_buffer_queue_;
+        std::queue<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> process_resolve_buffer_queue_;
 
         /**
          * @brief Mutex to guard access to the process_resolve_buffer_queue_.
@@ -325,7 +325,7 @@ namespace proxy
          *         later re-injection (and therefore dropped from the current pass)
          *         or dropped outright due to overload / allocation failure.
          */
-        packet_filter::packet_action enqueue_for_deferred_resolve(ndisapi::intermediate_buffer& buffer)
+        packet_filter::packet_action enqueue_for_deferred_resolve(netlib::ndisapi::intermediate_buffer& buffer)
         {
             {
                 std::scoped_lock lock(process_resolve_buffer_mutex_);
@@ -344,7 +344,7 @@ namespace proxy
                 }
             }
 
-            if (auto allocated_buffer = ndisapi::intermediate_buffer_pool::instance().allocate(buffer))
+            if (auto allocated_buffer = netlib::ndisapi::intermediate_buffer_pool::instance().allocate(buffer))
             {
                 bool pushed = false;
                 {
@@ -481,7 +481,7 @@ namespace proxy
             // Initialize packet filter
             packet_filter_ = std::make_unique<packet_filter>(
                 nullptr,
-                [this](HANDLE, ndisapi::intermediate_buffer& buffer)
+                [this](HANDLE, netlib::ndisapi::intermediate_buffer& buffer)
                 {
                     auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
                     const auto destination_mac = net::mac_address(ethernet_header->h_dest);
@@ -1031,13 +1031,13 @@ namespace proxy
         {
             using tcp_server_t = tcp_proxy_server<socks5_tcp_proxy_socket<AddrT>>;
             using udp_server_t = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<AddrT>>;
-            using tcp_negotiate_t = typename tcp_server_t::negotiate_context_t;
-            using udp_negotiate_t = typename udp_server_t::negotiate_context_t;
+            using tcp_negotiate_t = tcp_server_t::negotiate_context_t;
+            using udp_negotiate_t = udp_server_t::negotiate_context_t;
 
             auto tcp_server = (protocols == both || protocols == tcp)
                 ? std::make_unique<tcp_server_t>(
                     0, io_port_,
-                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)
+                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
                         -> std::tuple<AddrT, uint16_t, std::unique_ptr<tcp_negotiate_t>>
                     {
                         auto& mapper = tcp_mapper_for<AddrT>();
@@ -1082,7 +1082,7 @@ namespace proxy
             auto udp_server = (protocols == both || protocols == udp)
                 ? std::make_unique<udp_server_t>(
                     0, io_port_,
-                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)
+                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
                         -> std::tuple<AddrT, uint16_t, std::unique_ptr<udp_negotiate_t>>
                     {
                         auto& mapper = udp_mapper_for<AddrT>();
@@ -1262,11 +1262,8 @@ namespace proxy
                         socks_udp_proxy_server_v6.reset();
                     };
 
-                    if (!start_listener(socks_tcp_proxy_server_v6, "IPv6", "TCP"))
-                    {
-                        disable_ipv6_listeners();
-                    }
-                    else if (!start_listener(socks_udp_proxy_server_v6, "IPv6", "UDP"))
+                    if (!start_listener(socks_tcp_proxy_server_v6, "IPv6", "TCP") ||
+                        !start_listener(socks_udp_proxy_server_v6, "IPv6", "UDP"))
                     {
                         disable_ipv6_listeners();
                     }
@@ -1750,7 +1747,7 @@ namespace proxy
          *         - packet_action::revert: packet should be reverted (redirected)
          *         - packet_action::pass: packet should be passed through
          */
-        std::optional<packet_filter::packet_action> process_udp_packet(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        std::optional<packet_filter::packet_action> process_udp_packet(netlib::ndisapi::intermediate_buffer& buffer, const bool postponed)
         {
             auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
             auto* const ip_header = reinterpret_cast<iphdr_ptr>(ethernet_header + 1);
@@ -1847,7 +1844,7 @@ namespace proxy
          *         - packet_action::revert: packet should be reverted (redirected)
          *         - packet_action::pass: packet should be passed through
          */
-        std::optional<packet_filter::packet_action> process_tcp_packet(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        std::optional<packet_filter::packet_action> process_tcp_packet(netlib::ndisapi::intermediate_buffer& buffer, const bool postponed)
         {
             auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
             auto* const ip_header = reinterpret_cast<iphdr_ptr>(ethernet_header + 1);
@@ -1897,10 +1894,9 @@ namespace proxy
                 {
                     std::scoped_lock lock(tcp_mapper_lock_);
                     tcp_mapper_[ntohs(tcp_header->th_sport)] =
-                        tcp_mapper_entry{
+                        tcp_mapper_entry{std::chrono::steady_clock::now(),
                             net::ip_endpoint(net::ip_address_v4(ip_header->ip_dst),
-                                ntohs(tcp_header->th_dport)),
-                            std::chrono::steady_clock::now()
+                                ntohs(tcp_header->th_dport))
                         };
 
                     NETLIB_LOG(log_level::info,
@@ -1938,7 +1934,7 @@ namespace proxy
          * @param destination_mac Destination MAC, used to skip broadcast/multicast UDP.
          * @return The packet action to apply.
          */
-        packet_filter::packet_action handle_ipv6_filter(ndisapi::intermediate_buffer& buffer,
+        packet_filter::packet_action handle_ipv6_filter(netlib::ndisapi::intermediate_buffer& buffer,
                                                         const net::mac_address& destination_mac)
         {
             log_packet_to_pcap(buffer);
@@ -1957,7 +1953,7 @@ namespace proxy
                 // traffic is passed through UNPROXIED, so a proxied app's fragmented IPv6
                 // egress leaks its real source address. Warn once so the limitation is
                 // visible at runtime (see README, IPv6 fragmentation note).
-                static std::atomic_flag fragment_passthrough_warned;
+                static std::atomic_flag fragment_passthrough_warned;  // NOLINT(clang-diagnostic-unique-object-duplication)
                 if (!fragment_passthrough_warned.test_and_set(std::memory_order_relaxed))
                 {
                     NETLIB_LOG(log_level::warning,
@@ -2002,7 +1998,7 @@ namespace proxy
          * proxy-port lookup, and redirect objects. See process_udp_packet() for the
          * postponed/return-value contract.
          */
-        std::optional<packet_filter::packet_action> process_udp_packet_v6(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        std::optional<packet_filter::packet_action> process_udp_packet_v6(netlib::ndisapi::intermediate_buffer& buffer, const bool postponed)
         {
             auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
             auto* const ip_header = reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
@@ -2092,7 +2088,7 @@ namespace proxy
          * proxy-port lookup, and redirect objects. See process_tcp_packet() for the
          * postponed/return-value contract.
          */
-        std::optional<packet_filter::packet_action> process_tcp_packet_v6(ndisapi::intermediate_buffer& buffer, const bool postponed)
+        std::optional<packet_filter::packet_action> process_tcp_packet_v6(netlib::ndisapi::intermediate_buffer& buffer, const bool postponed)
         {
             auto* const ethernet_header = reinterpret_cast<ether_header_ptr>(buffer.m_IBuffer);
             auto* const ip_header = reinterpret_cast<ipv6hdr_ptr>(ethernet_header + 1);
@@ -2150,9 +2146,9 @@ namespace proxy
                     std::scoped_lock lock(tcp_mapper_v6_lock_);
                     tcp_mapper_v6_[ntohs(tcp_header->th_sport)] =
                         tcp_mapper_entry_v6{
+                            std::chrono::steady_clock::now(),
                             net::ip_endpoint(net::ip_address_v6(ip_header->ip6_dst),
-                                ntohs(tcp_header->th_dport)),
-                            std::chrono::steady_clock::now()
+                                ntohs(tcp_header->th_dport))
                         };
 
                     NETLIB_LOG(log_level::info,
@@ -2199,7 +2195,7 @@ namespace proxy
          * @param packet_queue Reference to a vector of intermediate_buffer pointers to be sent.
          * @return true if the packets were successfully sent to the adapters, false otherwise.
          */
-        bool send_packets_to_adapters(std::vector<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr>& packet_queue) const
+        bool send_packets_to_adapters(std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr>& packet_queue) const
         {
             DWORD packets_success = 0;
             return packet_filter_->SendPacketsToAdaptersUnsorted(
@@ -2219,7 +2215,7 @@ namespace proxy
          * @param packet_queue Reference to a vector of intermediate_buffer pointers to be sent.
          * @return true if the packets were successfully sent to MSTCP, false otherwise.
          */
-        bool send_packets_to_mstcp(std::vector<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr>& packet_queue) const
+        bool send_packets_to_mstcp(std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr>& packet_queue) const
         {
             DWORD packets_success = 0;
             return packet_filter_->SendPacketsToMstcpUnsorted(
@@ -2256,9 +2252,9 @@ namespace proxy
         void process_resolve_thread_proc()
         {
             // Use local (non-static) containers to avoid static initialization order issues and data races
-            std::queue<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> local_queue;
-            std::vector<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_adapters;
-            std::vector<ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_mstcp;
+            std::queue<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> local_queue;
+            std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_adapters;
+            std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_mstcp;
 
             // Run the tcp_mapper_ sweep at most once per maintenance interval, even
             // under heavy resolver activity. The interval is half the TTL so an

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -201,9 +201,9 @@ namespace proxy
             const log_level log_level = log_level::error,
             std::shared_ptr<std::ostream> log_stream = nullptr)
             : logger(log_level, std::move(log_stream)),
-            proxy_port_(proxy_port),
             completion_port_(completion_port),
-            query_remote_peer_(query_remote_peer_fn)
+            query_remote_peer_(query_remote_peer_fn),
+            proxy_port_(proxy_port)
         {
             if (!create_server_socket())
             {
@@ -900,7 +900,7 @@ namespace proxy
                 // via IPv4-mapped addresses (e.g. ::ffff:127.0.0.1). ProxiFyre's
                 // IPv6 proxy path targets the configured (often IPv4) SOCKS5 server
                 // through its v4-mapped form, so the socket must be dual-stack.
-                DWORD v6_only = 0;
+                constexpr DWORD v6_only = 0;
                 if (setsockopt(remote_socket, IPPROTO_IPV6, IPV6_V6ONLY,
                     reinterpret_cast<const char*>(&v6_only), sizeof(v6_only)) == SOCKET_ERROR)
                 {
@@ -939,7 +939,7 @@ namespace proxy
 
             // The client_service structure specifies the address family,
             // IP address, and port of the server to be connected to.
-            WSAEVENT tracked_event = WSA_INVALID_EVENT;
+            WSAEVENT tracked_event;
             {
                 std::scoped_lock lock(lock_);
 
@@ -1145,8 +1145,8 @@ namespace proxy
 
                 // WaitForMultipleObjects can return WAIT_FAILED (0xFFFFFFFF) -- e.g. when a handle
                 // in the array has become invalid. An INFINITE wait never returns WAIT_TIMEOUT, but
-                // guard against any out-of-range value: using it as a vector index below would be a
-                // wild out-of-bounds access. Log, back off briefly to avoid a hot spin if the
+                // guard against any out-of-range value: using it as a vector index below would be wild out-of-bounds access.
+                // Log, back off briefly to avoid a hot spin if the
                 // condition persists, and rebuild the wait set on the next iteration.
                 if (event_index == WAIT_FAILED || event_index >= wait_events.size())
                 {

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -245,21 +245,21 @@ namespace proxy
         per_io_context_t io_context_send_to_remote_{ proxy_io_operation::relay_io_write, nullptr, false };
 
         /**
-         * @brief Set on the first is_ready_for_removal() pass that sees both sockets closed,
-         *        so the next pass (a full cleanup cycle later) releases the self-references.
-         *        The grace lets any still-queued IOCP completion drain first.
-         */
-        bool removal_armed_ = false;
-
-        /**
          * @brief Count of overlapped I/O operations posted on this socket that have not yet
          *        completed. Incremented (io_posted) immediately before each WSARecv/WSASend and
          *        decremented (io_completed) once per completion, and on a synchronous post
          *        failure. is_ready_for_removal() releases the self-references only when this is
          *        zero -- a genuine "no completion can still reference our io_context members"
          *        guarantee rather than a wall-clock grace.
-         */
+        */
         std::atomic<long> outstanding_io_{ 0 };
+
+        /**
+         * @brief Set on the first is_ready_for_removal() pass that sees both sockets closed,
+         *        so the next pass (a full cleanup cycle later) releases the self-references.
+         *        The grace lets any still-queued IOCP completion drain first.
+         */
+        bool removal_armed_ = false;
 
         /**
          * @brief Indicates whether Nagle's algorithm is disabled for the remote socket.

--- a/netlib/src/winsys/io_completion_port.h
+++ b/netlib/src/winsys/io_completion_port.h
@@ -249,7 +249,7 @@ namespace netlib::winsys
         /// then wait for the count to reach zero -- guaranteeing no worker is (or can start)
         /// executing the handler once unregister_handler() returns.
         /// </summary>
-        struct handler_state
+        struct handler_state  // NOLINT(clang-diagnostic-padded)
         {
             std::function<callback_t> callback;
             std::atomic<int32_t> in_flight{ 0 };

--- a/socksify/socksify.vcxproj
+++ b/socksify/socksify.vcxproj
@@ -239,6 +239,7 @@
     <ClInclude Include="..\netlib\src\iphelper\owner_module_resolver.h" />
     <ClInclude Include="..\netlib\src\iphelper\process_lookup.h" />
     <ClInclude Include="..\netlib\src\log\log.h" />
+    <ClInclude Include="..\netlib\src\ndisapi\intermediate_buffer.h" />
     <ClInclude Include="..\netlib\src\ndisapi\intermediate_buffer_pool.h" />
     <ClInclude Include="..\netlib\src\ndisapi\queued_multi_interface_packet_filter.h" />
     <ClInclude Include="..\netlib\src\ndisapi\static_filters.h" />

--- a/socksify/socksify.vcxproj.filters
+++ b/socksify/socksify.vcxproj.filters
@@ -168,6 +168,9 @@
     <ClInclude Include="..\netlib\src\iphelper\network_adapter_info.h">
       <Filter>Header Files\netlib\iphelper</Filter>
     </ClInclude>
+    <ClInclude Include="..\netlib\src\ndisapi\intermediate_buffer.h">
+      <Filter>Header Files\netlib\ndisapi</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -40,8 +40,52 @@ socksify_unmanaged::socksify_unmanaged(const log_level_mx log_level) :
     // completes, leaving the matching cleanup to the destructor.
     struct winsock_cleanup_guard
     {
+        winsock_cleanup_guard() noexcept = default;
+
+        explicit winsock_cleanup_guard(const bool engaged) noexcept
+            : engaged(engaged)
+        {
+        }
+
+        ~winsock_cleanup_guard() noexcept
+        {
+            reset();
+        }
+
+        winsock_cleanup_guard(const winsock_cleanup_guard&) = delete;
+        winsock_cleanup_guard& operator=(const winsock_cleanup_guard&) = delete;
+
+        winsock_cleanup_guard(winsock_cleanup_guard&& other) noexcept
+            : engaged(std::exchange(other.engaged, false))
+        {
+        }
+
+        winsock_cleanup_guard& operator=(winsock_cleanup_guard&& other) noexcept
+        {
+            if (this != &other)
+            {
+                reset();
+                engaged = std::exchange(other.engaged, false);
+            }
+
+            return *this;
+        }
+
+        void release() noexcept
+        {
+            engaged = false;
+        }
+
+        void reset() noexcept
+        {
+            if (engaged)
+            {
+                engaged = false;
+                ::WSACleanup();
+            }
+        }
+
         bool engaged = true;
-        ~winsock_cleanup_guard() { if (engaged) ::WSACleanup(); }
     } winsock_guard;
 
     lock_ = std::make_unique<mutex_impl>();
@@ -131,7 +175,7 @@ socksify_unmanaged* socksify_unmanaged::get_instance(const log_level_mx log_leve
 bool socksify_unmanaged::start() const
 {
     using namespace std::string_literals;
-    std::lock_guard lock(lock_->lock);
+    std::scoped_lock lock(lock_->lock);
 
     if (!proxy_->start())
     {
@@ -150,7 +194,7 @@ bool socksify_unmanaged::start() const
 bool socksify_unmanaged::stop() const
 {
     using namespace std::string_literals;
-    std::lock_guard lock(lock_->lock);
+    std::scoped_lock lock(lock_->lock);
 
     if (!proxy_)
     {


### PR DESCRIPTION
## Summary
- clean up netlib packet buffer wrappers, proxy helpers, and routing utilities
- document that user-mode intermediate_buffer copies may preserve the full m_hAdapter/m_qLink union because m_qLink is kernel-only metadata
- keep intermediate_buffer_pool self-contained by including <mutex> and preserving mutex lifetime before the pool

## Verification
- git diff --cached --check
- dotnet msbuild socksify.sln /p:Configuration=Debug /p:Platform=x64 /t:Build /v:n (fails: missing Visual C++ MSBuild targets, Microsoft.Cpp.Default.props)