### PR TITLE
Fix IPv6 routing and QUIC UDP relay reliability

### DIFF
--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Principal;
 using Topshelf;
 using LogLevel = Socksifier.LogLevel;
 
@@ -92,7 +93,8 @@ namespace ProxiFyre
                 // Add the defined SOCKS5 proxies
                 var proxy = _socksify.AddSocks5Proxy(appSettings.Socks5ProxyEndpoint, appSettings.Username,
                     appSettings.Password, appSettings.SupportedProtocolsParse,
-                    true); // Assuming the AddSocks5Proxy method supports a list of protocols
+                    appSettings.SupportedAddressFamiliesParse,
+                    true);
 
                 if (proxy.ToInt64() == -1)
                 {
@@ -104,11 +106,14 @@ namespace ProxiFyre
                 var protocols = appSettings.SupportedProtocols != null && appSettings.SupportedProtocols.Count > 0
                     ? string.Join(", ", appSettings.SupportedProtocols)
                     : "TCP, UDP";
+                var addressFamilies = appSettings.SupportedAddressFamilies != null && appSettings.SupportedAddressFamilies.Count > 0
+                    ? string.Join(", ", appSettings.SupportedAddressFamilies)
+                    : "IPv4, IPv6";
                 foreach (var appName in appSettings.AppNames)
                     // Associate the defined application names to the proxies
                     if (_socksify.AssociateProcessNameToProxy(appName, proxy) && _logLevel >= LogLevel.Info)
                         LoggerInstance.Info(
-                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {protocols}!");
+                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {protocols} and address families {addressFamilies}!");
             }
 
             foreach (var excludedEntry in serviceSettings.ExcludedList)
@@ -246,6 +251,31 @@ namespace ProxiFyre
                             $"{string.Join(", ", unknownProtocols)}. Only \"TCP\" and \"UDP\" are recognized; " +
                             "unrecognized tokens are ignored (a proxy with no recognized protocol defaults to both).");
                 }
+
+                if (proxy.SupportedAddressFamilies != null)
+                {
+                    if (proxy.SupportedAddressFamilies.Count == 0)
+                    {
+                        var message = $"Proxy '{proxy.Socks5ProxyEndpoint}' has an empty " +
+                                      "\"supportedAddressFamilies\" array. Omit the setting to enable both " +
+                                      "families, or specify \"IPv4\", \"IPv6\", or both.";
+                        LoggerInstance.Error(message);
+                        throw new InvalidOperationException(message);
+                    }
+
+                    var unknownAddressFamilies = proxy.SupportedAddressFamilies
+                        .Where(f => !string.Equals(f, "IPv4", StringComparison.OrdinalIgnoreCase) &&
+                                    !string.Equals(f, "IPv6", StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    if (unknownAddressFamilies.Count > 0)
+                    {
+                        var values = string.Join(", ", unknownAddressFamilies.Select(f => f ?? "<null>"));
+                        var message = $"Proxy '{proxy.Socks5ProxyEndpoint}' lists unrecognized address " +
+                                      $"family/families: {values}. Only \"IPv4\" and \"IPv6\" are valid.";
+                        LoggerInstance.Error(message);
+                        throw new InvalidOperationException(message);
+                    }
+                }
             }
 
             // Drop null/blank excluded entries for the same reason.
@@ -291,14 +321,16 @@ namespace ProxiFyre
         //            "socks5ProxyEndpoint": "158.101.205.51:1080",
         //            "username": "username1",
         //            "password": "password1",
-        //            "supportedProtocols": ["TCP", "UDP"]
+        //            "supportedProtocols": ["TCP", "UDP"],
+        //            "supportedAddressFamilies": ["IPv4", "IPv6"]
         //        },
         //        {
         //            "appNames": ["firefox", "firefox_dev"],
         //            "socks5ProxyEndpoint": "159.101.205.52:1080",
         //            "username": "username2",
         //            "password": "password2",
-        //            "supportedProtocols": ["TCP"]
+        //            "supportedProtocols": ["TCP"],
+        //            "supportedAddressFamilies": ["IPv4"]
         //        }
         //    ],
         //    "excludes": [
@@ -366,13 +398,16 @@ namespace ProxiFyre
             /// <param name="username">Username for proxy authentication.</param>
             /// <param name="password">Password for proxy authentication.</param>
             /// <param name="supportedProtocols">List of supported protocols (e.g., TCP, UDP).</param>
-            public AppSettings(List<string> appNames, string socks5ProxyEndpoint, string username, string password, List<string> supportedProtocols)
+            /// <param name="supportedAddressFamilies">List of supported destination address families (e.g., IPv4, IPv6).</param>
+            public AppSettings(List<string> appNames, string socks5ProxyEndpoint, string username, string password,
+                List<string> supportedProtocols, List<string> supportedAddressFamilies = null)
             {
                 AppNames = appNames;
                 Socks5ProxyEndpoint = socks5ProxyEndpoint;
                 Username = username;
                 Password = password;
                 SupportedProtocols = supportedProtocols;
+                SupportedAddressFamilies = supportedAddressFamilies;
             }
 
             /// <summary>
@@ -401,6 +436,11 @@ namespace ProxiFyre
             public List<string> SupportedProtocols { get; }
 
             /// <summary>
+            /// Gets the list of supported destination address families (e.g., IPv4, IPv6).
+            /// </summary>
+            public List<string> SupportedAddressFamilies { get; }
+
+            /// <summary>
             /// Gets the supported protocols as an enum value.
             /// </summary>
             public SupportedProtocolsEnum SupportedProtocolsParse
@@ -417,6 +457,36 @@ namespace ProxiFyre
                         : SupportedProtocolsEnum.BOTH;
                 }
             }
+
+            /// <summary>
+            /// Gets the supported destination address families as an enum value.
+            /// </summary>
+            public SupportedAddressFamiliesEnum SupportedAddressFamiliesParse
+            {
+                get
+                {
+                    if (SupportedAddressFamilies == null)
+                        return SupportedAddressFamiliesEnum.BOTH;
+
+                    var supportsIPv4 = ContainsAddressFamily("IPv4");
+                    var supportsIPv6 = ContainsAddressFamily("IPv6");
+                    if (supportsIPv4 && supportsIPv6)
+                        return SupportedAddressFamiliesEnum.BOTH;
+                    if (supportsIPv4)
+                        return SupportedAddressFamiliesEnum.IPv4;
+                    if (supportsIPv6)
+                        return SupportedAddressFamiliesEnum.IPv6;
+
+                    throw new InvalidOperationException(
+                        "supportedAddressFamilies must contain IPv4, IPv6, or both.");
+                }
+            }
+
+            private bool ContainsAddressFamily(string value)
+            {
+                return SupportedAddressFamilies != null &&
+                    SupportedAddressFamilies.Any(f => string.Equals(f, value, StringComparison.OrdinalIgnoreCase));
+            }
         }
     }
 
@@ -425,6 +495,21 @@ namespace ProxiFyre
     /// </summary>
     internal class Program
     {
+        private static bool IsElevated()
+        {
+            try
+            {
+                using (var identity = WindowsIdentity.GetCurrent())
+                {
+                    return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Main method. Configures and runs the ProxiFyre service using Topshelf.
         /// </summary>
@@ -446,6 +531,20 @@ namespace ProxiFyre
                                      || command == "uninstall"
                                      || command == "start"
                                      || command == "stop";
+
+            var isHelpCommand = command == "help"
+                                || command == "--help"
+                                || command == "-h"
+                                || command == "/?";
+
+            if (!isLifecycleCommand && !isHelpCommand && !IsElevated())
+            {
+                Console.Error.WriteLine(
+                    "ProxiFyre must run with administrator privileges so process ownership, " +
+                    "application exclusions, and packet redirection remain reliable. Start it from " +
+                    "an Administrator console or install and start the Windows service.");
+                return 5; // ERROR_ACCESS_DENIED
+            }
 
             var originalOut = Console.Out;
             var originalError = Console.Error;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The application uses a configuration file named `app-config.json`. This JSON fil
 - **username**: A string that specifies the username for the proxy (optional).
 - **password**: A string that specifies the password for the proxy (optional).
 - **supportedProtocols**: An array of strings specifying the supported protocols (e.g., `"TCP"`, `"UDP"`).
+- **supportedAddressFamilies**: An array containing `"IPv4"`, `"IPv6"`, or both. If omitted, both are enabled. An explicit empty array or any other value is rejected as a configuration error.
 - **excludes** *(new in v2.1.1)*: An array of application names or paths to exclude from proxy routing.
 - **bypassLan** *(new in v2.2.0)*: A boolean to bypass proxy for local network traffic (default: `false`).
 
@@ -54,10 +55,26 @@ LogLevel can have one of the following values which define the detail of the log
 
 ---
 
+### supportedAddressFamilies
+
+Use `supportedAddressFamilies` when a SOCKS5 proxy cannot relay every destination address family. For example, an IPv4-only proxy should be configured with:
+
+```json
+"supportedAddressFamilies": ["IPv4"]
+```
+
+For a matched application, unsupported destination families are blocked instead of being passed through directly or sent to a SOCKS path that cannot complete. This prevents IPv6 leaks and lets browsers fall back to IPv4 when the proxy only supports IPv4 destinations.
+
+If the field is omitted, ProxiFyre assumes both IPv4 and IPv6 destinations are supported, preserving the previous behavior.
+
+---
+
 ### Excludes (new in v2.1.1)
 
 The `excludes` section lets you define processes that should **bypass the proxy**.  
 This is useful when you want a global proxy setup but keep certain apps (like browsers, local dev tools, or games) unproxied.
+
+When using a catch-all proxy entry (`"appNames": [""]`) together with another VPN, exclude the VPN's carrier process. Otherwise ProxiFyre can capture the VPN's outer tunnel packets, causing the proxy connection to recursively depend on itself and eventually time out.
 
 Unlike `appNames`, exclusion entries match by **substring** (a name is matched against the process's filename, a path-form entry against the full path) — so `chrome` also excludes `chrome_proxy.exe`. Exclusion is deliberately permissive so an app you meant to keep direct is not accidentally proxied.
 
@@ -72,7 +89,8 @@ Example:
       "socks5ProxyEndpoint": "oracle.sshvpn.me:1080",
       "username": "username1",
       "password": "password1",
-      "supportedProtocols": ["TCP", "UDP"]
+      "supportedProtocols": ["TCP", "UDP"],
+      "supportedAddressFamilies": ["IPv4", "IPv6"]
     }
   ],
   "excludes": [
@@ -105,7 +123,8 @@ Example:
     {
       "appNames": ["chrome", "firefox"],
       "socks5ProxyEndpoint": "127.0.0.1:1080",
-      "supportedProtocols": ["TCP", "UDP"]
+      "supportedProtocols": ["TCP", "UDP"],
+      "supportedAddressFamilies": ["IPv4", "IPv6"]
     }
   ]
 }
@@ -131,12 +150,14 @@ If the SOCKS5 proxy does not support authorization, you can skip the `username` 
      "socks5ProxyEndpoint": "158.101.205.51:1080",
      "username": "username1",
      "password": "password1",
-     "supportedProtocols": ["TCP", "UDP"]
+     "supportedProtocols": ["TCP", "UDP"],
+     "supportedAddressFamilies": ["IPv4", "IPv6"]
    },
    {
      "appNames": ["firefox", "firefox_dev"],
      "socks5ProxyEndpoint": "127.0.0.1:8080",
-     "supportedProtocols": ["TCP"]
+     "supportedProtocols": ["TCP"],
+     "supportedAddressFamilies": ["IPv4"]
    }
  ],
  "excludes": [
@@ -191,7 +212,7 @@ Please ensure you download the correct installer to avoid any installation issue
 
 ### Running the Application
 
-4. **Run the Application**: Navigate to the directory where you extracted the software. Find the main application executable (`ProxiFyre.exe`) and run it. It's recommended to run the application as an administrator to ensure all functionalities work as expected.
+4. **Run the Application**: Navigate to the directory where you extracted the software. Start `ProxiFyre.exe` from an Administrator console. Administrative privileges are required for reliable process ownership, exclusions, and packet redirection; interactive startup exits with an error when it is not elevated.
 
 ⚠️ **Firewall Note**: If ProxiFyre does not appear to work, check Windows Firewall. ProxiFyre needs to accept and initiate network connections.
 

--- a/app-config.sample.json
+++ b/app-config.sample.json
@@ -7,7 +7,8 @@
             "socks5ProxyEndpoint": "proxy.example.com:1080",
             "username": "REPLACE_WITH_USERNAME_OR_LEAVE_EMPTY",
             "password": "REPLACE_WITH_PASSWORD_OR_LEAVE_EMPTY",
-            "supportedProtocols": ["TCP", "UDP"]
+            "supportedProtocols": ["TCP", "UDP"],
+            "supportedAddressFamilies": ["IPv4", "IPv6"]
         }
     ],
     "excludes": []

--- a/netlib/src/ndisapi/static_filters.h
+++ b/netlib/src/ndisapi/static_filters.h
@@ -401,12 +401,34 @@ namespace ndisapi
         {
             STATIC_FILTER static_filter{};
             to_static_filter(filter, static_filter);
-            if (AddStaticFilterBack(&static_filter))
+
+            // Allocate/copy the userspace representation before mutating the
+            // driver table. Otherwise a bad_alloc from emplace_back would leave
+            // a driver rule that this object cannot subsequently address/remove.
+            filters_.emplace_back(filter);
+            try
             {
-                filters_.emplace_back(filter);
-                return true;
+                if (AddStaticFilterBack(&static_filter))
+                    return true;
             }
+
+            catch (...)
+            {
+                filters_.pop_back();
+                throw;
+            }
+
+            filters_.pop_back();
             return false;
+        }
+
+        /// <summary>
+        /// Returns the number of filters tracked in userspace and installed in
+        /// the driver table.
+        /// </summary>
+        [[nodiscard]] size_t size() const noexcept
+        {
+            return filters_.size();
         }
 
         /// <summary>

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <condition_variable>
+#include <deque>
+
 // SIO_UDP_CONNRESET normally comes from <mstcpip.h>, but this header-only file relies on the
 // project's master include order and the macro is not reliably visible here across SDKs. Provide
 // the standard fallback definition; _WSAIOW/IOC_VENDOR are from <winsock2.h>, which is always
