### PR TITLE
CI: run release builds on Windows 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             build_configuration: 'Release'
           - platform: 'ARM64'
             build_configuration: 'Release'
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Pin the build matrix to the Windows Server 2022 hosted runner, which includes Visual Studio 2022 and the v143 toolset required by the native projects. Keep the upload-only job on windows-latest.

## Why

After PR #156 constrained setup-msbuild to Visual Studio 17, the release run confirmed that windows-latest now contains only Visual Studio 18 and cannot satisfy that constraint. The official Windows 2022 image remains available.

Failed run: https://github.com/wiresock/proxifyre/actions/runs/29277300570