### PR TITLE
Build: include sample config in release output

### DIFF
--- a/ProxiFyre/ProxiFyre.csproj
+++ b/ProxiFyre/ProxiFyre.csproj
@@ -122,6 +122,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="..\app-config.sample.json">
+      <Link>app-config.sample.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary

Link the tracked root-level app-config.sample.json into the ProxiFyre project and copy it to each build output directory.

## Why

PR #148 added the safe sample as the replacement for ignored app-config.json files, but the release project never copied it into packaged output. The first v2.3.0 artifact integrity check caught that all three ZIPs omitted the template.

## Verification

- Release x64 rebuild succeeded with Version=2.3.0
- output sample exists and is byte-identical to the tracked source
- PDB exclusion remains handled by the release ZIP step