@@ -72,6 +75,15 @@ namespace proxy
         using query_remote_peer_t = std::tuple<address_type_t, uint16_t, std::unique_ptr<negotiate_context_t>>(
             address_type_t, uint16_t);
 
+        /**
+         * @brief Callback invoked after a UDP relay has been fully established.
+         *
+         * The router uses this as a transaction commit: its source-port authorization
+         * remains available while SOCKS5 connect/ASSOCIATE is in progress and is consumed
+         * only after the relay socket has been published successfully.
+         */
+        using commit_remote_peer_t = void(address_type_t, uint16_t);
+
     private:
         /**
          * @brief Maximum number of simultaneous proxy connections.
@@ -80,6 +92,30 @@ namespace proxy
          * the proxy server will track in its internal connection array.
          */
         constexpr static size_t connections_array_size = 64;
+
+        /**
+         * @brief Requested UDP socket buffer size for QUIC-sized bursts.
+         *
+         * Browser QUIC can emit many ~1200 byte datagrams immediately. The first
+         * datagram for a local UDP source port may need to establish a SOCKS5 TCP
+         * control connection and complete UDP ASSOCIATE before it can be forwarded;
+         * while that happens, the local UDP proxy socket relies on the kernel
+         * receive buffer to hold the rest of the burst.
+         */
+        constexpr static int udp_socket_buffer_size = 4 * 1024 * 1024;
+
+        /** Number of blocking SOCKS5 UDP ASSOCIATE operations allowed in parallel. */
+        constexpr static size_t association_worker_count = 4;
+
+        /** Maximum payload bytes retained while UDP associations are being established. */
+        constexpr static size_t max_pending_datagram_bytes = udp_socket_buffer_size;
+
+        struct pending_datagram  // NOLINT(clang-diagnostic-padded)
+        {
+            SOCKADDR_STORAGE sender{};
+            std::unique_ptr<net_packet_t> packet;
+            uint32_t size{};
+        };
 
         /**
          * @brief Mutex for synchronizing access to internal data structures.
@@ -102,6 +138,22 @@ namespace proxy
          * Periodically checks and removes inactive or closed client connections.
          */
         std::thread check_clients_thread_;
+
+        /** Workers that keep blocking SOCKS5 negotiation off the IOCP threads. */
+        std::vector<std::thread> association_workers_;
+
+        /** One FIFO per source port; a port appears in association_queue_ at most once. */
+        std::map<uint16_t, std::deque<pending_datagram>> pending_datagrams_;
+
+        /** Source ports waiting for one association worker. */
+        std::deque<uint16_t> association_queue_;
+
+        std::condition_variable association_cv_;
+
+        /** Wakes session maintenance immediately when the shared receive needs recovery. */
+        std::condition_variable maintenance_cv_;
+
+        size_t pending_datagram_bytes_{ 0 };
 
         /**
          * @brief Map of active proxy sockets indexed by local UDP port.
@@ -140,7 +192,7 @@ namespace proxy
         per_io_context_t server_io_context_{ proxy_io_operation::relay_io_read, nullptr, true };
 
         /**
-         * @brief Storage for the address of the sender of the last received UDP packet.
+         * @brief Storage populated by the currently outstanding server receive.
          */
         SOCKADDR_STORAGE recv_from_sa_{};
 
@@ -153,6 +205,11 @@ namespace proxy
          * @brief Function to query remote peer information for a given local address and port.
          */
         std::function<query_remote_peer_t> query_remote_peer_;
+
+        /**
+         * @brief Optional callback that commits a successfully established source-port mapping.
+         */
+        std::function<commit_remote_peer_t> commit_remote_peer_;
 
         /**
          * @brief Completion key associated with the server socket in the I/O completion port.
@@ -177,12 +234,272 @@ namespace proxy
          */
         uint16_t proxy_port_;
 
+        /** Set when a completed server receive could not be re-armed synchronously. */
+        std::atomic_bool server_receive_rearm_needed_{ false };
+
         /**
          * @brief Indicates whether the server is terminating.
          *
          * Set to true when the server is stopping or has stopped.
          */
         std::atomic_bool end_server_{ true }; // set to true on proxy termination
+
+        void tune_udp_socket_buffers(const SOCKET socket, const char* const socket_name) const noexcept
+        {
+            const auto set_buffer = [this, socket, socket_name](const int option, const char* const option_name)
+            {
+                int requested_size = udp_socket_buffer_size;
+                if (setsockopt(socket, SOL_SOCKET, option,
+                    reinterpret_cast<const char*>(&requested_size), sizeof(requested_size)) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("{}: failed to set {} to {} bytes: {}",
+                        socket_name, option_name, requested_size, WSAGetLastError());
+                    return;
+                }
+
+                int actual_size = 0;
+                int actual_size_len = static_cast<int>(sizeof(actual_size));
+                if (getsockopt(socket, SOL_SOCKET, option,
+                    reinterpret_cast<char*>(&actual_size), &actual_size_len) == 0)
+                {
+                    NETLIB_DEBUG("{}: {} is {} bytes", socket_name, option_name, actual_size);
+                }
+            };
+
+            set_buffer(SO_RCVBUF, "SO_RCVBUF");
+            set_buffer(SO_SNDBUF, "SO_SNDBUF");
+        }
+
+        [[nodiscard]] std::optional<std::pair<address_type_t, uint16_t>> local_endpoint_from(
+            const SOCKADDR_STORAGE& sender) const
+        {
+            if constexpr (address_type_t::af_type == AF_INET)
+            {
+                if (sender.ss_family != AF_INET)
+                    return std::nullopt;
+
+                const auto* address = reinterpret_cast<const sockaddr_in*>(&sender);
+                return std::pair{ address_type_t{ address->sin_addr }, ntohs(address->sin_port) };
+            }
+            else if constexpr (address_type_t::af_type == AF_INET6)
+            {
+                if (sender.ss_family != AF_INET6)
+                    return std::nullopt;
+
+                const auto* address = reinterpret_cast<const sockaddr_in6*>(&sender);
+                return std::pair{ address_type_t{ address->sin6_addr }, ntohs(address->sin6_port) };
+            }
+            else
+            {
+                static_assert(false_v<T>, "Unsupported address family used as a template parameter!");
+            }
+            return {};
+        }
+
+        bool post_server_receive()
+        {
+            DWORD flags = 0;
+            recv_from_sa_ = {};
+            recv_from_sa_size_ = sizeof(recv_from_sa_);
+            static_cast<WSAOVERLAPPED&>(server_io_context_) = WSAOVERLAPPED{};
+
+            return (::WSARecvFrom(
+                server_socket_,
+                &server_recv_buf_,
+                1,
+                nullptr,
+                &flags,
+                reinterpret_cast<sockaddr*>(&recv_from_sa_),
+                &recv_from_sa_size_,
+                &server_io_context_,
+                nullptr) != SOCKET_ERROR) || (ERROR_IO_PENDING == WSAGetLastError());
+        }
+
+        void release_pending_datagram(pending_datagram& datagram)
+        {
+            if (datagram.packet)
+                packet_pool_->free(std::move(datagram.packet));
+        }
+
+        void forward_pending_datagram(const std::shared_ptr<T>& proxy_socket, pending_datagram& datagram)
+        {
+            if (const auto local_endpoint = local_endpoint_from(datagram.sender))
+                commit_remote_peer(local_endpoint->first, local_endpoint->second);
+
+            per_io_context_t context{ proxy_io_operation::relay_io_read, proxy_socket, true };
+            context.wsa_buf = std::move(datagram.packet);
+            proxy_socket->process_receive_buffer_complete(datagram.size, &context);
+        }
+
+        void process_local_datagram(pending_datagram datagram)
+        {
+            const auto local_endpoint = local_endpoint_from(datagram.sender);
+            if (!local_endpoint || local_endpoint->second == 0)
+            {
+                release_pending_datagram(datagram);
+                return;
+            }
+
+            const auto local_port = local_endpoint->second;
+            std::unique_lock lock(lock_);
+
+            if (end_server_.load(std::memory_order_acquire))
+            {
+                release_pending_datagram(datagram);
+                return;
+            }
+
+            const auto enqueue = [this, local_port](pending_datagram& queued_datagram,  // NOLINT(clang-diagnostic-padded)
+                                                    const bool schedule_association) -> bool
+            {
+                if (queued_datagram.size > max_pending_datagram_bytes ||
+                    pending_datagram_bytes_ > max_pending_datagram_bytes - queued_datagram.size)
+                {
+                    NETLIB_WARNING("Dropping UDP datagram for source port {}: pending association queue is full",
+                        local_port);
+                    release_pending_datagram(queued_datagram);
+                    return false;
+                }
+
+                auto [pending, inserted] = pending_datagrams_.try_emplace(local_port);
+                pending->second.emplace_back(std::move(queued_datagram));
+                pending_datagram_bytes_ += pending->second.back().size;
+
+                if (inserted && schedule_association)
+                {
+                    association_queue_.push_back(local_port);
+                    association_cv_.notify_one();
+                }
+
+                return true;
+            };
+
+            // An empty entry is retained while a newly established relay drains its queued first
+            // flight. Keep appending there so packets cannot overtake datagrams received earlier.
+            if (pending_datagrams_.contains(local_port))
+            {
+                (void)enqueue(datagram, false);
+                return;
+            }
+
+            if (const auto existing = proxy_sockets_.find(local_port); existing != proxy_sockets_.end())
+            {
+                forward_pending_datagram(existing->second, datagram);
+                return;
+            }
+
+            (void)enqueue(datagram, true);
+        }
+
+        void association_worker()
+        {
+            while (true)
+            {
+                std::unique_lock lock(lock_);
+                association_cv_.wait(lock, [this]
+                {
+                    return end_server_.load(std::memory_order_acquire) || !association_queue_.empty();
+                });
+
+                if (end_server_.load(std::memory_order_acquire))
+                    return;
+
+                const auto local_port = association_queue_.front();
+                association_queue_.pop_front();
+
+                auto pending = pending_datagrams_.find(local_port);
+                if (pending == pending_datagrams_.end() || pending->second.empty())
+                    continue;
+
+                const auto sender = pending->second.front().sender;
+                std::shared_ptr<T> proxy_socket;
+
+                try
+                {
+                    if (!connect_to_remote_host(sender, lock, proxy_socket))
+                        proxy_socket.reset();
+                }
+                catch (const std::exception& e)
+                {
+                    if (!lock.owns_lock())
+                        lock.lock();
+                    NETLIB_ERROR("UDP association worker failed for source port {}: {}", local_port, e.what());
+                }
+                catch (...)
+                {
+                    if (!lock.owns_lock())
+                        lock.lock();
+                    NETLIB_ERROR("UDP association worker failed for source port {}: unknown exception", local_port);
+                }
+
+                pending = pending_datagrams_.find(local_port);
+                if (pending == pending_datagrams_.end())
+                    continue;
+
+                if (!proxy_socket || end_server_.load(std::memory_order_acquire))
+                {
+                    auto datagrams = std::move(pending->second);
+                    pending_datagrams_.erase(pending);
+                    for (auto& datagram : datagrams)
+                    {
+                        pending_datagram_bytes_ -= datagram.size;
+                        release_pending_datagram(datagram);
+                    }
+                    continue;
+                }
+
+                // Keep the map entry as an ordering marker while the first flight drains. New
+                // packets append to it instead of bypassing older queued datagrams via the now-live
+                // proxy_sockets_ entry.
+                while (!end_server_.load(std::memory_order_acquire))
+                {
+                    pending = pending_datagrams_.find(local_port);
+                    if (pending == pending_datagrams_.end())
+                        break;
+
+                    if (pending->second.empty())
+                    {
+                        pending_datagrams_.erase(pending);
+                        break;
+                    }
+
+                    auto datagrams = std::move(pending->second);
+                    pending->second.clear();
+
+                    for (auto& datagram : datagrams)
+                    {
+                        pending_datagram_bytes_ -= datagram.size;
+                        forward_pending_datagram(proxy_socket, datagram);
+                        lock.unlock();
+                        std::this_thread::yield();
+                        lock.lock();
+
+                        if (end_server_.load(std::memory_order_acquire))
+                            break;
+                    }
+
+                    if (end_server_.load(std::memory_order_acquire))
+                    {
+                        for (auto& datagram : datagrams)
+                            release_pending_datagram(datagram);
+                    }
+                }
+            }
+        }
+
+        void release_all_pending_datagrams()
+        {
+            std::scoped_lock lock(lock_);
+            for (auto& [port, datagrams] : pending_datagrams_)
+            {
+                for (auto& datagram : datagrams)
+                    release_pending_datagram(datagram);
+            }
+
+            pending_datagrams_.clear();
+            association_queue_.clear();
+            pending_datagram_bytes_ = 0;
+        }
 
     public:
         /**
@@ -202,10 +519,12 @@ namespace proxy
         socks5_local_udp_proxy_server(const uint16_t proxy_port, netlib::winsys::io_completion_port& completion_port,
             const std::function<query_remote_peer_t>& query_remote_peer_fn,
             const log_level log_level = log_level::error,
-            std::shared_ptr<std::ostream> log_stream = nullptr)
+            std::shared_ptr<std::ostream> log_stream = nullptr,
+            const std::function<commit_remote_peer_t>& commit_remote_peer_fn = {})
             : logger(log_level, std::move(log_stream)),
             completion_port_(completion_port),
             query_remote_peer_(query_remote_peer_fn),
+            commit_remote_peer_(commit_remote_peer_fn),
             proxy_port_(proxy_port)
         {
             if (!create_server_socket())
@@ -219,18 +538,19 @@ namespace proxy
         /**
          * @brief Destructor. Cleans up resources and stops the server if running.
          *
-         * Closes the server socket and calls stop() if the server is still running.
+         * Stops a running server before releasing its socket and worker-owned state.
          */
         ~socks5_local_udp_proxy_server()
         {
-            if (server_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
+            if (end_server_ == false)
+            {
+                stop();
+            }
+            else if (server_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
             {
                 closesocket(server_socket_);
                 server_socket_ = INVALID_SOCKET;
             }
-
-            if (end_server_ == false)
-                stop();
         }
 
         // Deleted copy constructor to prevent copying.
@@ -273,6 +593,13 @@ namespace proxy
             }
 
             end_server_ = false;
+            server_receive_rearm_needed_.store(false, std::memory_order_release);
+
+            if (server_socket_ == static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                end_server_ = true;
+                return false;
+            }
 
             if (server_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
             {
@@ -306,13 +633,6 @@ namespace proxy
                             operation_guard& operator=(operation_guard&&) = delete;
                         } guard{ active_iocp_operations_ };
 
-                        auto result = true;
-                        auto server_read = false;
-
-                        // unique_lock (not lock_guard): connect_to_remote_host() releases and
-                        // re-acquires this around its blocking SOCKS5 negotiation (see H2 there).
-                        std::unique_lock lock(lock_);
-
                         auto io_context = static_cast<per_io_context_t*>(povlp);
 
                         // While the server is shutting down we must still fully process each
@@ -323,47 +643,56 @@ namespace proxy
                         // guard keeps outstanding_io_ balanced without a special early return.
                         const bool shutting_down = end_server_.load(std::memory_order_acquire);
 
-                        // If this is the server socket's read operation
+                        // Copy a completed local datagram before reusing the one server buffer and
+                        // OVERLAPPED. The re-post happens before any SOCKS5 setup, so a blocking
+                        // UDP ASSOCIATE can never stop the socket from draining a QUIC burst.
                         if (io_context == &server_io_context_)
                         {
-                            // Server socket read operation complete
-                            server_read = true;
+                            pending_datagram datagram{};
 
                             if (status && num_bytes && !shutting_down)
                             {
-                                do
+                                datagram.packet = packet_pool_->allocate(num_bytes);
+                                if (datagram.packet)
                                 {
-                                    if (false == connect_to_remote_host(io_context, lock))
-                                    {
-                                        result = false;
-                                        break;
-                                    }
-
-                                    io_context->wsa_buf = packet_pool_->allocate(num_bytes);
-
-                                    if (!io_context->wsa_buf)
-                                    {
-                                        result = false;
-                                        break;
-                                    }
-
-                                    io_context->wsa_buf->len = num_bytes;
-                                    memmove(io_context->wsa_buf->buf, server_receive_buffer_.data(), num_bytes);
-                                } while (false);
+                                    datagram.sender = recv_from_sa_;
+                                    datagram.size = num_bytes;
+                                    datagram.packet->len = num_bytes;
+                                    memmove(datagram.packet->buf, server_receive_buffer_.data(), num_bytes);
+                                }
                             }
+
+                            const auto receive_rearmed = shutting_down || post_server_receive();
+                            if (!receive_rearmed)
+                            {
+                                // io_completion_port callbacks have no control-flow return
+                                // contract: their bool result is intentionally ignored. Hand
+                                // recovery to clear_thread instead of leaving this listener
+                                // permanently alive with no outstanding WSARecvFrom.
+                                server_receive_rearm_needed_.store(true, std::memory_order_release);
+                                maintenance_cv_.notify_one();
+                                NETLIB_WARNING("Failed to re-arm the local UDP receive; retrying from the maintenance thread");
+                            }
+
+                            if (datagram.packet)
+                                process_local_datagram(std::move(datagram));
+
+                            return true;
                         }
+
+                        std::unique_lock lock(lock_);
 
                         // Balance the io_posted() done when a per-session overlapped op was
                         // posted. This completion is a real delivery -- success OR failure: an
                         // aborted recv/send flushed by close_client()'s CancelIoEx during teardown
                         // arrives here with status == false. It must therefore decrement the owning
                         // proxy socket's outstanding-I/O count exactly once on every exit path,
-                        // independent of status/result and of whether we dispatch below; trapping
+                        // independent of status and of whether we dispatch below; trapping
                         // the decrement inside "if (status && result)" would leak the count on every
                         // torn-down session and the socket would never become removable. Server-read
                         // completions ride server_io_context_, which no proxy socket ever counted, so
                         // they are excluded. The strong ref keeps the socket alive until decrement.
-                        std::shared_ptr<T> completing_socket = server_read ? nullptr : io_context->proxy_socket_ptr;
+                        std::shared_ptr<T> completing_socket = io_context->proxy_socket_ptr;
                         struct io_dec_guard {
                             T* s;
                             explicit io_dec_guard(T* sock) : s(sock) {}
@@ -386,17 +715,17 @@ namespace proxy
                             // there is nothing to free -- the recv uses a member io_context -- so we
                             // just fall through to the io_dec decrement.
                             case proxy_io_operation::relay_io_read:
-                                if (status && result && !shutting_down)
+                                if (status && !shutting_down)
                                     proxy_socket->process_receive_buffer_complete(num_bytes, io_context);
                                 break;
 
                             case proxy_io_operation::negotiate_io_read:
-                                if (status && result && !shutting_down)
+                                if (status && !shutting_down)
                                     proxy_socket->process_receive_negotiate_complete(num_bytes, io_context);
                                 break;
 
                             case proxy_io_operation::negotiate_io_write:
-                                if (status && result && !shutting_down)
+                                if (status && !shutting_down)
                                     proxy_socket->process_send_negotiate_complete(num_bytes, io_context);
                                 break;
 
@@ -419,57 +748,53 @@ namespace proxy
                             }
                         }
 
