### PR TITLE
CI: pin release builds to Visual Studio 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v3
+        with:
+          vs-version: '[17.0,18.0)'
 
       - name: Install vcpkg
         shell: bash
@@ -77,7 +79,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- update checkout to the current Node 24 action
- update setup-msbuild to v3
- constrain MSBuild discovery to Visual Studio 2022 ([17.0,18.0)) so the required v143 toolset is available

## Why

The first v2.3.0 release run failed because windows-latest selected Visual Studio 18/MSBuild 18, which does not include the project's v143 toolset. The all-platform release gate correctly prevented publication.

Failed run: https://github.com/wiresock/proxifyre/actions/runs/29276772324