-                        if (server_read)
-                        {
-                            // The server read context does not own a session; drop the strong
-                            // reference taken in connect_to_remote_host so a finished session
-                            // is not pinned alive until the next inbound datagram replaces it.
-                            io_context->proxy_socket_ptr.reset();
-
-                            DWORD flags = 0;
-
-                            // Re-arm the server read. The completion this generates will be
-                            // counted when it is dispatched (the fetch_add at the top of this
-                            // lambda), so there is no separate counter bump here.
-                            if (!end_server_)
-                            {
-                                if ((::WSARecvFrom(
-                                    server_socket_,
-                                    &server_recv_buf_,
-                                    1,
-                                    nullptr,
-                                    &flags,
-                                    reinterpret_cast<sockaddr*>(&recv_from_sa_),
-                                    &recv_from_sa_size_,
-                                    &server_io_context_,
-                                    nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                                {
-                                    result = false;
-                                }
-                            }
-                        }
-
-                        return result;
+                        return true;
                    }); associate_status == true)
                 {
                     completion_key_ = io_key;
-                    DWORD flags = 0;
+
+                    try
+                    {
+                        association_workers_.reserve(association_worker_count);
+                        for (size_t i = 0; i < association_worker_count; ++i)
+                        {
+                            association_workers_.emplace_back(
+                                &socks5_local_udp_proxy_server<T>::association_worker, this);
+                        }
+                    }
+                    catch (...)
+                    {
+                        end_server_ = true;
+                        association_cv_.notify_all();
+                        for (auto& worker : association_workers_)
+                        {
+                            if (worker.joinable())
+                                worker.join();
+                        }
+                        association_workers_.clear();
+                        closesocket(server_socket_);
+                        server_socket_ = INVALID_SOCKET;
+                        (void)completion_port_.unregister_handler(completion_key_);
+                        completion_key_ = 0;
+                        return false;
+                    }
 
                     // Post the initial server read. Its completion is counted when dispatched
                     // (the fetch_add at the top of the completion lambda), so no bump here.
-                    if ((::WSARecvFrom(
-                        server_socket_,
-                        &server_recv_buf_,
-                        1,
-                        nullptr,
-                        &flags,
-                        reinterpret_cast<sockaddr*>(&recv_from_sa_),
-                        &recv_from_sa_size_,
-                        &server_io_context_,
-                        nullptr) == SOCKET_ERROR) && (ERROR_IO_PENDING != WSAGetLastError()))
-                   {
-                        closesocket(server_socket_);
+                    if (!post_server_receive())
+                    {
                         end_server_ = true;
+                        association_cv_.notify_all();
+                        for (auto& worker : association_workers_)
+                        {
+                            if (worker.joinable())
+                                worker.join();
+                        }
+                        association_workers_.clear();
+                        closesocket(server_socket_);
+                        server_socket_ = INVALID_SOCKET;
+                        (void)completion_port_.unregister_handler(completion_key_);
+                        completion_key_ = 0;
                         return false;
                     }
                 }
@@ -515,6 +840,8 @@ namespace proxy
 
             // Step 1: Signal shutdown - IOCP lambda will check this and exit
             end_server_ = true;
+            association_cv_.notify_all();
+            maintenance_cv_.notify_all();
 
             // Step 2: Close server socket
             // This causes the pending WSARecvFrom to complete with an error. Note the completion
@@ -527,12 +854,22 @@ namespace proxy
                 server_socket_ = INVALID_SOCKET;
             }
 
+            // Step 3: Association workers may be inside a bounded blocking SOCKS5 handshake. Joining them
+            // here guarantees none can publish a relay after the proxy-socket drain begins.
+            for (auto& worker : association_workers_)
+            {
+                if (worker.joinable())
+                    worker.join();
+            }
+            association_workers_.clear();
+            release_all_pending_datagrams();
+
             // NOTE: the IOCP handler stays registered until AFTER the drain below. The aborted
             // completions produced by close_client()'s CancelIoEx must still dispatch through it so
             // they release their heap contexts and decrement each socket's outstanding_io_;
             // unregistering here would drop those completions and the drain would never complete.
 
-            // Step 3: Cancel every proxy socket's pending I/O so its posted operations complete
+            // Step 4: Cancel every proxy socket's pending I/O so its posted operations complete
             // promptly (aborted) and stop pinning the socket. Keep the sockets in the map for now --
             // they must stay alive until their in-flight completions have drained. Simply clearing
             // the map does NOT destroy them: each socket's recv io_context holds a self-reference,
@@ -550,7 +887,7 @@ namespace proxy
                 }
             }
 
-            // Step 4: Wait until every proxy socket has drained all posted overlapped I/O (its
+            // Step 5: Wait until every proxy socket has drained all posted overlapped I/O (its
             // per-socket outstanding count reaches zero) AND no IOCP callback is still running.
             // The handler is still registered, so close_client()'s aborted completions dispatch,
             // release their heap contexts, and the io_dec guard decrements the count. Gate on the
@@ -599,7 +936,7 @@ namespace proxy
                 std::this_thread::sleep_for(wait_time);
             }
 
-            // Step 4b: Regardless of how the drain loop exited, make sure no IOCP callback is still
+            // Step 5b: Regardless of how the drain loop exited, make sure no IOCP callback is still
             // executing before we proceed. A worker inside the completion lambda has captured `this`
             // (it touches lock_, end_server_, packet_pool_, server_io_context_ and decrements
             // active_iocp_operations_ on the way out), so unregistering the handler and returning
@@ -620,7 +957,7 @@ namespace proxy
                 std::this_thread::sleep_for(std::min(1ms * (1 << std::min(active_wait / 10, 6)), 100ms));
             }
 
-            // Step 5: All completions have now been processed (or we timed out), so unregister the
+            // Step 6: All completions have now been processed (or we timed out), so unregister the
             // IOCP handler -- no further completion will dispatch into this server.
             if (completion_key_ != 0)
             {
@@ -628,7 +965,7 @@ namespace proxy
                 completion_key_ = 0;
             }
 
-            // Step 6: Only if the drain completed do we break each socket's self-reference and clear
+            // Step 7: Only if the drain completed do we break each socket's self-reference and clear
             // the map so the sockets (and their already-released heap I/O contexts) destruct. If the
             // drain timed out, some overlapped op is still outstanding; releasing/clearing now would
             // free an io_context that a still-queued completion could dereference, so we deliberately
@@ -644,7 +981,7 @@ namespace proxy
                 proxy_sockets_.clear();
             }
 
-            // Step 7: Join background threads
+            // Step 8: Join background threads
             if (proxy_server_.joinable())
             {
                 proxy_server_.join();
@@ -680,6 +1017,26 @@ namespace proxy
             return std::make_tuple(address_type_t{}, 0, nullptr);
         }
 
+        void commit_remote_peer(const address_type_t accepted_peer_address,
+            const uint16_t accepted_peer_port) const noexcept
+        {
+            if (!commit_remote_peer_)
+                return;
+
+            try
+            {
+                commit_remote_peer_(accepted_peer_address, accepted_peer_port);
+            }
+            catch (const std::exception& e)
+            {
+                NETLIB_WARNING("Failed to commit UDP source-port mapping {}: {}", accepted_peer_port, e.what());
+            }
+            catch (...)
+            {
+                NETLIB_WARNING("Failed to commit UDP source-port mapping {}: unknown error", accepted_peer_port);
+            }
+        }
+
         /**
          * @brief Creates and binds the UDP server socket for the proxy server.
          *
@@ -713,6 +1070,8 @@ namespace proxy
                         WSAGetLastError());
                 }
             }
+
+            tune_udp_socket_buffers(server_socket_, "local UDP proxy server socket");
 
             if constexpr (address_type_t::af_type == AF_INET)
             {
@@ -1282,7 +1641,7 @@ namespace proxy
          * @brief Establishes a UDP relay session to a remote host through a SOCKS5 proxy.
          *
          * This method is responsible for setting up a UDP relay for a new client connection.
-         * It determines the local peer's address and port from the last received UDP packet,
+         * It determines the local peer's address and port from the captured UDP sender,
          * checks if a proxy socket for this client already exists, and if not:
          *   - Resolves the remote SOCKS5 proxy address, port, and negotiation context.
          *   - Establishes a TCP connection to the SOCKS5 proxy and performs authentication/negotiation.
@@ -1293,56 +1652,52 @@ namespace proxy
          *
          * If any step fails, all resources are cleaned up and the method returns false.
          *
-         * @param io_context Pointer to the per-I/O context structure for the current operation.
-         *                   On success, its proxy_socket_ptr is set to the active proxy socket.
+         * @param local_peer_sa Address of the local UDP sender captured with its datagram.
+         * @param lock Server mutex lock. Blocking setup temporarily releases it.
+         * @param proxy_socket Receives the established or existing relay session.
          * @return True if the relay session was established or already exists, false on failure.
          */
-        bool connect_to_remote_host(per_io_context_t* io_context, std::unique_lock<std::mutex>& lock)
+        bool connect_to_remote_host(const SOCKADDR_STORAGE& local_peer_sa, std::unique_lock<std::mutex>& lock,
+            std::shared_ptr<T>& proxy_socket)
         {
-            uint16_t local_peer_port = 0;
-            address_type_t local_peer_address{};
+            const auto local_endpoint = local_endpoint_from(local_peer_sa);
+            if (!local_endpoint || local_endpoint->second == 0)
+                return false;
 
-            if constexpr (address_type_t::af_type == AF_INET)
-            {
-                local_peer_port = ntohs(reinterpret_cast<sockaddr_in*>(&recv_from_sa_)->sin_port);
-                local_peer_address = address_type_t(reinterpret_cast<sockaddr_in*>(&recv_from_sa_)->sin_addr);
-            }
-            else if constexpr (address_type_t::af_type == AF_INET6)
-            {
-                local_peer_port = ntohs(reinterpret_cast<sockaddr_in6*>(&recv_from_sa_)->sin6_port);
-                local_peer_address = address_type_t(reinterpret_cast<sockaddr_in6*>(&recv_from_sa_)->sin6_addr);
-            }
-            else
-            {
-                static_assert(false_v<T>, "Unsupported address family used as a template parameter!");
-            }
+            const auto& [local_peer_address, local_peer_port] = *local_endpoint;
 
             // Lookup an existing proxy socket
             if (auto it = proxy_sockets_.find(local_peer_port); it != proxy_sockets_.end())
             {
-                // Set to shared_ptr instead of raw pointer
-                io_context->proxy_socket_ptr = it->second;
+                proxy_socket = it->second;
+                // Each redirected datagram refreshes the router's source-port
+                // authorization. Consume that refresh even when the relay session
+                // already exists so no stale authorization is left behind.
+                commit_remote_peer(local_peer_address, local_peer_port);
                 return true;
             }
 
             auto [remote_address, remote_port, negotiate_ctx] =
                 get_remote_peer(local_peer_address, local_peer_port);
 
+            if (remote_port == 0 || !negotiate_ctx)
+            {
+                NETLIB_DEBUG(
+                    "connect_to_remote_host: No valid UDP source-port mapping for {}:{}",
+                    local_peer_address,
+                    local_peer_port);
+                return false;
+            }
+
             NETLIB_DEBUG(
                 "connect_to_remote_host: Connect to SOCKS5 proxy and send ASSOCIATE command: {}:{}",
                 remote_address,
                 remote_port);
 
-            // H2: the SOCKS5 TCP connect + ASSOCIATE below is fully blocking (connect_with_timeout
-            // up to ~5s, then several blocking send/recv each bounded only by a ~5s timeout), so it
-            // can hold lock_ for 10s+. Under lock_ that freezes EVERY other UDP completion for this
-            // proxy plus clear_thread and stop(). Release lock_ across the blocking negotiation and
-            // relay-socket setup. This is safe: the server read is serialized (recv_from_sa_ and
-            // server_receive_buffer_ are not re-armed until after this returns), the new session is
-            // not yet in proxy_sockets_ so no other completion can touch it, and our completion's
-            // active_iocp_operations_ guard is still held so stop() cannot tear the server down
-            // underneath us. We re-acquire lock_ and re-check end_server_ before publishing. Every
-            // early return below re-acquires lock_ first: the caller relies on it being held.
+            // SOCKS5 TCP connect + ASSOCIATE is blocking and may take several seconds. This method
+            // runs only on the dedicated association workers, and releases lock_ so independent
+            // source ports and ordinary relay completions continue. stop() joins the workers before
+            // tearing down published sessions. Every early return below re-acquires lock_.
             lock.unlock();
 
             auto socks5_tcp_socket = connect_to_socks5_proxy(remote_address, remote_port);
@@ -1386,6 +1741,8 @@ namespace proxy
                 lock.lock();
                 return false;
             }
+
+            tune_udp_socket_buffers(remote_socket, "SOCKS5 UDP relay socket");
 
             // Suppress spurious WSAECONNRESET on the relay socket too (see create_server_socket):
             // an ICMP port-unreachable from the SOCKS5 UDP relay must not kill this relay's reads.
@@ -1494,10 +1851,9 @@ namespace proxy
             // proxy_sockets_ and the server members are accessed under the lock again.
             lock.lock();
 
-            // stop() may have set end_server_ during the unlocked window. It is currently blocked in
-            // its drain loop waiting on our active_iocp_operations_ guard, so the server object is
-            // still alive -- but we must not create a NEW session during shutdown (it would only be
-            // torn down again). Abort cleanly.
+            // stop() may have set end_server_ during the unlocked window. It joins association
+            // workers before tearing down sessions, so the server object is still alive, but a NEW
+            // session must not be published during shutdown.
             if (end_server_.load(std::memory_order_acquire))
             {
                 closesocket(remote_socket);
@@ -1505,20 +1861,21 @@ namespace proxy
                 return false;
             }
 
-            // Server reads are serialized so no concurrent creation for this source port is expected,
-            // but guard defensively: if an entry appeared meanwhile, drop what we built and use it.
+            // A source port is scheduled to one association worker, but guard defensively: if an
+            // entry appeared meanwhile, drop what we built and use it.
             if (auto existing = proxy_sockets_.find(local_peer_port); existing != proxy_sockets_.end())
             {
                 closesocket(remote_socket);
                 closesocket(socks5_tcp_socket);
-                io_context->proxy_socket_ptr = existing->second;
+                proxy_socket = existing->second;
+                commit_remote_peer(local_peer_address, local_peer_port);
                 return true;
             }
 
             auto [it, result] = proxy_sockets_.emplace(local_peer_port,
                 std::make_shared<T>(
                     socks5_tcp_socket, packet_pool_, server_socket_,
-                    recv_from_sa_, remote_socket, udp_endpoint->ip,
+                    local_peer_sa, remote_socket, udp_endpoint->ip,
                     udp_endpoint->port, std::move(negotiate_ctx),
                     logger::log_level_, logger::log_stream_));
 
@@ -1529,12 +1886,13 @@ namespace proxy
                     // Initialize I/O contexts with shared_ptr
                     it->second->initialize_io_contexts();
 
-                    // Now safe to associate and start
-                    it->second->associate_to_completion_port(completion_key_, completion_port_);
-                    it->second->start();
+                    if (!it->second->associate_to_completion_port(completion_key_, completion_port_))
+                        throw std::runtime_error("failed to associate UDP relay sockets with IOCP");
 
-                    // Set the context pointer to the shared_ptr
-                    io_context->proxy_socket_ptr = it->second;
+                    if (!it->second->start())
+                        throw std::runtime_error("failed to start UDP data relay");
+
+                    proxy_socket = it->second;
                 }
                 catch (const std::exception& e)
                 {
@@ -1571,6 +1929,8 @@ namespace proxy
                 return false;
             }
 
+            commit_remote_peer(local_peer_address, local_peer_port);
+
             return result;
         }
 
@@ -1595,8 +1955,8 @@ namespace proxy
          * 0. Releasing the self-reference inline while that completion is outstanding would risk
          * a use-after-free when the IOCP handler finally dereferences its proxy_socket_ptr. This
          * mirrors the drain gate in socks5_udp_proxy_socket::is_ready_for_removal(). Runs under
-         * the caller's lock_ (connect_to_remote_host is called while the completion handler
-         * holds it), which serializes this against completions and clear_thread.
+         * the caller's lock_ (connect_to_remote_host is called by an association worker while
+         * holding it), which serializes this against completions and clear_thread.
          *
          * @param it Valid iterator into proxy_sockets_ for the failed session.
          */
@@ -1637,8 +1997,18 @@ namespace proxy
         {
             while (end_server_ == false)
             {
+                bool receive_retry_failed = false;
+                if (server_receive_rearm_needed_.exchange(false, std::memory_order_acq_rel) &&
+                    end_server_.load(std::memory_order_acquire) == false &&
+                    !post_server_receive())
                 {
-                    std::scoped_lock lock(lock_);
+                    server_receive_rearm_needed_.store(true, std::memory_order_release);
+                    receive_retry_failed = true;
+                    NETLIB_WARNING("Maintenance retry failed to re-arm the local UDP receive");
+                }
+
+                {
+                    std::unique_lock lock(lock_);
 
                     for (auto it = proxy_sockets_.begin(); it != proxy_sockets_.end();)
                     {
@@ -1651,10 +2021,26 @@ namespace proxy
                             ++it;
                         }
                     }
-                }
 
-                using namespace std::chrono_literals;
-                std::this_thread::sleep_for(1000ms);
+                    using namespace std::chrono_literals;
+                    if (receive_retry_failed)
+                    {
+                        // Keep a persistent socket error from turning the maintenance
+                        // thread into a tight retry/log loop.
+                        maintenance_cv_.wait_for(lock, 1000ms, [this]
+                        {
+                            return end_server_.load(std::memory_order_acquire);
+                        });
+                    }
+                    else
+                    {
+                        maintenance_cv_.wait_for(lock, 1000ms, [this]
+                        {
+                            return end_server_.load(std::memory_order_acquire) ||
+                                server_receive_rearm_needed_.load(std::memory_order_acquire);
+                        });
+                    }
+                }
             }
         }
     };

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -3153,7 +3153,7 @@ namespace proxy
             // redirect also captures IPv4-mapped destinations (::ffff:a.b.c.d) that a
             // dual-stack app opens to a v4 LAN host, the IPv4 private/link-local/multicast
             // ranges are also exempted in their v4-mapped form so bypassLan covers them.
-            static constexpr std::array<const char*, 9> local_ranges{ {
+            static constexpr std::array<const char*, 10> local_ranges{ {
                 "::1/128",                  // Loopback
                 "fe80::/10",                // Link-local unicast
                 "fc00::/7",                 // Unique local addresses (ULA)
@@ -3162,7 +3162,8 @@ namespace proxy
                 "::ffff:172.16.0.0/108",    // IPv4-mapped 172.16.0.0/12 (private)
                 "::ffff:192.168.0.0/112",   // IPv4-mapped 192.168.0.0/16 (private)
                 "::ffff:169.254.0.0/112",   // IPv4-mapped 169.254.0.0/16 (link-local)
-                "::ffff:127.0.0.0/104"      // IPv4-mapped loopback
+                "::ffff:127.0.0.0/104",     // IPv4-mapped loopback
+                "::ffff:224.0.0.0/100"      // IPv4-mapped 224.0.0.0/4 (multicast)
             } };
 
             for (const auto* const cidr : local_ranges)

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -49,6 +49,61 @@ namespace proxy
          */
         using s5_udp_proxy_server_v6 = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<net::ip_address_v6>>;
 
+    public:
+        enum supported_protocols : uint8_t
+        {
+            tcp,
+            udp,
+            both
+        };
+
+        enum supported_address_families : uint8_t
+        {
+            ipv4,
+            ipv6,
+            all
+        };
+
+        struct resolved_proxy_endpoint
+        {
+            std::optional<net::ip_endpoint<net::ip_address_v4>> ipv4;
+            std::optional<net::ip_endpoint<net::ip_address_v6>> ipv6;
+        };
+
+    private:
+        enum class proxy_port_action : uint8_t
+        {
+            none,
+            proxy,
+            block
+        };
+
+        struct proxy_port_result
+        {
+            proxy_port_action action{ proxy_port_action::none };
+            uint16_t port{};  // NOLINT(clang-diagnostic-padded)
+        };
+
+        static bool protocol_supports_tcp(const supported_protocols protocols) noexcept
+        {
+            return protocols == supported_protocols::both || protocols == supported_protocols::tcp;
+        }
+
+        static bool protocol_supports_udp(const supported_protocols protocols) noexcept
+        {
+            return protocols == supported_protocols::both || protocols == supported_protocols::udp;
+        }
+
+        static bool family_supports_ipv4(const supported_address_families families) noexcept
+        {
+            return families == supported_address_families::all || families == supported_address_families::ipv4;
+        }
+
+        static bool family_supports_ipv6(const supported_address_families families) noexcept
+        {
+            return families == supported_address_families::all || families == supported_address_families::ipv6;
+        }
+
         /**
          * @brief Entry stored in the TCP source-port mappers: redirected destination
          *        endpoint and the steady-clock timestamp at which the mapping was
@@ -84,6 +139,16 @@ namespace proxy
          *        entries indefinitely.
          */
         static constexpr std::chrono::seconds tcp_mapper_entry_ttl_{ 30 };
+
+        /**
+         * @brief Maximum age for an uncommitted UDP source-port authorization.
+         *
+         * Unlike TCP, UDP setup may fail after the first redirected datagram while
+         * establishing the SOCKS5 control connection and UDP ASSOCIATE. Keeping the
+         * authorization until setup commits permits a retry; the TTL prevents stale
+         * source-port reuse from authorizing an unrelated later socket.
+         */
+        static constexpr std::chrono::seconds udp_mapper_entry_ttl_{ 30 };
 
         /**
          * @brief Maximum number of packets that may be queued for deferred process
@@ -123,8 +188,8 @@ namespace proxy
         /**
          * @brief Stores the set of UDP ports being mapped.
          */
-        std::unordered_set<uint16_t> udp_mapper_;
-        std::unordered_set<uint16_t> udp_mapper_v6_;
+        std::unordered_map<uint16_t, std::chrono::steady_clock::time_point> udp_mapper_;
+        std::unordered_map<uint16_t, std::chrono::steady_clock::time_point> udp_mapper_v6_;
 
         /**
          * @brief Mutex to synchronize access to the TCP port mapping.
@@ -160,6 +225,16 @@ namespace proxy
          *        IPv4 and IPv6 proxy pair.
          */
         std::vector<std::pair<std::unique_ptr<s5_tcp_proxy_server_v6>, std::unique_ptr<s5_udp_proxy_server_v6>>> proxy_servers_v6_;
+
+        /**
+         * @brief Configured protocol support for each proxy, index-aligned with proxy_servers_.
+         */
+        std::vector<supported_protocols> proxy_protocols_;
+
+        /**
+         * @brief Configured destination address-family support for each proxy, index-aligned with proxy_servers_.
+         */
+        std::vector<supported_address_families> proxy_address_families_;
 
         /**
          * @brief Maps proxy indexes to their corresponding process names (sorted by proxy ID).
@@ -430,13 +505,6 @@ namespace proxy
         }
 
     public:
-        enum supported_protocols : uint8_t
-        {
-            tcp,
-            udp,
-            both
-        };
-
         /**
          * The socks_local_router class constructor, used to set up a local router to handle SOCKS traffic.
          * It creates instances of `tcp_local_redirect`, `socks5_udp_local_redirect` and `queued_packet_filter`
@@ -734,8 +802,8 @@ namespace proxy
 
                 // Start the IPv6 proxies (index-aligned with proxy_servers_). IPv6
                 // listeners are optional: if the OS/socket stack rejects either half
-                // of the pair, disable that IPv6 slot so later packet handling falls
-                // back to pass-through instead of redirecting to a dead local port.
+                // of the pair, disable that IPv6 slot so later packet handling blocks
+                // matched traffic instead of redirecting to a dead local port.
                 for (auto& [tcp, udp] : proxy_servers_v6_)
                 {
                     // Disable this IPv6 slot by moving its servers out of the shared
@@ -1090,11 +1158,18 @@ namespace proxy
 
                         if (const auto it = mapper.find(port); it != mapper.end())
                         {
+                            if (std::chrono::steady_clock::now() - it->second > udp_mapper_entry_ttl_)
+                            {
+                                NETLIB_LOG(log_level::warning,
+                                    "UDP Redirect entry for port {} was stale (age exceeded TTL); discarding.",
+                                    port);
+                                mapper.erase(it);
+                                return std::make_tuple(AddrT{}, 0, nullptr);
+                            }
+
                             NETLIB_LOG(log_level::info,
                                 "UDP Redirect entry was found for the {} : {}",
                                 std::string{ address }, port);
-
-                            mapper.erase(it);
 
                             return std::make_tuple(upstream.ip, upstream.port,
                                 std::make_unique<udp_negotiate_t>(
@@ -1104,7 +1179,13 @@ namespace proxy
                         }
 
                         return std::make_tuple(AddrT{}, 0, nullptr);
-                    }, log_level_, log_stream_)
+                    }, log_level_, log_stream_,
+                    [this]([[maybe_unused]] const AddrT address, const uint16_t port)
+                    {
+                        auto& mapper = udp_mapper_for<AddrT>();
+                        std::scoped_lock lock(udp_mapper_lock_for<AddrT>());
+                        mapper.erase(port);
+                    })
                 : nullptr;
 
             return { std::move(tcp_server), std::move(udp_server) };
@@ -1116,6 +1197,7 @@ namespace proxy
          * @param endpoint string representing the endpoint of the SOCKS5 proxy server.
          * @param protocols enum representing the protocols to be proxied.
          * @param cred_pair optional pair of strings representing username and password for authentication.
+         * @param address_families enum representing the destination address family/families to be proxied.
          * @param start boolean flag to start the proxy server after creating it.
          * @return an optional value containing the index of the added proxy server if successful, std::nullopt otherwise.
          */
@@ -1123,6 +1205,7 @@ namespace proxy
             const std::string& endpoint,
             const supported_protocols protocols,
             const std::optional<std::pair<std::string, std::string>>& cred_pair,
+            const supported_address_families address_families = supported_address_families::all,
             const bool start = false
         )
         {
@@ -1141,6 +1224,25 @@ namespace proxy
                 return {};
             }
 
+            const auto ipv4_destinations_enabled = family_supports_ipv4(address_families);
+            const auto ipv6_destinations_enabled = family_supports_ipv6(address_families);
+
+            if (!ipv4_destinations_enabled && !ipv6_destinations_enabled)
+            {
+                NETLIB_LOG(log_level::error,
+                    "Failed to add SOCKS5 proxy {}: no destination address families are enabled.",
+                    endpoint);
+                return {};
+            }
+
+            if (!proxy_endpoint->ipv4)
+            {
+                NETLIB_LOG(log_level::error,
+                    "Failed to add SOCKS5 proxy {}: the proxy endpoint must resolve to an IPv4 address.",
+                    endpoint);
+                return {};
+            }
+
             // Serialize the lifecycle-state mutations (filter list, proxy
             // construction/start, and proxy_servers_ insertion) against
             // start()/stop() so that this function cannot register/start a
@@ -1148,31 +1250,6 @@ namespace proxy
             // otherwise leave a running proxy that the cleanup snapshot of
             // proxy_servers_ has already missed) or with stop().
             std::scoped_lock lifecycle_lock(lifecycle_mutex_);
-
-            // Construct filter objects for the TCP and UDP traffic to and from the proxy server
-            // These filters are used to decide which packets to pass or drop
-            // They are configured to match packets based on their source/destination IP and port numbers
-            // and their protocol (TCP or UDP)
-            auto create_filter = [](const uint8_t protocol, const ndisapi::direction_t direction,
-                const net::ip_address_v4& address, const uint16_t port)
-            {
-                ndisapi::filter<net::ip_address_v4> filter;
-                filter.set_protocol(protocol)
-                    .set_direction(direction)
-                    .set_action(ndisapi::action_t::pass)
-                    .set_dest_address(net::ip_subnet{ address, net::ip_address_v4{"255.255.255.255"} })
-                    .set_dest_port(std::make_pair(port, port));
-                return filter;
-            };
-
-            const auto tcp_out_filter = create_filter(IPPROTO_TCP, ndisapi::direction_t::out, proxy_endpoint.value().ip,
-                                                      proxy_endpoint.value().port);
-            const auto tcp_in_filter = create_filter(IPPROTO_TCP, ndisapi::direction_t::in, proxy_endpoint.value().ip,
-                                                     proxy_endpoint.value().port);
-            const auto udp_out_filter = create_filter(IPPROTO_UDP, ndisapi::direction_t::out, proxy_endpoint.value().ip,
-                                                      proxy_endpoint.value().port);
-            const auto udp_in_filter = create_filter(IPPROTO_UDP, ndisapi::direction_t::in, proxy_endpoint.value().ip,
-                                                     proxy_endpoint.value().port);
 
             // NOTE: the static PASS filters for the upstream endpoint are installed only AFTER
             // the proxy pair is successfully built and (optionally) started -- see below, just
@@ -1184,46 +1261,87 @@ namespace proxy
                 // Create the IPv4 proxy-server pair first; this is the historical,
                 // required path. The IPv6 pair is best-effort below so IPv4 proxy
                 // registration still works on hosts where IPv6 sockets are disabled.
-                auto [socks_tcp_proxy_server, socks_udp_proxy_server] =
-                    build_proxy_pair<net::ip_address_v4>(proxy_endpoint.value(), protocols, cred_pair);
+                std::unique_ptr<s5_tcp_proxy_server> socks_tcp_proxy_server;
+                std::unique_ptr<s5_udp_proxy_server> socks_udp_proxy_server;
+
+                if (ipv4_destinations_enabled)
+                {
+                    auto proxy_pair_v4 = build_proxy_pair<net::ip_address_v4>(*proxy_endpoint->ipv4, protocols, cred_pair);
+                    socks_tcp_proxy_server = std::move(proxy_pair_v4.first);
+                    socks_udp_proxy_server = std::move(proxy_pair_v4.second);
+                }
 
                 std::unique_ptr<s5_tcp_proxy_server_v6> socks_tcp_proxy_server_v6;
                 std::unique_ptr<s5_udp_proxy_server_v6> socks_udp_proxy_server_v6;
+                std::optional<net::ip_endpoint<net::ip_address_v6>> upstream_v6;
 
-                try
+                if (ipv6_destinations_enabled)
                 {
-                    // The IPv6 path connects to the IPv4-mapped form of the configured
-                    // upstream over a dual-stack socket, so existing IPv4 SOCKS5
-                    // endpoints (e.g. 127.0.0.1:1080) keep working while IPv6
-                    // destinations are proxied instead of leaking.
-                    // Build the IPv4-mapped IPv6 form of the configured (IPv4) upstream
-                    // directly from its octets rather than via "::ffff:" + string parsing,
-                    // which would silently yield :: on a parse failure under NDEBUG.
-                    in6_addr mapped_upstream{};
-                    mapped_upstream.u.Byte[10] = 0xff;
-                    mapped_upstream.u.Byte[11] = 0xff;
-                    const in_addr upstream_v4 = proxy_endpoint.value().ip;
-                    memcpy(&mapped_upstream.u.Byte[12], &upstream_v4, sizeof(upstream_v4));
-                    const net::ip_endpoint<net::ip_address_v6> upstream_v6{
-                        net::ip_address_v6{ mapped_upstream },
-                        proxy_endpoint.value().port
-                    };
+                    try
+                    {
+                        // Use one deterministic upstream transport for both listener families.
+                        // AF_INET6 listeners reach the proxy's A record through an IPv4-mapped
+                        // address on their dual-stack sockets. This avoids silently selecting a
+                        // potentially unroutable AAAA record merely because the destination is IPv6.
+                        in6_addr mapped_upstream{};
+                        mapped_upstream.u.Byte[10] = 0xff;
+                        mapped_upstream.u.Byte[11] = 0xff;
+                        const in_addr upstream_v4 = proxy_endpoint->ipv4->ip;
+                        memcpy(&mapped_upstream.u.Byte[12], &upstream_v4, sizeof(upstream_v4));
+                        upstream_v6 = net::ip_endpoint<net::ip_address_v6>{
+                            net::ip_address_v6{ mapped_upstream },
+                            proxy_endpoint->ipv4->port
+                        };
 
-                    auto proxy_pair_v6 = build_proxy_pair<net::ip_address_v6>(upstream_v6, protocols, cred_pair);
-                    socks_tcp_proxy_server_v6 = std::move(proxy_pair_v6.first);
-                    socks_udp_proxy_server_v6 = std::move(proxy_pair_v6.second);
+                        auto proxy_pair_v6 = build_proxy_pair<net::ip_address_v6>(*upstream_v6, protocols, cred_pair);
+                        socks_tcp_proxy_server_v6 = std::move(proxy_pair_v6.first);
+                        socks_udp_proxy_server_v6 = std::move(proxy_pair_v6.second);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        NETLIB_LOG(log_level::warning,
+                            "IPv6 SOCKS5 proxy listeners for {} are disabled: {}",
+                            endpoint, e.what());
+                    }
+                    catch (...)
+                    {
+                        NETLIB_LOG(log_level::warning,
+                            "IPv6 SOCKS5 proxy listeners for {} are disabled: unknown error",
+                            endpoint);
+                    }
                 }
-                catch (const std::exception& e)
+
+                const auto has_requested_listeners = [protocols](const auto& tcp_server, const auto& udp_server) noexcept
                 {
-                    NETLIB_LOG(log_level::warning,
-                        "IPv6 SOCKS5 proxy listeners for {} are disabled: {}",
-                        endpoint, e.what());
-                }
-                catch (...)
+                    return (!protocol_supports_tcp(protocols) || tcp_server) &&
+                        (!protocol_supports_udp(protocols) || udp_server);
+                };
+
+                if (ipv4_destinations_enabled &&
+                    !has_requested_listeners(socks_tcp_proxy_server, socks_udp_proxy_server))
                 {
-                    NETLIB_LOG(log_level::warning,
-                        "IPv6 SOCKS5 proxy listeners for {} are disabled: unknown error",
+                    NETLIB_LOG(log_level::error,
+                        "Failed to add SOCKS5 proxy {}: IPv4 destination listeners were not created.",
                         endpoint);
+                    return {};
+                }
+
+                if (ipv6_destinations_enabled &&
+                    !has_requested_listeners(socks_tcp_proxy_server_v6, socks_udp_proxy_server_v6))
+                {
+                    if (!ipv4_destinations_enabled)
+                    {
+                        NETLIB_LOG(log_level::error,
+                            "Failed to add SOCKS5 proxy {}: IPv6 destination listeners were not created.",
+                            endpoint);
+                        return {};
+                    }
+
+                    NETLIB_LOG(log_level::warning,
+                        "IPv6 destination proxying for {} is disabled because IPv6 listeners were not created.",
+                        endpoint);
+                    socks_tcp_proxy_server_v6.reset();
+                    socks_udp_proxy_server_v6.reset();
                 }
 
                 if (start) // optionally start proxies
@@ -1248,8 +1366,11 @@ namespace proxy
                         return true;
                     };
 
-                    if (!start_listener(socks_tcp_proxy_server, "IPv4", "TCP")) return {};
-                    if (!start_listener(socks_udp_proxy_server, "IPv4", "UDP")) return {};
+                    if (ipv4_destinations_enabled)
+                    {
+                        if (!start_listener(socks_tcp_proxy_server, "IPv4", "TCP")) return {};
+                        if (!start_listener(socks_udp_proxy_server, "IPv4", "UDP")) return {};
+                    }
 
                     const auto disable_ipv6_listeners = [&]
                     {
@@ -1262,30 +1383,129 @@ namespace proxy
                         socks_udp_proxy_server_v6.reset();
                     };
 
-                    if (!start_listener(socks_tcp_proxy_server_v6, "IPv6", "TCP") ||
-                        !start_listener(socks_udp_proxy_server_v6, "IPv6", "UDP"))
+                    if (ipv6_destinations_enabled &&
+                        (!start_listener(socks_tcp_proxy_server_v6, "IPv6", "TCP") ||
+                        !start_listener(socks_udp_proxy_server_v6, "IPv6", "UDP")))
                     {
+                        if (!ipv4_destinations_enabled)
+                            return {};
+
                         disable_ipv6_listeners();
                     }
                 }
 
-                // Install the static PASS filters for the upstream endpoint only NOW that the
-                // proxy pair has been successfully built and (if requested) started. add_filter_back
-                // commits immediately to the driver, so installing earlier leaked orphaned filters
-                // on every failure path (build_proxy_pair throwing, or a required listener failing
-                // to start and returning {}). Kept under lifecycle_lock and outside lock_, mirroring
-                // the original lock scope.
-                if (protocols == both || protocols == udp)
+                // Reserve every index-aligned vector before touching the driver
+                // filter table. Once these reserves succeed, publishing the proxy
+                // pair below consists only of noexcept moves/copies.
                 {
-                    static_filters_.add_filter_back(tcp_out_filter);
-                    static_filters_.add_filter_back(tcp_in_filter);
-                    static_filters_.add_filter_back(udp_out_filter);
-                    static_filters_.add_filter_back(udp_in_filter);
+                    std::scoped_lock lock(lock_);
+                    proxy_servers_.reserve(proxy_servers_.size() + 1);
+                    proxy_servers_v6_.reserve(proxy_servers_v6_.size() + 1);
+                    proxy_protocols_.reserve(proxy_protocols_.size() + 1);
+                    proxy_address_families_.reserve(proxy_address_families_.size() + 1);
                 }
-                else if (protocols == tcp)
+
+                // Install PASS filters only for upstream addresses selected by
+                // listeners that survived construction/start. Inbound filters match
+                // the proxy as the packet source; outbound filters match it as the
+                // destination.
+                const auto install_upstream_filters = [this, protocols](const auto& upstream) -> bool  // NOLINT(clang-diagnostic-padded)
                 {
-                    static_filters_.add_filter_back(tcp_out_filter);
-                    static_filters_.add_filter_back(tcp_in_filter);
+                    using address_t = std::remove_cvref_t<decltype(upstream.ip)>;
+                    const auto mask = []
+                    {
+                        if constexpr (std::is_same_v<address_t, net::ip_address_v4>)
+                            return net::ip_address_v4{ "255.255.255.255" };
+                        else
+                            return net::ip_address_v6{ "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" };
+                    }();
+                    const net::ip_subnet<address_t> subnet{ upstream.ip, mask };
+
+                    const auto create_filter = [&subnet, &upstream](const uint8_t protocol,
+                                                                    const ndisapi::direction_t direction,
+                                                                    const bool match_configured_port)
+                    {
+                        ndisapi::filter<address_t> filter;
+                        filter.set_protocol(protocol)
+                            .set_direction(direction)
+                            .set_action(ndisapi::action_t::pass);
+
+                        if (direction == ndisapi::direction_t::in)
+                        {
+                            filter.set_source_address(subnet);
+                            if (match_configured_port)
+                                filter.set_source_port(std::make_pair(upstream.port, upstream.port));
+                        }
+                        else
+                        {
+                            filter.set_dest_address(subnet);
+                            if (match_configured_port)
+                                filter.set_dest_port(std::make_pair(upstream.port, upstream.port));
+                        }
+
+                        return filter;  // NOLINT(clang-diagnostic-nrvo)
+                    };
+
+                    const auto first_filter_position = static_filters_.size();
+                    const auto rollback = [this, first_filter_position]
+                    {
+                        while (static_filters_.size() > first_filter_position)
+                        {
+                            if (!static_filters_.remove_filter(static_cast<uint32_t>(first_filter_position)))
+                            {
+                                NETLIB_LOG(log_level::error,
+                                    "Failed to roll back an upstream PASS filter at position {}.",
+                                    first_filter_position);
+                                break;
+                            }
+                        }
+                    };
+
+                    try
+                    {
+                        const auto add_filter = [this, &rollback](const auto& filter)
+                        {
+                            if (static_filters_.add_filter_back(filter))
+                                return true;
+
+                            rollback();
+                            return false;
+                        };
+
+                        if (!add_filter(create_filter(IPPROTO_TCP, ndisapi::direction_t::out, true)) ||
+                            !add_filter(create_filter(IPPROTO_TCP, ndisapi::direction_t::in, true)))
+                            return false;
+
+                        if (protocol_supports_udp(protocols))
+                        {
+                            // UDP ASSOCIATE may return a relay port unrelated to the
+                            // configured SOCKS5 port. Exempt the proxy host's UDP traffic
+                            // by address so relay packets cannot be captured recursively.
+                            if (!add_filter(create_filter(IPPROTO_UDP, ndisapi::direction_t::out, false)) ||
+                                !add_filter(create_filter(IPPROTO_UDP, ndisapi::direction_t::in, false)))
+                                return false;
+                        }
+
+                        return true;
+                    }
+                    catch (...)
+                    {
+                        rollback();
+                        throw;
+                    }
+                };
+
+                const bool has_ipv4_listeners = socks_tcp_proxy_server || socks_udp_proxy_server;
+                const bool has_ipv6_listeners = socks_tcp_proxy_server_v6 || socks_udp_proxy_server_v6;
+
+                if ((has_ipv4_listeners || has_ipv6_listeners) && proxy_endpoint->ipv4)
+                {
+                    if (!install_upstream_filters(*proxy_endpoint->ipv4))
+                    {
+                        NETLIB_LOG(log_level::error,
+                            "Failed to install upstream PASS filters for SOCKS5 proxy {}.", endpoint);
+                        return {};
+                    }
                 }
 
                 // Lock the mutex to safely add the proxy servers to the shared data
@@ -1293,20 +1513,12 @@ namespace proxy
                 // so they stay index-aligned (the returned index addresses both).
                 std::scoped_lock lock(lock_);
 
-                // Reserve capacity on BOTH vectors up front so the two appends below
-                // are exception-atomic: reserve() is the only step here that can throw
-                // (std::bad_alloc on reallocation), while the subsequent emplace_back of
-                // moved unique_ptrs is noexcept once capacity is guaranteed. If either
-                // reserve throws, neither vector has grown, preserving the index-alignment
-                // invariant (a half-completed append would otherwise permanently skew the
-                // vectors and silently leave IPv6 unproxied for later proxies).
-                proxy_servers_.reserve(proxy_servers_.size() + 1);
-                proxy_servers_v6_.reserve(proxy_servers_v6_.size() + 1);
-
                 proxy_servers_.emplace_back(
                     std::move(socks_tcp_proxy_server), std::move(socks_udp_proxy_server));
                 proxy_servers_v6_.emplace_back(
                     std::move(socks_tcp_proxy_server_v6), std::move(socks_udp_proxy_server_v6));
+                proxy_protocols_.push_back(protocols);
+                proxy_address_families_.push_back(address_families);
 
                 return proxy_servers_.size() - 1; // Return the index of the added proxy server
             }
@@ -1317,6 +1529,19 @@ namespace proxy
             }
 
             return {}; // Return nullopt in case of error or exception
+        }
+
+        /**
+         * Backwards-compatible overload that enables both IPv4 and IPv6 destinations.
+         */
+        std::optional<size_t> add_socks5_proxy(
+            const std::string& endpoint,
+            const supported_protocols protocols,
+            const std::optional<std::pair<std::string, std::string>>& cred_pair,
+            const bool start
+        )
+        {
+            return add_socks5_proxy(endpoint, protocols, cred_pair, supported_address_families::all, start);
         }
 
         /**
@@ -1384,67 +1609,97 @@ namespace proxy
         }
 
         /**
-         * Parses a string to construct a network endpoint, consisting of an IPv4 address and a port number.
-         * The format of the string is expected to be "IP:PORT".
-         * @param endpoint The string representation of the network endpoint.
-         * @return A std::optional containing a net::ip_endpoint<net::ip_address_v4> object if parsing is successful,
-         *         or an empty std::optional otherwise.
+         * Resolves a proxy endpoint into the first usable address of each family.
+         * Hostnames use AF_UNSPEC so an A record can be found even when DNS returns
+         * AAAA first. Proxy registration currently requires that IPv4 result; the
+         * IPv6 result is retained for diagnostics/future native-IPv6 upstream support.
          */
-        static std::optional<net::ip_endpoint<net::ip_address_v4>> parse_endpoint(const std::string& endpoint)
+        static std::optional<resolved_proxy_endpoint> parse_endpoint(const std::string& endpoint)
         {
-            net::ip_endpoint<net::ip_address_v4> result_endpoint;
+            std::string host;
+            std::string service;
 
-            // Locate the ':' character in the string. This separates the IP address and port.
-            if (const auto pos = endpoint.find(':'); pos != std::string::npos)
+            if (endpoint.starts_with('['))
             {
-                // Extract and validate the IP address.
-                auto [result_v4, address_v4] = net::ip_address_v4::from_string(endpoint.substr(0, pos));
-
-                // Extract and validate the port number.
-                if (auto [p, ec] = std::from_chars(endpoint.data() + pos + 1, endpoint.data() + endpoint.size(),
-                                                   result_endpoint.port); ec == std::errc())
+                const auto closing_bracket = endpoint.find(']');
+                if (closing_bracket == std::string::npos || closing_bracket == 1 ||
+                    closing_bracket + 2 >= endpoint.size() || endpoint[closing_bracket + 1] != ':')
                 {
-                    if (result_v4)
-                    {
-                        // If the IP address is valid, assign it to the result endpoint.
-                        result_endpoint.ip = address_v4;
-                    }
-                    else
-                    {
-                        // If the IP address is not valid, resolve it using the getaddrinfo function.
-                        addrinfo* resulted_address_info = nullptr;
-                        addrinfo hints{};
+                    return {};
+                }
 
-                        ZeroMemory(&hints, sizeof(hints));
-                        hints.ai_family = AF_INET;
-                        hints.ai_socktype = SOCK_STREAM;
-                        hints.ai_protocol = IPPROTO_TCP;
+                host = endpoint.substr(1, closing_bracket - 1);
+                service = endpoint.substr(closing_bracket + 2);
+            }
+            else
+            {
+                const auto separator = endpoint.rfind(':');
+                if (separator == std::string::npos || separator == 0 || separator + 1 >= endpoint.size() ||
+                    endpoint.find(':') != separator)
+                {
+                    return {};
+                }
 
-                        if (const auto ret_val = getaddrinfo(endpoint.substr(0, pos).c_str(),
-                                                             std::to_string(result_endpoint.port).c_str(), &hints,
-                                                             &resulted_address_info); ret_val == 0)
-                        {
-                            for (const auto* ptr = resulted_address_info; ptr != nullptr; ptr = ptr->ai_next)
-                            {
-                                if (ptr->ai_family == AF_INET)
-                                {
-                                    const auto* const ipv4 = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
-                                    result_endpoint.ip = net::ip_address_v4(ipv4->sin_addr);
-                                    break;
-                                }
-                            }
-                            freeaddrinfo(resulted_address_info);
-                        }
+                host = endpoint.substr(0, separator);
+                service = endpoint.substr(separator + 1);
+            }
+
+            uint16_t port = 0;
+            const auto [parsed_to, parse_error] =
+                std::from_chars(service.data(), service.data() + service.size(), port);
+            if (parse_error != std::errc() || parsed_to != service.data() + service.size() || port == 0)
+            {
+                return {};
+            }
+
+            addrinfo hints{};
+            hints.ai_family = AF_UNSPEC;
+            hints.ai_socktype = SOCK_STREAM;
+            hints.ai_protocol = IPPROTO_TCP;
+
+            addrinfo* addresses = nullptr;
+            if (getaddrinfo(host.c_str(), service.c_str(), &hints, &addresses) != 0)
+            {
+                return {};
+            }
+
+            resolved_proxy_endpoint result;
+            for (const auto* address = addresses; address != nullptr; address = address->ai_next)
+            {
+                if (!result.ipv4 && address->ai_family == AF_INET &&
+                    address->ai_addrlen >= static_cast<int>(sizeof(sockaddr_in)))
+                {
+                    const auto* const socket_address = reinterpret_cast<const sockaddr_in*>(address->ai_addr);
+                    const net::ip_address_v4 ip{ socket_address->sin_addr };
+                    if (ip != net::ip_address_v4{})
+                    {
+                        result.ipv4 = net::ip_endpoint<net::ip_address_v4>{ ip, port };
                     }
+                }
+                else if (!result.ipv6 && address->ai_family == AF_INET6 &&
+                    address->ai_addrlen >= static_cast<int>(sizeof(sockaddr_in6)))
+                {
+                    const auto* const socket_address = reinterpret_cast<const sockaddr_in6*>(address->ai_addr);
+                    const net::ip_address_v6 ip{ socket_address->sin6_addr };
+                    if (ip != net::ip_address_v6{})
+                    {
+                        result.ipv6 = net::ip_endpoint<net::ip_address_v6>{ ip, port };
+                    }
+                }
+
+                if (result.ipv4 && result.ipv6)
+                {
+                    break;
                 }
             }
 
-            // If the IP address is not default, return the result endpoint.
-            if (result_endpoint.ip != net::ip_address_v4{})
-                return result_endpoint;
+            freeaddrinfo(addresses);
+            if (!result.ipv4 && !result.ipv6)
+            {
+                return {};
+            }
 
-            // Otherwise, return an empty std::optional.
-            return {};
+            return result;
         }
 
     private:
@@ -1564,7 +1819,7 @@ namespace proxy
          * @return A std::optional containing the TCP port number if the process name is found,
          *         or an empty std::optional otherwise.
          */
-        std::optional<uint16_t> get_proxy_port_tcp(const std::shared_ptr<iphelper::network_process>& process)
+        proxy_port_result get_proxy_port_tcp(const std::shared_ptr<iphelper::network_process>& process)
         {
             if (!process) return {};
 
@@ -1574,9 +1829,19 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].first
-                        ? std::optional(proxy_servers_[proxy_id].first->proxy_port())
-                        : std::nullopt;
+                    if (proxy_id >= proxy_protocols_.size() || !protocol_supports_tcp(proxy_protocols_[proxy_id]))
+                        return {};
+
+                    if (proxy_id < proxy_address_families_.size() &&
+                        !family_supports_ipv4(proxy_address_families_[proxy_id]))
+                    {
+                        return { proxy_port_action::block, 0 };
+                    }
+
+                    if (proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].first)
+                        return { proxy_port_action::proxy, proxy_servers_[proxy_id].first->proxy_port() };
+
+                    return { proxy_port_action::block, 0 };
                 }
             }
 
@@ -1589,7 +1854,7 @@ namespace proxy
          * @return A std::optional containing the UDP port number if the process name is found,
          *         or an empty std::optional otherwise.
          */
-        std::optional<uint16_t> get_proxy_port_udp(const std::shared_ptr<iphelper::network_process>& process)
+        proxy_port_result get_proxy_port_udp(const std::shared_ptr<iphelper::network_process>& process)
         {
             if (!process) return {};
 
@@ -1600,9 +1865,19 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].second
-                        ? std::optional(proxy_servers_[proxy_id].second->proxy_port())
-                        : std::nullopt;
+                    if (proxy_id >= proxy_protocols_.size() || !protocol_supports_udp(proxy_protocols_[proxy_id]))
+                        return {};
+
+                    if (proxy_id < proxy_address_families_.size() &&
+                        !family_supports_ipv4(proxy_address_families_[proxy_id]))
+                    {
+                        return { proxy_port_action::block, 0 };
+                    }
+
+                    if (proxy_id < proxy_servers_.size() && proxy_servers_[proxy_id].second)
+                        return { proxy_port_action::proxy, proxy_servers_[proxy_id].second->proxy_port() };
+
+                    return { proxy_port_action::block, 0 };
                 }
             }
 
@@ -1654,7 +1929,7 @@ namespace proxy
          * kept index-aligned with proxy_servers_, so the same proxy_to_names_ mapping
          * selects the matching IPv6 proxy.
          */
-        std::optional<uint16_t> get_proxy_port_tcp_v6(const std::shared_ptr<iphelper::network_process>& process)
+        proxy_port_result get_proxy_port_tcp_v6(const std::shared_ptr<iphelper::network_process>& process)
         {
             if (!process) return {};
 
@@ -1664,9 +1939,19 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].first
-                        ? std::optional(proxy_servers_v6_[proxy_id].first->proxy_port())
-                        : std::nullopt;
+                    if (proxy_id >= proxy_protocols_.size() || !protocol_supports_tcp(proxy_protocols_[proxy_id]))
+                        return {};
+
+                    if (proxy_id < proxy_address_families_.size() &&
+                        !family_supports_ipv6(proxy_address_families_[proxy_id]))
+                    {
+                        return { proxy_port_action::block, 0 };
+                    }
+
+                    if (proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].first)
+                        return { proxy_port_action::proxy, proxy_servers_v6_[proxy_id].first->proxy_port() };
+
+                    return { proxy_port_action::block, 0 };
                 }
             }
 
@@ -1676,7 +1961,7 @@ namespace proxy
         /**
          * IPv6 counterpart of get_proxy_port_udp(). See get_proxy_port_tcp_v6().
          */
-        std::optional<uint16_t> get_proxy_port_udp_v6(const std::shared_ptr<iphelper::network_process>& process)
+        proxy_port_result get_proxy_port_udp_v6(const std::shared_ptr<iphelper::network_process>& process)
         {
             if (!process) return {};
 
@@ -1686,9 +1971,19 @@ namespace proxy
             {
                 if (match_app_name(process_pattern, process))
                 {
-                    return proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].second
-                        ? std::optional(proxy_servers_v6_[proxy_id].second->proxy_port())
-                        : std::nullopt;
+                    if (proxy_id >= proxy_protocols_.size() || !protocol_supports_udp(proxy_protocols_[proxy_id]))
+                        return {};
+
+                    if (proxy_id < proxy_address_families_.size() &&
+                        !family_supports_ipv6(proxy_address_families_[proxy_id]))
+                    {
+                        return { proxy_port_action::block, 0 };
+                    }
+
+                    if (proxy_id < proxy_servers_v6_.size() && proxy_servers_v6_[proxy_id].second)
+                        return { proxy_port_action::proxy, proxy_servers_v6_[proxy_id].second->proxy_port() };
+
+                    return { proxy_port_action::block, 0 };
                 }
             }
 
@@ -1794,25 +2089,43 @@ namespace proxy
             if (process->excluded || process->bypass_udp)
                 return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
 
-            if (const auto port = process->udp_proxy_port ? process->udp_proxy_port : get_proxy_port_udp(process); port.has_value())
+            const auto proxy_lookup = process->udp_proxy_port
+                ? proxy_port_result{ proxy_port_action::proxy, process->udp_proxy_port.value() }
+                : get_proxy_port_udp(process);
+
+            if (proxy_lookup.action == proxy_port_action::proxy)
             {
-                if (udp_redirect_->is_new_endpoint(buffer))
-                {
-                    std::scoped_lock lock(udp_mapper_lock_);
-                    udp_mapper_.insert(ntohs(udp_header->th_sport));
+                const auto is_new_endpoint = udp_redirect_->is_new_endpoint(buffer);
+                const auto source_address = net::ip_address_v4(ip_header->ip_src);
+                const auto source_port = ntohs(udp_header->th_sport);
+                const auto destination_address = net::ip_address_v4(ip_header->ip_dst);
+                const auto destination_port = ntohs(udp_header->th_dport);
 
-                    NETLIB_LOG(log_level::info,
-                        "Redirecting UDP {} : {} -> {} : {}",
-                        net::ip_address_v4(ip_header->ip_src), ntohs(udp_header->th_sport),
-                        net::ip_address_v4(ip_header->ip_dst), ntohs(udp_header->th_dport));
-                }
-
-                if (udp_redirect_->process_client_to_server_packet(buffer, htons(port.value())))
+                if (udp_redirect_->process_client_to_server_packet(buffer, htons(proxy_lookup.port)))
                 {
+                    // Refresh authorization for every datagram that was actually redirected. A
+                    // SOCKS5 relay expires sooner than the redirect endpoint, so the next packet
+                    // must be able to authorize recreation even when the endpoint is not new.
+                    {
+                        std::scoped_lock lock(udp_mapper_lock_);
+                        udp_mapper_.insert_or_assign(source_port, std::chrono::steady_clock::now());
+                    }
+
+                    if (is_new_endpoint)
+                    {
+                        NETLIB_LOG(log_level::info,
+                            "Redirecting UDP {} : {} -> {} : {}",
+                            source_address, source_port, destination_address, destination_port);
+                    }
+
                     log_packet_to_pcap(buffer);
                     return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
                 }
 
+            }
+            else if (proxy_lookup.action == proxy_port_action::block)
+            {
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::drop };
             }
             else
             {
@@ -1887,7 +2200,11 @@ namespace proxy
             if (process->excluded || process->bypass_tcp)
                 return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
 
-            if (const auto port = process->tcp_proxy_port ? process->tcp_proxy_port : get_proxy_port_tcp(process); port.has_value())
+            const auto proxy_lookup = process->tcp_proxy_port
+                ? proxy_port_result{ proxy_port_action::proxy, process->tcp_proxy_port.value() }
+                : get_proxy_port_tcp(process);
+
+            if (proxy_lookup.action == proxy_port_action::proxy)
             {
                 // If this is a SYN packet (connection initiation), map the source port to the destination endpoint
                 if ((tcp_header->th_flags & (TH_SYN | TH_ACK)) == TH_SYN)
@@ -1906,11 +2223,15 @@ namespace proxy
                 }
 
                 // Attempt to process the packet for client-to-server redirection
-                if (tcp_redirect_->process_client_to_server_packet(buffer, htons(port.value())))
+                if (tcp_redirect_->process_client_to_server_packet(buffer, htons(proxy_lookup.port)))
                 {
                     log_packet_to_pcap(buffer);
                     return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
                 }
+            }
+            else if (proxy_lookup.action == proxy_port_action::block)
+            {
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::drop };
             }
             else
             {
@@ -2053,24 +2374,44 @@ namespace proxy
             if (process->excluded || process->bypass_udp)
                 return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
 
-            if (const auto port = process->udp_proxy_port ? process->udp_proxy_port : get_proxy_port_udp_v6(process); port.has_value())
+            const auto proxy_lookup = get_proxy_port_udp_v6(process);
+
+            if (proxy_lookup.action == proxy_port_action::proxy)
             {
-                if (udp_redirect_v6_->is_new_endpoint(buffer))
-                {
-                    std::scoped_lock lock(udp_mapper_v6_lock_);
-                    udp_mapper_v6_.insert(ntohs(udp_header->th_sport));
+                const auto is_new_endpoint = udp_redirect_v6_->is_new_endpoint(buffer);
+                const auto source_address = std::string{ net::ip_address_v6{ip_header->ip6_src} };
+                const auto source_port = ntohs(udp_header->th_sport);
+                const auto destination_address = std::string{ net::ip_address_v6{ip_header->ip6_dst} };
+                const auto destination_port = ntohs(udp_header->th_dport);
 
-                    NETLIB_LOG(log_level::info,
-                        "Redirecting UDP6 {} : {} -> {} : {}",
-                        std::string{ net::ip_address_v6{ip_header->ip6_src} }, ntohs(udp_header->th_sport),
-                        std::string{ net::ip_address_v6{ip_header->ip6_dst} }, ntohs(udp_header->th_dport));
-                }
-
-                if (udp_redirect_v6_->process_client_to_server_packet(buffer, htons(port.value())))
+                if (udp_redirect_v6_->process_client_to_server_packet(buffer, htons(proxy_lookup.port)))
                 {
+                    {
+                        std::scoped_lock lock(udp_mapper_v6_lock_);
+                        udp_mapper_v6_.insert_or_assign(source_port, std::chrono::steady_clock::now());
+                    }
+
+                    if (is_new_endpoint)
+                    {
+                        NETLIB_LOG(log_level::info,
+                            "Redirecting UDP6 {} : {} -> {} : {}",
+                            source_address, source_port, destination_address, destination_port);
+                    }
+
                     log_packet_to_pcap(buffer);
                     return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
                 }
+            }
+            else if (proxy_lookup.action == proxy_port_action::block)
+            {
+                static std::atomic_flag warned = ATOMIC_FLAG_INIT; // NOLINT(clang-diagnostic-exit-time-destructors, clang-diagnostic-unique-object-duplication)
+                if (!warned.test_and_set(std::memory_order_relaxed))
+                {
+                    NETLIB_LOG(log_level::warning,
+                        "Blocking IPv6 UDP traffic for a matched process because the selected proxy does not support IPv6 destinations.");
+                }
+
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::drop };
             }
             else
             {
@@ -2138,7 +2479,9 @@ namespace proxy
             if (process->excluded || process->bypass_tcp)
                 return packet_filter::packet_action{ packet_filter::packet_action::action_type::pass };
 
-            if (const auto port = process->tcp_proxy_port ? process->tcp_proxy_port : get_proxy_port_tcp_v6(process); port.has_value())
+            const auto proxy_lookup = get_proxy_port_tcp_v6(process);
+
+            if (proxy_lookup.action == proxy_port_action::proxy)
             {
                 // If this is a SYN packet (connection initiation), map the source port to the destination endpoint
                 if ((tcp_header->th_flags & (TH_SYN | TH_ACK)) == TH_SYN)
@@ -2158,11 +2501,22 @@ namespace proxy
                 }
 
                 // Attempt to process the packet for client-to-server redirection
-                if (tcp_redirect_v6_->process_client_to_server_packet(buffer, htons(port.value())))
+                if (tcp_redirect_v6_->process_client_to_server_packet(buffer, htons(proxy_lookup.port)))
                 {
                     log_packet_to_pcap(buffer);
                     return packet_filter::packet_action{ packet_filter::packet_action::action_type::revert };
                 }
+            }
+            else if (proxy_lookup.action == proxy_port_action::block)
+            {
+                static std::atomic_flag warned = ATOMIC_FLAG_INIT; // NOLINT(clang-diagnostic-exit-time-destructors, clang-diagnostic-unique-object-duplication)
+                if (!warned.test_and_set(std::memory_order_relaxed))
+                {
+                    NETLIB_LOG(log_level::warning,
+                        "Blocking IPv6 TCP traffic for a matched process because the selected proxy does not support IPv6 destinations.");
+                }
+
+                return packet_filter::packet_action{ packet_filter::packet_action::action_type::drop };
             }
             else
             {
@@ -2256,8 +2610,8 @@ namespace proxy
             std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_adapters;
             std::vector<netlib::ndisapi::intermediate_buffer_pool::intermediate_buffer_ptr> to_mstcp;
 
-            // Run the tcp_mapper_ sweep at most once per maintenance interval, even
-            // under heavy resolver activity. The interval is half the TTL so an
+            // Run the source-port mapper sweeps at most once per maintenance interval,
+            // even under heavy resolver activity. The interval is half the TTL so an
             // entry is evicted within at most 1.5 * TTL of becoming stale, and the
             // condition variable below uses the same period as its wait timeout so
             // the sweep still runs when the deferred-resolve queue stays empty.
@@ -2269,8 +2623,8 @@ namespace proxy
             {
                 {
                     std::unique_lock lock(process_resolve_buffer_mutex_);
-                    // Timed wait so we still run periodic maintenance (tcp_mapper_
-                    // TTL eviction) when no packets are being deferred. Also wake
+                    // Timed wait so we still run periodic mapper TTL eviction when no
+                    // packets are being deferred. Also wake
                     // early for maintenance-only notifications so throttled
                     // alloc-failure/drop diagnostics are not delayed until the next
                     // timeout when no packet was actually queued, but only once
@@ -2300,12 +2654,9 @@ namespace proxy
                     std::swap(process_resolve_buffer_queue_, local_queue);
                 }
 
-                // Evict stale tcp_mapper_ entries whose SYN was redirected but never
-                // produced a local proxy connection (e.g. peer RST, timeout, app gave
-                // up). Without this sweep such entries would leak indefinitely since
-                // the only other removal site is the SOCKS5 negotiate callback. The
-                // sweep is rate-limited to maintenance_interval to bound CPU cost
-                // when the resolver loop runs frequently under sustained load.
+                // Evict stale source-port entries whose redirected traffic never
+                // completed local proxy setup. The sweep is rate-limited to
+                // maintenance_interval to bound CPU cost under sustained load.
                 if (const auto now = std::chrono::steady_clock::now();
                     now - last_sweep >= maintenance_interval)
                 {
@@ -2333,6 +2684,39 @@ namespace proxy
                             if (now - it->second.created_at > tcp_mapper_entry_ttl_)
                             {
                                 it = tcp_mapper_v6_.erase(it);
+                            }
+                            else
+                            {
+                                ++it;
+                            }
+                        }
+                    }
+
+                    // UDP authorizations remain present while SOCKS5 TCP connect and
+                    // UDP ASSOCIATE are in progress so a failed attempt can be retried.
+                    // Age out authorizations that never reach the commit callback.
+                    {
+                        std::scoped_lock lock(udp_mapper_lock_);
+                        for (auto it = udp_mapper_.begin(); it != udp_mapper_.end();)
+                        {
+                            if (now - it->second > udp_mapper_entry_ttl_)
+                            {
+                                it = udp_mapper_.erase(it);
+                            }
+                            else
+                            {
+                                ++it;
+                            }
+                        }
+                    }
+
+                    {
+                        std::scoped_lock lock(udp_mapper_v6_lock_);
+                        for (auto it = udp_mapper_v6_.begin(); it != udp_mapper_v6_.end();)
+                        {
+                            if (now - it->second > udp_mapper_entry_ttl_)
+                            {
+                                it = udp_mapper_v6_.erase(it);
                             }
                             else
                             {
@@ -2466,6 +2850,11 @@ namespace proxy
                             {
                                 to_mstcp.push_back(std::move(buffer_ptr));
                             }
+                            else if (result && result->action == packet_filter::packet_action::action_type::drop)
+                            {
+                                // Drop is a valid deferred result when a matched
+                                // proxy intentionally blocks this address family.
+                            }
                             else
                             {
                                 // Invariant: a postponed packet always yields a result. If a
@@ -2485,6 +2874,11 @@ namespace proxy
                             else if (result && result->action == packet_filter::packet_action::action_type::revert)
                             {
                                 to_mstcp.push_back(std::move(buffer_ptr));
+                            }
+                            else if (result && result->action == packet_filter::packet_action::action_type::drop)
+                            {
+                                // Drop is a valid deferred result when a matched
+                                // proxy intentionally blocks this address family.
                             }
                             else
                             {
@@ -2515,6 +2909,11 @@ namespace proxy
                         {
                             to_mstcp.push_back(std::move(buffer_ptr));
                         }
+                        else if (result && result->action == packet_filter::packet_action::action_type::drop)
+                        {
+                            // Drop is a valid deferred result when a matched
+                            // proxy intentionally blocks this address family.
+                        }
                         else
                         {
                             // Should always have a result for postponed packets; if not,
@@ -2533,6 +2932,11 @@ namespace proxy
                         else if (result && result->action == packet_filter::packet_action::action_type::revert)
                         {
                             to_mstcp.push_back(std::move(buffer_ptr));
+                        }
+                        else if (result && result->action == packet_filter::packet_action::action_type::drop)
+                        {
+                            // Drop is a valid deferred result when a matched
+                            // proxy intentionally blocks this address family.
                         }
                         else
                         {

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -1161,16 +1161,44 @@ namespace proxy
                 {
                     std::scoped_lock lock(lock_);
 
-                    WSACloseEvent(wait_events[event_index]);
-
                     // Extract socket handles before creating the shared_ptr
                     // so we can clean them up if initialization fails
                     auto local_socket = std::get<1>(sock_array_events_[event_index]);
                     auto remote_socket = std::get<2>(sock_array_events_[event_index]);
                     auto negotiate_ctx = std::move(std::get<3>(sock_array_events_[event_index]));
 
+                    // An FD_CONNECT event reports completion, not necessarily success. Retrieve
+                    // its error before handing the socket to the SOCKS5 session; otherwise a failed
+                    // connect is promoted to a live proxy socket.
+                    int connect_error = 0;
+                    WSANETWORKEVENTS network_events{};
+                    if (WSAEnumNetworkEvents(remote_socket, wait_events[event_index], &network_events) == SOCKET_ERROR)
+                    {
+                        connect_error = WSAGetLastError();
+                    }
+                    else if ((network_events.lNetworkEvents & FD_CONNECT) == 0)
+                    {
+                        connect_error = WSAEINVAL;
+                    }
+                    else
+                    {
+                        connect_error = network_events.iErrorCode[FD_CONNECT_BIT];
+                    }
+
+                    WSACloseEvent(wait_events[event_index]);
+
                     // Remove from tracking array first - we own the resources now
                     sock_array_events_.erase(sock_array_events_.begin() + event_index);
+
+                    if (connect_error != 0)
+                    {
+                        NETLIB_WARNING("connect_to_remote_host_thread: remote connect failed: {}", connect_error);
+                        shutdown(local_socket, SD_BOTH);
+                        closesocket(local_socket);
+                        shutdown(remote_socket, SD_BOTH);
+                        closesocket(remote_socket);
+                        continue;
+                    }
 
                     try
                     {

--- a/socksify/Socksifier.cpp
+++ b/socksify/Socksifier.cpp
@@ -205,10 +205,11 @@ void Socksifier::Socksifier::SetBypassLan()
 /// <param name="username">The username for authentication.</param>
 /// <param name="password">The password for authentication.</param>
 /// <param name="protocols">The supported protocols.</param>
+/// <param name="addressFamilies">The supported destination address families.</param>
 /// <param name="start">Whether to start the proxy immediately.</param>
 /// <returns>A handle to the proxy instance, or -1 on failure.</returns>
 IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username, String^ password,
-    SupportedProtocolsEnum protocols, const bool start)
+    SupportedProtocolsEnum protocols, SupportedAddressFamiliesEnum addressFamilies, const bool start)
 {
     if (!unmanaged_ptr_)
         return static_cast<IntPtr>(-1);
@@ -226,11 +227,25 @@ IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username
         break;
     }
 
+    auto address_families_mx = supported_address_families_mx::both;
+    switch (addressFamilies)
+    {
+    case SupportedAddressFamiliesEnum::IPv4:
+        address_families_mx = supported_address_families_mx::ipv4;
+        break;
+    case SupportedAddressFamiliesEnum::IPv6:
+        address_families_mx = supported_address_families_mx::ipv6;
+        break;
+    default:
+        break;
+    }
+
     if (username != nullptr && password != nullptr)
     {
         return static_cast<IntPtr>(unmanaged_ptr_->add_socks5_proxy(
             msclr::interop::marshal_as<std::string>(endpoint),
             protocols_mx,
+            address_families_mx,
             start,
             msclr::interop::marshal_as<std::string>(username),
             msclr::interop::marshal_as<std::string>(password)
@@ -238,7 +253,22 @@ IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username
     }
 
     return static_cast<IntPtr>(unmanaged_ptr_->add_socks5_proxy(
-        msclr::interop::marshal_as<std::string>(endpoint), protocols_mx, start));
+        msclr::interop::marshal_as<std::string>(endpoint), protocols_mx, address_families_mx, start));
+}
+
+/// <summary>
+/// Adds a SOCKS5 proxy with both IPv4 and IPv6 destinations enabled.
+/// </summary>
+/// <param name="endpoint">The SOCKS5 proxy endpoint.</param>
+/// <param name="username">The username for authentication.</param>
+/// <param name="password">The password for authentication.</param>
+/// <param name="protocols">The supported protocols.</param>
+/// <param name="start">Whether to start the proxy immediately.</param>
+/// <returns>A handle to the proxy instance, or -1 on failure.</returns>
+IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username, String^ password,
+    SupportedProtocolsEnum protocols, const bool start)
+{
+    return AddSocks5Proxy(endpoint, username, password, protocols, SupportedAddressFamiliesEnum::BOTH, start);
 }
 
 /// <summary>

--- a/socksify/Socksifier.h
+++ b/socksify/Socksifier.h
@@ -86,6 +86,19 @@ namespace Socksifier
     };
 
     /// <summary>
+    /// Specifies the supported destination address families for proxying.
+    /// </summary>
+    public enum class SupportedAddressFamiliesEnum
+    {
+        /// <summary>IPv4 destinations only.</summary>
+        IPv4,
+        /// <summary>IPv6 destinations only.</summary>
+        IPv6,
+        /// <summary>Both IPv4 and IPv6 destinations.</summary>
+        BOTH
+    };
+
+    /// <summary>
     /// Represents a single log entry for Socksifier events.
     /// </summary>
     public ref class LogEntry sealed
@@ -251,6 +264,19 @@ namespace Socksifier
 
         /// <summary>
         /// Adds a SOCKS5 proxy to the gateway.
+        /// </summary>
+        /// <param name="endpoint">The proxy endpoint (IP:Port).</param>
+        /// <param name="username">The username for authentication.</param>
+        /// <param name="password">The password for authentication.</param>
+        /// <param name="protocols">The supported protocols.</param>
+        /// <param name="addressFamilies">The supported destination address families.</param>
+        /// <param name="start">Whether to start the proxy immediately.</param>
+        /// <returns>A handle to the proxy instance.</returns>
+        IntPtr AddSocks5Proxy(String^ endpoint, String^ username, String^ password, SupportedProtocolsEnum protocols,
+            SupportedAddressFamiliesEnum addressFamilies, bool start);
+
+        /// <summary>
+        /// Adds a SOCKS5 proxy to the gateway with both IPv4 and IPv6 destinations enabled.
         /// </summary>
         /// <param name="endpoint">The proxy endpoint (IP:Port).</param>
         /// <param name="username">The username for authentication.</param>

--- a/socksify/mixed_types.h
+++ b/socksify/mixed_types.h
@@ -49,6 +49,19 @@ enum class supported_protocols_mx : uint8_t
 };
 
 /**
+ * @brief Specifies the supported destination address families for proxying.
+ */
+enum class supported_address_families_mx : uint8_t
+{
+    /// <summary>IPv4 destinations only.</summary>
+    ipv4 = 0,
+    /// <summary>IPv6 destinations only.</summary>
+    ipv6 = 1,
+    /// <summary>Both IPv4 and IPv6 destinations.</summary>
+    both = 2
+};
+
+/**
  * @brief Enumerates the types of events that can occur in the proxy gateway.
  */
 enum class event_type_mx : uint32_t

--- a/socksify/socksify.vcxproj
+++ b/socksify/socksify.vcxproj
@@ -279,6 +279,7 @@
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="Socksifier.cpp" />
     <ClCompile Include="socksify_unmanaged.cpp">
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -236,6 +236,7 @@ void socksify_unmanaged::set_bypass_lan() const
  * @brief Adds a SOCKS5 proxy to the gateway.
  * @param endpoint The proxy endpoint in "IP:Port" format.
  * @param protocol The supported protocol(s) for the proxy.
+ * @param address_family The supported destination address family/families.
  * @param start Whether to start the proxy immediately.
  * @param login Optional username for authentication.
  * @param password Optional password for authentication.
@@ -244,6 +245,7 @@ void socksify_unmanaged::set_bypass_lan() const
 LONG_PTR socksify_unmanaged::add_socks5_proxy(
     const std::string& endpoint,
     const supported_protocols_mx protocol,
+    const supported_address_families_mx address_family,
     const bool start,
     const std::string& login,
     const std::string& password) const
@@ -270,12 +272,40 @@ LONG_PTR socksify_unmanaged::add_socks5_proxy(
         break;
     }
 
-    if (const auto result = proxy_->add_socks5_proxy(endpoint, protocols, cred, start); result)
+    proxy::socks_local_router::supported_address_families address_families =
+        proxy::socks_local_router::supported_address_families::all;
+    switch (address_family)
+    {
+    case supported_address_families_mx::ipv4:
+        address_families = proxy::socks_local_router::supported_address_families::ipv4;
+        break;
+    case supported_address_families_mx::ipv6:
+        address_families = proxy::socks_local_router::supported_address_families::ipv6;
+        break;
+    case supported_address_families_mx::both:
+        address_families = proxy::socks_local_router::supported_address_families::all;
+        break;
+    }
+
+    if (const auto result = proxy_->add_socks5_proxy(endpoint, protocols, cred, address_families, start); result)
     {
         return static_cast<LONG_PTR>(result.value());
     }
 
     return -1;
+}
+
+/**
+ * @brief Adds a SOCKS5 proxy with both IPv4 and IPv6 destinations enabled.
+ */
+LONG_PTR socksify_unmanaged::add_socks5_proxy(
+    const std::string& endpoint,
+    const supported_protocols_mx protocol,
+    const bool start,
+    const std::string& login,
+    const std::string& password) const
+{
+    return add_socks5_proxy(endpoint, protocol, supported_address_families_mx::both, start, login, password);
 }
 
 /**

--- a/socksify/socksify_unmanaged.h
+++ b/socksify/socksify_unmanaged.h
@@ -81,7 +81,7 @@ public:
      * @param start Whether to start the proxy immediately.
      * @param login Optional username for authentication.
      * @param password Optional password for authentication.
-     * @return A handle (LONG_PTR) to the proxy instance, or 0 on failure.
+     * @return A handle (LONG_PTR) to the proxy instance, or -1 on failure.
      */
     [[nodiscard]] LONG_PTR add_socks5_proxy(
         const std::string& endpoint,

--- a/socksify/socksify_unmanaged.h
+++ b/socksify/socksify_unmanaged.h
@@ -77,10 +77,23 @@ public:
      * @brief Adds a SOCKS5 proxy to the gateway.
      * @param endpoint The proxy endpoint in "IP:Port" format.
      * @param protocol The supported protocol(s) for the proxy.
+     * @param address_family The supported destination address family/families.
      * @param start Whether to start the proxy immediately.
      * @param login Optional username for authentication.
      * @param password Optional password for authentication.
      * @return A handle (LONG_PTR) to the proxy instance, or 0 on failure.
+     */
+    [[nodiscard]] LONG_PTR add_socks5_proxy(
+        const std::string& endpoint,
+        supported_protocols_mx protocol,
+        supported_address_families_mx address_family,
+        bool start = false,
+        const std::string& login = "",
+        const std::string& password = ""
+    ) const;
+
+    /**
+     * @brief Adds a SOCKS5 proxy with both IPv4 and IPv6 destinations enabled.
      */
     [[nodiscard]] LONG_PTR add_socks5_proxy(
         const std::string& endpoint,


### PR DESCRIPTION
## Summary

- add explicit IPv4/IPv6 destination-family handling, including fail-closed behavior for unsupported families and a consistent IPv4 upstream transport
- harden SOCKS5 UDP ASSOCIATE for QUIC bursts with immediate receive re-arming, parallel association workers, ordered bounded first-flight queues, and transactional source-port authorization
- bypass dynamic SOCKS5 UDP relay ports by proxy address, make PASS-filter installation transactional, and recover failed UDP receive re-arms from the maintenance thread
- validate asynchronous TCP connect completion, require elevation for interactive packet redirection, and document the new configuration behavior

## Why

Edge failed when the selected SOCKS5 proxy had no IPv6 connectivity while the local system did. Chrome QUIC also became unreliable under request bursts because UDP association setup blocked receive progress and the proxy's dynamically assigned relay ports were outside the static bypass rules.

## Verification

- Debug x64 solution build succeeded
- native C/C++ code analysis completed with 0 errors and 0 warnings
- configuration reflection checks covered omitted, case-insensitive, empty, and unknown `supportedAddressFamilies` values
- unelevated interactive startup returned `ERROR_ACCESS_DENIED` (5) with the administrator guidance
- `git diff --check` passed