### PR TITLE
Add native SOCKS5-over-TLS transport

### DIFF
--- a/ProxiFyre/Program.cs
+++ b/ProxiFyre/Program.cs
@@ -81,19 +81,14 @@ namespace ProxiFyre
 
             foreach (var appSettings in serviceSettings.Proxies)
             {
-                // Warn on a half-specified credential: SOCKS5 username/password auth needs
-                // both, so providing only one silently falls back to no authentication.
-                var hasUser = !string.IsNullOrEmpty(appSettings.Username);
-                var hasPass = !string.IsNullOrEmpty(appSettings.Password);
-                if (hasUser != hasPass)
-                    LoggerInstance.Warn(
-                        $"Proxy {appSettings.Socks5ProxyEndpoint}: only one of username/password is set; " +
-                        "authentication will be skipped. Provide both or neither.");
-
                 // Add the defined SOCKS5 proxies
                 var proxy = _socksify.AddSocks5Proxy(appSettings.Socks5ProxyEndpoint, appSettings.Username,
                     appSettings.Password, appSettings.SupportedProtocolsParse,
                     appSettings.SupportedAddressFamiliesParse,
+                    appSettings.Socks5TransportParse,
+                    appSettings.EffectiveTlsServerName,
+                    NormalizeFingerprint(appSettings.TlsPinnedSha256),
+                    appSettings.TlsAllowInvalidCertificate,
                     true);
 
                 if (proxy.ToInt64() == -1)
@@ -109,11 +104,14 @@ namespace ProxiFyre
                 var addressFamilies = appSettings.SupportedAddressFamilies != null && appSettings.SupportedAddressFamilies.Count > 0
                     ? string.Join(", ", appSettings.SupportedAddressFamilies)
                     : "IPv4, IPv6";
+                var transport = appSettings.Socks5TransportParse == Socks5TransportEnum.TLS
+                    ? "SOCKS5Tls"
+                    : "SOCKS5";
                 foreach (var appName in appSettings.AppNames)
                     // Associate the defined application names to the proxies
                     if (_socksify.AssociateProcessNameToProxy(appName, proxy) && _logLevel >= LogLevel.Info)
                         LoggerInstance.Info(
-                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} SOCKS5 proxy with protocols {protocols} and address families {addressFamilies}!");
+                            $"Successfully associated {appName} to {appSettings.Socks5ProxyEndpoint} {transport} proxy with protocols {protocols} and address families {addressFamilies}!");
             }
 
             foreach (var excludedEntry in serviceSettings.ExcludedList)
@@ -207,6 +205,16 @@ namespace ProxiFyre
                     throw new InvalidOperationException(message);
                 }
 
+                var hasUsername = !string.IsNullOrEmpty(proxy.Username);
+                var hasPassword = !string.IsNullOrEmpty(proxy.Password);
+                if (hasUsername != hasPassword)
+                {
+                    var message = $"Proxy '{proxy.Socks5ProxyEndpoint}' must specify both \"username\" and " +
+                                  "\"password\", or leave both empty.";
+                    LoggerInstance.Error(message);
+                    throw new InvalidOperationException(message);
+                }
+
                 // Drop null and whitespace-only application names (a null String^ throws in
                 // marshal_as<std::wstring>, and "   " is a typo that matches nothing), but PRESERVE
                 // an explicit empty string "": it is the catch-all that matches EVERY process (see
@@ -237,19 +245,23 @@ namespace ProxiFyre
                 }
 
                 // Warn on unrecognized protocol tokens: SupportedProtocolsParse only counts
-                // "TCP"/"UDP" and ignores anything else, defaulting to BOTH only when neither
-                // is present -- so a typo alongside a valid token is silently dropped, and a
-                // typo on its own silently proxies both protocols.
+                // "TCP"/"UDP" (case-insensitively) and ignores anything else, defaulting to
+                // BOTH only when neither is present -- so a typo alongside a valid token is
+                // silently dropped, and a typo on its own silently proxies both protocols.
                 if (proxy.SupportedProtocols != null)
                 {
                     var unknownProtocols = proxy.SupportedProtocols
-                        .Where(p => p != "TCP" && p != "UDP")
+                        .Where(p => !string.Equals(p, "TCP", StringComparison.OrdinalIgnoreCase) &&
+                                    !string.Equals(p, "UDP", StringComparison.OrdinalIgnoreCase))
                         .ToList();
                     if (unknownProtocols.Count > 0)
+                    {
+                        var values = string.Join(", ", unknownProtocols.Select(p => p ?? "<null>"));
                         LoggerInstance.Warn(
                             $"Proxy '{proxy.Socks5ProxyEndpoint}' lists unrecognized protocol(s): " +
-                            $"{string.Join(", ", unknownProtocols)}. Only \"TCP\" and \"UDP\" are recognized; " +
+                            $"{values}. Only \"TCP\" and \"UDP\" are recognized; " +
                             "unrecognized tokens are ignored (a proxy with no recognized protocol defaults to both).");
+                    }
                 }
 
                 if (proxy.SupportedAddressFamilies != null)
@@ -276,12 +288,45 @@ namespace ProxiFyre
                         throw new InvalidOperationException(message);
                     }
                 }
+
+                var transport = proxy.Socks5TransportParse;
+                if (transport == Socks5TransportEnum.TLS)
+                {
+                    if (!string.IsNullOrWhiteSpace(proxy.TlsPinnedSha256) && !IsSha256Fingerprint(proxy.TlsPinnedSha256))
+                    {
+                        var message = $"Proxy '{proxy.Socks5ProxyEndpoint}' has an invalid " +
+                                      "\"tlsPinnedSha256\" value. Use a 64-character hex SHA-256 certificate fingerprint.";
+                        LoggerInstance.Error(message);
+                        throw new InvalidOperationException(message);
+                    }
+
+                    if (proxy.TlsAllowInvalidCertificate && string.IsNullOrWhiteSpace(proxy.TlsPinnedSha256))
+                    {
+                        LoggerInstance.Warn(
+                            $"Proxy '{proxy.Socks5ProxyEndpoint}' allows invalid TLS certificates without a certificate pin. " +
+                            "This disables upstream identity verification.");
+                    }
+                }
             }
 
             // Drop null/blank excluded entries for the same reason.
             settings.ExcludedList.RemoveAll(string.IsNullOrWhiteSpace);
 
             return settings;
+        }
+
+        private static bool IsSha256Fingerprint(string value)
+        {
+            var normalized = NormalizeFingerprint(value);
+            return normalized.Length == 64 && normalized.All(Uri.IsHexDigit);
+        }
+
+        private static string NormalizeFingerprint(string value)
+        {
+            return new string((value ?? string.Empty)
+                .Where(c => c != ':' && c != '-' && !char.IsWhiteSpace(c))
+                .Select(char.ToLowerInvariant)
+                .ToArray());
         }
 
         /// <summary>
@@ -400,7 +445,9 @@ namespace ProxiFyre
             /// <param name="supportedProtocols">List of supported protocols (e.g., TCP, UDP).</param>
             /// <param name="supportedAddressFamilies">List of supported destination address families (e.g., IPv4, IPv6).</param>
             public AppSettings(List<string> appNames, string socks5ProxyEndpoint, string username, string password,
-                List<string> supportedProtocols, List<string> supportedAddressFamilies = null)
+                List<string> supportedProtocols, List<string> supportedAddressFamilies = null,
+                string socks5Transport = null, string tlsServerName = null, string tlsPinnedSha256 = null,
+                bool tlsAllowInvalidCertificate = false)
             {
                 AppNames = appNames;
                 Socks5ProxyEndpoint = socks5ProxyEndpoint;
@@ -408,6 +455,10 @@ namespace ProxiFyre
                 Password = password;
                 SupportedProtocols = supportedProtocols;
                 SupportedAddressFamilies = supportedAddressFamilies;
+                Socks5Transport = socks5Transport;
+                TlsServerName = tlsServerName;
+                TlsPinnedSha256 = tlsPinnedSha256;
+                TlsAllowInvalidCertificate = tlsAllowInvalidCertificate;
             }
 
             /// <summary>
@@ -441,20 +492,80 @@ namespace ProxiFyre
             public List<string> SupportedAddressFamilies { get; }
 
             /// <summary>
+            /// Gets the upstream transport used to reach the SOCKS5 proxy.
+            /// </summary>
+            public string Socks5Transport { get; }
+
+            /// <summary>
+            /// Gets the TLS SNI and certificate validation server name.
+            /// </summary>
+            public string TlsServerName { get; }
+
+            /// <summary>
+            /// Gets the optional SHA-256 certificate fingerprint pin.
+            /// </summary>
+            public string TlsPinnedSha256 { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether invalid TLS certificates are allowed.
+            /// </summary>
+            public bool TlsAllowInvalidCertificate { get; }
+
+            /// <summary>
+            /// Gets the effective TLS server name, defaulting to the endpoint host.
+            /// </summary>
+            public string EffectiveTlsServerName
+            {
+                get
+                {
+                    return string.IsNullOrWhiteSpace(TlsServerName)
+                        ? ExtractEndpointHost(Socks5ProxyEndpoint)
+                        : TlsServerName.Trim();
+                }
+            }
+
+            /// <summary>
             /// Gets the supported protocols as an enum value.
             /// </summary>
             public SupportedProtocolsEnum SupportedProtocolsParse
             {
                 get
                 {
+                    var supportsTcp = ContainsProtocol("TCP");
+                    var supportsUdp = ContainsProtocol("UDP");
                     if (SupportedProtocols == null || SupportedProtocols.Count == 0 ||
-                        (SupportedProtocols.Contains("TCP") && SupportedProtocols.Contains("UDP")))
+                        (supportsTcp && supportsUdp))
                         return SupportedProtocolsEnum.BOTH;
-                    if (SupportedProtocols.Contains("TCP"))
+                    if (supportsTcp)
                         return SupportedProtocolsEnum.TCP;
-                    return SupportedProtocols.Contains("UDP")
+                    return supportsUdp
                         ? SupportedProtocolsEnum.UDP
                         : SupportedProtocolsEnum.BOTH;
+                }
+            }
+
+            /// <summary>
+            /// Gets the upstream SOCKS5 transport as an enum value.
+            /// </summary>
+            public Socks5TransportEnum Socks5TransportParse
+            {
+                get
+                {
+                    var transport = Socks5Transport?.Trim();
+                    if (string.IsNullOrEmpty(transport) ||
+                        string.Equals(transport, "TCP", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(transport, "Plain", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(transport, "SOCKS5", StringComparison.OrdinalIgnoreCase))
+                        return Socks5TransportEnum.TCP;
+
+                    if (string.Equals(transport, "TLS", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(transport, "SOCKS5TLS", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(transport, "SOCKS5_TLS", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(transport, "SOCKS5-TLS", StringComparison.OrdinalIgnoreCase))
+                        return Socks5TransportEnum.TLS;
+
+                    throw new InvalidOperationException(
+                        "socks5Transport must be TCP or TLS.");
                 }
             }
 
@@ -486,6 +597,25 @@ namespace ProxiFyre
             {
                 return SupportedAddressFamilies != null &&
                     SupportedAddressFamilies.Any(f => string.Equals(f, value, StringComparison.OrdinalIgnoreCase));
+            }
+
+            private bool ContainsProtocol(string value)
+            {
+                return SupportedProtocols != null &&
+                    SupportedProtocols.Any(p => string.Equals(p, value, StringComparison.OrdinalIgnoreCase));
+            }
+
+            private static string ExtractEndpointHost(string endpoint)
+            {
+                var value = (endpoint ?? string.Empty).Trim();
+                if (value.StartsWith("[", StringComparison.Ordinal))
+                {
+                    var end = value.IndexOf(']');
+                    return end > 1 ? value.Substring(1, end - 1) : value;
+                }
+
+                var colon = value.LastIndexOf(':');
+                return colon > 0 ? value.Substring(0, colon) : value;
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The application uses a configuration file named `app-config.json`. This JSON fil
 - **socks5ProxyEndpoint**: A string that specifies the SOCKS5 proxy endpoint.
 - **username**: A string that specifies the username for the proxy (optional).
 - **password**: A string that specifies the password for the proxy (optional).
+- **socks5Transport**: `"TCP"` for normal SOCKS5 (default) or `"TLS"` for SOCKS5-over-TLS.
+- **tlsServerName**: SNI/certificate validation name for `"socks5Transport": "TLS"` (defaults to the endpoint host).
+- **tlsPinnedSha256**: Optional SHA-256 certificate fingerprint pin for TLS upstreams.
+- **tlsAllowInvalidCertificate**: Allows invalid TLS certificates (default: `false`). Prefer `tlsPinnedSha256` for self-signed test certificates.
 - **supportedProtocols**: An array of strings specifying the supported protocols (e.g., `"TCP"`, `"UDP"`).
 - **supportedAddressFamilies**: An array containing `"IPv4"`, `"IPv6"`, or both. If omitted, both are enabled. An explicit empty array or any other value is rejected as a configuration error.
 - **excludes** *(new in v2.1.1)*: An array of application names or paths to exclude from proxy routing.
@@ -135,6 +139,26 @@ Example:
 ### SOCKS5 Proxy Authorization
 
 If the SOCKS5 proxy does not support authorization, you can skip the `username` and `password` fields in the configuration.
+
+---
+
+### SOCKS5-over-TLS / Alighieri
+
+ProxiFyre can initiate a TLS session to a SOCKS5 proxy that expects SOCKS5-over-TLS, such as Alighieri with `tls.certfile` / `tls.keyfile` enabled. TLS transport supports both TCP `CONNECT` and the UDP `ASSOCIATE` control channel.
+
+```json
+{
+  "appNames": ["chrome"],
+  "socks5ProxyEndpoint": "proxy.example.com:443",
+  "socks5Transport": "TLS",
+  "tlsServerName": "proxy.example.com",
+  "tlsPinnedSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "supportedProtocols": ["TCP", "UDP"],
+  "supportedAddressFamilies": ["IPv4", "IPv6"]
+}
+```
+
+For public certificates, omit `tlsPinnedSha256` and leave `tlsAllowInvalidCertificate` as `false`. Setting `tlsPinnedSha256` selects exact leaf-certificate pin validation instead of normal chain/hostname validation, which allows a self-signed certificate while still authenticating the configured certificate. Prefer that mode for self-signed lab certificates rather than disabling validation globally. The native transport currently negotiates TLS 1.2, which is supported by Alighieri's rustls listener.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If the SOCKS5 proxy does not support authorization, you can skip the `username` 
 
 ### SOCKS5-over-TLS / Alighieri
 
-ProxiFyre can initiate a TLS session to a SOCKS5 proxy that expects SOCKS5-over-TLS, such as Alighieri with `tls.certfile` / `tls.keyfile` enabled. TLS transport supports both TCP `CONNECT` and the UDP `ASSOCIATE` control channel.
+ProxiFyre can initiate a TLS session to a SOCKS5 proxy that expects SOCKS5-over-TLS, such as [Alighieri](https://github.com/wiresock/alighieri) with `tls.certfile` / `tls.keyfile` enabled. TLS transport supports both TCP `CONNECT` and the UDP `ASSOCIATE` control channel.
 
 ```json
 {

--- a/app-config.sample.json
+++ b/app-config.sample.json
@@ -7,6 +7,10 @@
             "socks5ProxyEndpoint": "proxy.example.com:1080",
             "username": "REPLACE_WITH_USERNAME_OR_LEAVE_EMPTY",
             "password": "REPLACE_WITH_PASSWORD_OR_LEAVE_EMPTY",
+            "socks5Transport": "TCP",
+            "tlsServerName": "",
+            "tlsPinnedSha256": "",
+            "tlsAllowInvalidCertificate": false,
             "supportedProtocols": ["TCP", "UDP"],
             "supportedAddressFamilies": ["IPv4", "IPv6"]
         }

--- a/netlib/src/proxy/schannel_tls_stream.h
+++ b/netlib/src/proxy/schannel_tls_stream.h
@@ -1,0 +1,897 @@
+#pragma once
+
+#ifndef SECURITY_WIN32
+#define SECURITY_WIN32
+#endif
+
+#ifndef SCHANNEL_USE_BLACKLISTS
+#define SCHANNEL_USE_BLACKLISTS
+#endif
+
+#include <security.h>
+#include <winternl.h>
+#include <schannel.h>
+#include <wincrypt.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace proxy
+{
+    class schannel_tls_stream
+    {
+    public:
+        enum class decrypt_status : uint8_t
+        {
+            ok,
+            need_more_data,
+            closed,
+            failed
+        };
+
+        schannel_tls_stream(const SOCKET socket, socks5_tls_options options)
+            : socket_(socket),
+              options_(std::move(options)),
+              read_buffer_(tls_read_buffer_size)
+        {
+        }
+
+        schannel_tls_stream(const schannel_tls_stream&) = delete;
+        schannel_tls_stream& operator=(const schannel_tls_stream&) = delete;
+
+        schannel_tls_stream(schannel_tls_stream&&) = delete;
+        schannel_tls_stream& operator=(schannel_tls_stream&&) = delete;
+
+        ~schannel_tls_stream()
+        {
+            if (context_acquired_)
+            {
+                DeleteSecurityContext(&context_);
+            }
+            if (credentials_acquired_)
+            {
+                FreeCredentialsHandle(&credentials_);
+            }
+        }
+
+        [[nodiscard]] const std::string& last_error() const noexcept
+        {
+            return last_error_;
+        }
+
+        [[nodiscard]] bool handshake()
+        {
+            if (handshake_complete_)
+            {
+                last_error_ = "SChannel TLS handshake has already completed.";
+                return false;
+            }
+
+            if (socket_ == INVALID_SOCKET)
+            {
+                last_error_ = "SChannel TLS socket is invalid.";
+                return false;
+            }
+
+            if (!options_.pinned_cert_sha256.empty())
+            {
+                options_.pinned_cert_sha256 = normalize_fingerprint(options_.pinned_cert_sha256);
+                if (!is_sha256_fingerprint(options_.pinned_cert_sha256))
+                {
+                    last_error_ = "SChannel TLS certificate pin must contain exactly 64 hexadecimal digits.";
+                    return false;
+                }
+            }
+
+            if (!options_.allow_invalid_certificate && options_.pinned_cert_sha256.empty() &&
+                options_.server_name.empty())
+            {
+                last_error_ = "SChannel TLS server name is required for certificate validation.";
+                return false;
+            }
+
+            if (!acquire_credentials())
+            {
+                return false;
+            }
+
+            receive_deadline_guard receive_deadline{ *this };
+
+            constexpr DWORD request_flags =
+                ISC_REQ_SEQUENCE_DETECT |
+                ISC_REQ_REPLAY_DETECT |
+                ISC_REQ_CONFIDENTIALITY |
+                ISC_REQ_EXTENDED_ERROR |
+                ISC_REQ_ALLOCATE_MEMORY |
+                ISC_REQ_STREAM;
+
+            DWORD context_attributes = 0;
+            TimeStamp expiry{};
+            bool first_call = true;
+
+            while (true)
+            {
+                SecBuffer out_buffer{};
+                out_buffer.BufferType = SECBUFFER_TOKEN;
+
+                SecBufferDesc out_desc{};
+                out_desc.ulVersion = SECBUFFER_VERSION;
+                out_desc.cBuffers = 1;
+                out_desc.pBuffers = &out_buffer;
+
+                SecBuffer in_buffers[2]{};
+                SecBufferDesc in_desc{};
+                SecBufferDesc* in_desc_ptr = nullptr;
+
+                if (!first_call)
+                {
+                    if (encrypted_buffer_.empty() && !read_encrypted())
+                    {
+                        return false;
+                    }
+
+                    in_buffers[0].BufferType = SECBUFFER_TOKEN;
+                    in_buffers[0].pvBuffer = encrypted_buffer_.data();
+                    in_buffers[0].cbBuffer = static_cast<unsigned long>(encrypted_buffer_.size());
+                    in_buffers[1].BufferType = SECBUFFER_EMPTY;
+
+                    in_desc.ulVersion = SECBUFFER_VERSION;
+                    in_desc.cBuffers = 2;
+                    in_desc.pBuffers = in_buffers;
+                    in_desc_ptr = &in_desc;
+                }
+
+                auto* const context_ptr = context_acquired_ ? &context_ : nullptr;
+                const auto status = InitializeSecurityContextA(
+                    &credentials_,
+                    context_ptr,
+                    options_.server_name.empty() ? nullptr : const_cast<SEC_CHAR*>(options_.server_name.c_str()),
+                    request_flags,
+                    0,
+                    SECURITY_NATIVE_DREP,
+                    in_desc_ptr,
+                    0,
+                    &context_,
+                    &out_desc,
+                    &context_attributes,
+                    &expiry);
+
+                if (!context_acquired_ && (status == SEC_I_CONTINUE_NEEDED || status == SEC_E_OK))
+                {
+                    context_acquired_ = true;
+                }
+
+                if (out_buffer.pvBuffer != nullptr)
+                {
+                    const auto send_result = out_buffer.cbBuffer == 0 ||
+                        raw_send_all(out_buffer.pvBuffer, static_cast<int>(out_buffer.cbBuffer));
+                    FreeContextBuffer(out_buffer.pvBuffer);
+                    if (!send_result)
+                    {
+                        return false;
+                    }
+                }
+
+                if (status == SEC_E_INCOMPLETE_MESSAGE)
+                {
+                    if (!read_encrypted())
+                    {
+                        return false;
+                    }
+                    first_call = false;
+                    continue;
+                }
+
+                if (status == SEC_I_CONTINUE_NEEDED)
+                {
+                    preserve_extra(in_buffers[1]);
+                    first_call = false;
+                    continue;
+                }
+
+                if (status == SEC_E_OK)
+                {
+                    preserve_extra(in_buffers[1]);
+                    constexpr DWORD required_attributes =
+                        ISC_RET_SEQUENCE_DETECT |
+                        ISC_RET_REPLAY_DETECT |
+                        ISC_RET_CONFIDENTIALITY |
+                        ISC_RET_STREAM;
+                    if ((context_attributes & required_attributes) != required_attributes)
+                    {
+                        last_error_ = "SChannel TLS context did not provide the requested stream security attributes.";
+                        return false;
+                    }
+
+                    const auto stream_status =
+                        QueryContextAttributes(&context_, SECPKG_ATTR_STREAM_SIZES, &stream_sizes_);
+                    if (stream_status != SEC_E_OK)
+                    {
+                        set_security_error("SChannel failed to query stream sizes", stream_status);
+                        return false;
+                    }
+                    if (stream_sizes_.cbMaximumMessage == 0)
+                    {
+                        last_error_ = "SChannel returned an invalid maximum TLS message size.";
+                        return false;
+                    }
+
+                    if (!verify_peer_certificate())
+                    {
+                        return false;
+                    }
+
+                    handshake_complete_ = true;
+                    return true;
+                }
+
+                set_security_error("SChannel TLS handshake failed", status);
+                return false;
+            }
+        }
+
+        [[nodiscard]] bool send_all(const void* const data, const int length)
+        {
+            if (length < 0)
+            {
+                last_error_ = "SChannel TLS send received an invalid buffer.";
+                return false;
+            }
+
+            std::vector<char> encrypted;
+            if (!encrypt(data, static_cast<size_t>(length), encrypted))
+            {
+                return false;
+            }
+
+            return encrypted.empty() || raw_send_all(encrypted.data(), static_cast<int>(encrypted.size()));
+        }
+
+        [[nodiscard]] bool recv_exact(void* const data, const int length)
+        {
+            if (!handshake_complete_)
+            {
+                last_error_ = "SChannel TLS receive attempted before handshake completion.";
+                return false;
+            }
+            if (length < 0 || (data == nullptr && length != 0))
+            {
+                last_error_ = "SChannel TLS receive received an invalid buffer.";
+                return false;
+            }
+
+            receive_deadline_guard receive_deadline{ *this };
+
+            auto* bytes = static_cast<char*>(data);
+            int received = 0;
+
+            while (received < length)
+            {
+                if (decrypted_buffer_.empty() && !decrypt_next_record())
+                {
+                    return false;
+                }
+
+                const auto to_copy = std::min<int>(
+                    length - received,
+                    static_cast<int>(decrypted_buffer_.size()));
+                memcpy(bytes + received, decrypted_buffer_.data(), to_copy);
+                decrypted_buffer_.erase(decrypted_buffer_.begin(), decrypted_buffer_.begin() + to_copy);
+                received += to_copy;
+            }
+
+            return true;
+        }
+
+        /**
+         * @brief Encrypts application data into one or more complete TLS records.
+         *
+         * The returned buffer owns all record bytes and may be used directly by an
+         * overlapped WSASend. Calls must be serialized with other encrypt calls for
+         * this security context.
+         */
+        [[nodiscard]] bool encrypt(const void* const data, const size_t length, std::vector<char>& encrypted)
+        {
+            encrypted.clear();
+
+            if (!handshake_complete_)
+            {
+                last_error_ = "SChannel TLS encrypt attempted before handshake completion.";
+                return false;
+            }
+            if (data == nullptr && length != 0)
+            {
+                last_error_ = "SChannel TLS encrypt received an invalid buffer.";
+                return false;
+            }
+
+            const auto* bytes = static_cast<const char*>(data);
+            auto remaining = length;
+            while (remaining != 0)
+            {
+                const auto chunk = static_cast<int>(std::min<size_t>(
+                    remaining,
+                    static_cast<size_t>(stream_sizes_.cbMaximumMessage)));
+                if (!encrypt_chunk(bytes, chunk, encrypted))
+                {
+                    encrypted.clear();
+                    return false;
+                }
+
+                bytes += chunk;
+                remaining -= static_cast<size_t>(chunk);
+            }
+
+            return true;
+        }
+
+        /**
+         * @brief Adds encrypted bytes and decrypts every complete TLS record currently buffered.
+         *
+         * SChannel can consume ahead during handshake or a small protocol read. This method
+         * therefore also emits plaintext left by recv_exact() and processes encrypted records
+         * retained from earlier calls. Incomplete record bytes remain owned by the stream.
+         */
+        [[nodiscard]] decrypt_status decrypt_available(
+            const void* const data,
+            const size_t length,
+            std::vector<char>& plaintext)
+        {
+            plaintext.clear();
+
+            if (!handshake_complete_)
+            {
+                last_error_ = "SChannel TLS decrypt attempted before handshake completion.";
+                return decrypt_status::failed;
+            }
+            if (data == nullptr && length != 0)
+            {
+                last_error_ = "SChannel TLS decrypt received an invalid buffer.";
+                return decrypt_status::failed;
+            }
+
+            if (!decrypted_buffer_.empty())
+            {
+                plaintext = std::move(decrypted_buffer_);
+                decrypted_buffer_.clear();
+            }
+
+            if (peer_closed_)
+            {
+                if (length != 0)
+                {
+                    last_error_ = "SChannel TLS received encrypted data after close_notify.";
+                    plaintext.clear();
+                    return decrypt_status::failed;
+                }
+                return decrypt_status::closed;
+            }
+
+            if (length != 0)
+            {
+                const auto* const begin = static_cast<const char*>(data);
+                encrypted_buffer_.insert(encrypted_buffer_.end(), begin, begin + length);
+            }
+
+            while (!encrypted_buffer_.empty())
+            {
+                SecBuffer buffers[4]{};
+                buffers[0].BufferType = SECBUFFER_DATA;
+                buffers[0].pvBuffer = encrypted_buffer_.data();
+                buffers[0].cbBuffer = static_cast<unsigned long>(encrypted_buffer_.size());
+                buffers[1].BufferType = SECBUFFER_EMPTY;
+                buffers[2].BufferType = SECBUFFER_EMPTY;
+                buffers[3].BufferType = SECBUFFER_EMPTY;
+
+                SecBufferDesc desc{};
+                desc.ulVersion = SECBUFFER_VERSION;
+                desc.cBuffers = 4;
+                desc.pBuffers = buffers;
+
+                const auto status = DecryptMessage(&context_, &desc, 0, nullptr);
+                if (status == SEC_E_INCOMPLETE_MESSAGE)
+                {
+                    return plaintext.empty() ? decrypt_status::need_more_data : decrypt_status::ok;
+                }
+                if (status == SEC_I_CONTEXT_EXPIRED)
+                {
+                    encrypted_buffer_.clear();
+                    peer_closed_ = true;
+                    last_error_ = "SChannel TLS stream closed.";
+                    return decrypt_status::closed;
+                }
+                if (status != SEC_E_OK)
+                {
+                    set_security_error(
+                        status == SEC_I_RENEGOTIATE
+                            ? "SChannel TLS renegotiation is not supported"
+                            : "SChannel failed to decrypt data",
+                        status);
+                    plaintext.clear();
+                    return decrypt_status::failed;
+                }
+
+                std::vector<char> extra;
+                for (const auto& buffer : buffers)
+                {
+                    if (buffer.BufferType == SECBUFFER_DATA && buffer.pvBuffer != nullptr && buffer.cbBuffer != 0)
+                    {
+                        const auto* const begin = static_cast<const char*>(buffer.pvBuffer);
+                        plaintext.insert(plaintext.end(), begin, begin + buffer.cbBuffer);
+                    }
+                    else if (buffer.BufferType == SECBUFFER_EXTRA && buffer.pvBuffer != nullptr && buffer.cbBuffer != 0)
+                    {
+                        const auto* const begin = static_cast<const char*>(buffer.pvBuffer);
+                        extra.assign(begin, begin + buffer.cbBuffer);
+                    }
+                }
+
+                encrypted_buffer_ = std::move(extra);
+            }
+
+            return plaintext.empty() ? decrypt_status::need_more_data : decrypt_status::ok;
+        }
+
+        /**
+         * @brief Creates the TLS close_notify token for an orderly client shutdown.
+         */
+        [[nodiscard]] bool create_shutdown_token(std::vector<char>& token)
+        {
+            token.clear();
+            if (!handshake_complete_ || !context_acquired_)
+            {
+                last_error_ = "SChannel TLS shutdown attempted before handshake completion.";
+                return false;
+            }
+            if (shutdown_started_)
+            {
+                last_error_ = "SChannel TLS shutdown has already started.";
+                return false;
+            }
+
+            DWORD shutdown_control = SCHANNEL_SHUTDOWN;
+            SecBuffer control_buffer{};
+            control_buffer.BufferType = SECBUFFER_TOKEN;
+            control_buffer.pvBuffer = &shutdown_control;
+            control_buffer.cbBuffer = sizeof(shutdown_control);
+
+            SecBufferDesc control_desc{};
+            control_desc.ulVersion = SECBUFFER_VERSION;
+            control_desc.cBuffers = 1;
+            control_desc.pBuffers = &control_buffer;
+
+            auto status = ApplyControlToken(&context_, &control_desc);
+            if (status != SEC_E_OK)
+            {
+                set_security_error("SChannel failed to apply the TLS shutdown token", status);
+                return false;
+            }
+
+            shutdown_started_ = true;
+
+            SecBuffer out_buffer{};
+            out_buffer.BufferType = SECBUFFER_TOKEN;
+            SecBufferDesc out_desc{};
+            out_desc.ulVersion = SECBUFFER_VERSION;
+            out_desc.cBuffers = 1;
+            out_desc.pBuffers = &out_buffer;
+
+            constexpr DWORD request_flags =
+                ISC_REQ_SEQUENCE_DETECT |
+                ISC_REQ_REPLAY_DETECT |
+                ISC_REQ_CONFIDENTIALITY |
+                ISC_REQ_EXTENDED_ERROR |
+                ISC_REQ_ALLOCATE_MEMORY |
+                ISC_REQ_STREAM;
+            DWORD context_attributes = 0;
+            TimeStamp expiry{};
+            status = InitializeSecurityContextA(
+                &credentials_,
+                &context_,
+                options_.server_name.empty() ? nullptr : const_cast<SEC_CHAR*>(options_.server_name.c_str()),
+                request_flags,
+                0,
+                SECURITY_NATIVE_DREP,
+                nullptr,
+                0,
+                &context_,
+                &out_desc,
+                &context_attributes,
+                &expiry);
+
+            const auto shutdown_status_ok = status == SEC_E_OK ||
+                status == SEC_I_CONTEXT_EXPIRED ||
+                status == SEC_I_CONTINUE_NEEDED;
+            if (out_buffer.pvBuffer != nullptr && out_buffer.cbBuffer != 0)
+            {
+                const auto* const begin = static_cast<const char*>(out_buffer.pvBuffer);
+                token.assign(begin, begin + out_buffer.cbBuffer);
+            }
+            if (out_buffer.pvBuffer != nullptr)
+            {
+                FreeContextBuffer(out_buffer.pvBuffer);
+            }
+
+            if (!shutdown_status_ok)
+            {
+                set_security_error("SChannel failed to create the TLS shutdown token", status);
+                token.clear();
+                return false;
+            }
+            if (token.empty())
+            {
+                last_error_ = "SChannel returned an empty TLS shutdown token.";
+                return false;
+            }
+
+            return true;
+        }
+
+    private:
+        class receive_deadline_guard
+        {
+        public:
+            explicit receive_deadline_guard(schannel_tls_stream& stream) noexcept
+                : stream_(stream)
+            {
+                int timeout_size = static_cast<int>(sizeof(original_timeout_));
+                if (getsockopt(stream_.socket_, SOL_SOCKET, SO_RCVTIMEO,
+                    reinterpret_cast<char*>(&original_timeout_), &timeout_size) == SOCKET_ERROR)
+                {
+                    original_timeout_ = receive_operation_timeout_ms;
+                }
+
+                stream_.receive_deadline_ = GetTickCount64() + receive_operation_timeout_ms;
+                stream_.receive_deadline_active_ = true;
+            }
+
+            receive_deadline_guard(const receive_deadline_guard&) = delete;
+            receive_deadline_guard& operator=(const receive_deadline_guard&) = delete;
+
+            ~receive_deadline_guard()
+            {
+                stream_.receive_deadline_active_ = false;
+                setsockopt(stream_.socket_, SOL_SOCKET, SO_RCVTIMEO,
+                    reinterpret_cast<const char*>(&original_timeout_), sizeof(original_timeout_));
+            }
+
+        private:
+            schannel_tls_stream& stream_;
+            DWORD original_timeout_ = receive_operation_timeout_ms;
+        };
+
+        [[nodiscard]] bool acquire_credentials()
+        {
+            DWORD credential_flags = SCH_CRED_NO_DEFAULT_CREDS | SCH_USE_STRONG_CRYPTO;
+            if (options_.allow_invalid_certificate || !options_.pinned_cert_sha256.empty())
+            {
+                credential_flags |= SCH_CRED_MANUAL_CRED_VALIDATION;
+            }
+            else
+            {
+                credential_flags |=
+                    SCH_CRED_AUTO_CRED_VALIDATION |
+                    SCH_CRED_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT |
+                    SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
+                    SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+            }
+
+            // Keep the record layer on TLS 1.2. SChannel exposes TLS 1.3
+            // post-handshake messages through SEC_I_RENEGOTIATE, which requires a second
+            // asynchronous handshake state machine during relay. Alighieri enables its
+            // rustls TLS 1.2 provider, so this remains interoperable without accepting
+            // obsolete protocol versions.
+            TLS_PARAMETERS tls_parameters{};
+            tls_parameters.grbitDisabledProtocols =
+                SP_PROT_SSL2_CLIENT |
+                SP_PROT_SSL3_CLIENT |
+                SP_PROT_TLS1_0_CLIENT |
+                SP_PROT_TLS1_1_CLIENT |
+                SP_PROT_TLS1_3_CLIENT;
+
+            SCH_CREDENTIALS credentials{};
+            credentials.dwVersion = SCH_CREDENTIALS_VERSION;
+            credentials.dwFlags = credential_flags;
+            credentials.cTlsParameters = 1;
+            credentials.pTlsParameters = &tls_parameters;
+
+            TimeStamp expiry{};
+            auto status = AcquireCredentialsHandleA(
+                nullptr,
+                const_cast<SEC_CHAR*>(UNISP_NAME_A),
+                SECPKG_CRED_OUTBOUND,
+                nullptr,
+                &credentials,
+                nullptr,
+                nullptr,
+                &credentials_,
+                &expiry);
+
+            // SCH_CREDENTIALS was added for crypto-agile TLS configuration. Fall back to
+            // SCHANNEL_CRED on older Windows releases that do not recognize version 5.
+            if (status != SEC_E_OK)
+            {
+                SCHANNEL_CRED legacy_credentials{};
+                legacy_credentials.dwVersion = SCHANNEL_CRED_VERSION;
+                legacy_credentials.grbitEnabledProtocols = SP_PROT_TLS1_2_CLIENT;
+                legacy_credentials.dwFlags = credential_flags;
+                status = AcquireCredentialsHandleA(
+                    nullptr,
+                    const_cast<SEC_CHAR*>(UNISP_NAME_A),
+                    SECPKG_CRED_OUTBOUND,
+                    nullptr,
+                    &legacy_credentials,
+                    nullptr,
+                    nullptr,
+                    &credentials_,
+                    &expiry);
+            }
+
+            if (status != SEC_E_OK)
+            {
+                set_security_error("SChannel failed to acquire credentials", status);
+                return false;
+            }
+
+            credentials_acquired_ = true;
+            return true;
+        }
+
+        [[nodiscard]] bool encrypt_chunk(
+            const char* const data,
+            const int length,
+            std::vector<char>& encrypted)
+        {
+            std::vector<char> packet(
+                stream_sizes_.cbHeader + length + stream_sizes_.cbTrailer);
+            memcpy(packet.data() + stream_sizes_.cbHeader, data, length);
+
+            SecBuffer buffers[4]{};
+            buffers[0].BufferType = SECBUFFER_STREAM_HEADER;
+            buffers[0].pvBuffer = packet.data();
+            buffers[0].cbBuffer = stream_sizes_.cbHeader;
+            buffers[1].BufferType = SECBUFFER_DATA;
+            buffers[1].pvBuffer = packet.data() + stream_sizes_.cbHeader;
+            buffers[1].cbBuffer = static_cast<unsigned long>(length);
+            buffers[2].BufferType = SECBUFFER_STREAM_TRAILER;
+            buffers[2].pvBuffer = packet.data() + stream_sizes_.cbHeader + length;
+            buffers[2].cbBuffer = stream_sizes_.cbTrailer;
+            buffers[3].BufferType = SECBUFFER_EMPTY;
+
+            SecBufferDesc desc{};
+            desc.ulVersion = SECBUFFER_VERSION;
+            desc.cBuffers = 4;
+            desc.pBuffers = buffers;
+
+            const auto status = EncryptMessage(&context_, 0, &desc, 0);
+            if (status != SEC_E_OK)
+            {
+                set_security_error("SChannel failed to encrypt data", status);
+                return false;
+            }
+
+            const auto packet_size = buffers[0].cbBuffer + buffers[1].cbBuffer + buffers[2].cbBuffer;
+            encrypted.insert(encrypted.end(), packet.data(), packet.data() + packet_size);
+            return true;
+        }
+
+        [[nodiscard]] bool decrypt_next_record()
+        {
+            while (true)
+            {
+                std::vector<char> plaintext;
+                const auto status = decrypt_available(nullptr, 0, plaintext);
+                if (status == decrypt_status::failed)
+                {
+                    return false;
+                }
+                if (!plaintext.empty())
+                {
+                    decrypted_buffer_ = std::move(plaintext);
+                    return true;
+                }
+                if (status == decrypt_status::closed)
+                {
+                    return false;
+                }
+                if (!read_encrypted())
+                {
+                    return false;
+                }
+            }
+        }
+
+        [[nodiscard]] bool read_encrypted()
+        {
+            if (receive_deadline_active_)
+            {
+                const auto now = GetTickCount64();
+                if (now >= receive_deadline_)
+                {
+                    last_error_ = "SChannel TLS receive operation timed out.";
+                    return false;
+                }
+
+                auto remaining_ms = static_cast<DWORD>(receive_deadline_ - now);
+                if (setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO,
+                    reinterpret_cast<const char*>(&remaining_ms), sizeof(remaining_ms)) == SOCKET_ERROR)
+                {
+                    last_error_ = "SChannel failed to set the TLS receive timeout: " +
+                        std::to_string(WSAGetLastError());
+                    return false;
+                }
+            }
+
+            const auto received = recv(socket_, read_buffer_.data(), static_cast<int>(read_buffer_.size()), 0);
+            if (received == SOCKET_ERROR)
+            {
+                last_error_ = "SChannel TLS socket recv failed: " + std::to_string(WSAGetLastError());
+                return false;
+            }
+            if (received == 0)
+            {
+                last_error_ = "SChannel TLS socket closed by peer.";
+                return false;
+            }
+
+            encrypted_buffer_.insert(encrypted_buffer_.end(), read_buffer_.data(), read_buffer_.data() + received);
+            return true;
+        }
+
+        [[nodiscard]] bool raw_send_all(const void* const data, const int length)
+        {
+            auto* bytes = static_cast<const char*>(data);
+            int sent_total = 0;
+            while (sent_total < length)
+            {
+                const auto sent = send(socket_, bytes + sent_total, length - sent_total, 0);
+                if (sent == SOCKET_ERROR)
+                {
+                    last_error_ = "SChannel TLS socket send failed: " + std::to_string(WSAGetLastError());
+                    return false;
+                }
+                if (sent == 0)
+                {
+                    last_error_ = "SChannel TLS socket send returned zero bytes.";
+                    return false;
+                }
+                sent_total += sent;
+            }
+
+            return true;
+        }
+
+        void preserve_extra(const SecBuffer& buffer)
+        {
+            if (buffer.BufferType == SECBUFFER_EXTRA && buffer.pvBuffer != nullptr && buffer.cbBuffer != 0)
+            {
+                const auto* begin = static_cast<const char*>(buffer.pvBuffer);
+                std::vector<char> extra(begin, begin + buffer.cbBuffer);
+                encrypted_buffer_ = std::move(extra);
+            }
+            else
+            {
+                encrypted_buffer_.clear();
+            }
+        }
+
+        [[nodiscard]] bool verify_peer_certificate()
+        {
+            if (options_.pinned_cert_sha256.empty())
+            {
+                return true;
+            }
+
+            PCCERT_CONTEXT cert = nullptr;
+            const auto status = QueryContextAttributes(&context_, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert);
+            if (status != SEC_E_OK)
+            {
+                set_security_error("SChannel failed to query peer certificate", status);
+                return false;
+            }
+            if (cert == nullptr)
+            {
+                last_error_ = "SChannel returned no peer certificate.";
+                return false;
+            }
+
+            std::array<BYTE, 32> hash{};
+            DWORD hash_size = static_cast<DWORD>(hash.size());
+            const auto hash_result = CryptHashCertificate(
+                0,
+                CALG_SHA_256,
+                0,
+                cert->pbCertEncoded,
+                cert->cbCertEncoded,
+                hash.data(),
+                &hash_size);
+            const auto hash_error = hash_result ? ERROR_SUCCESS : GetLastError();
+            CertFreeCertificateContext(cert);
+
+            if (!hash_result)
+            {
+                last_error_ = "SChannel failed to hash peer certificate: " + std::to_string(hash_error);
+                return false;
+            }
+            if (hash_size != hash.size())
+            {
+                last_error_ = "SChannel returned an invalid SHA-256 certificate hash size.";
+                return false;
+            }
+
+            if (hex_encode(hash.data(), hash_size) != options_.pinned_cert_sha256)
+            {
+                last_error_ = "SChannel peer certificate SHA-256 fingerprint did not match the configured pin.";
+                return false;
+            }
+
+            return true;
+        }
+
+        static std::string normalize_fingerprint(const std::string& value)
+        {
+            std::string normalized;
+            normalized.reserve(value.size());
+            for (const auto ch : value)
+            {
+                if (ch == ':' || ch == '-' || std::isspace(static_cast<unsigned char>(ch)))
+                {
+                    continue;
+                }
+                normalized.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+            }
+            return normalized;
+        }
+
+        static bool is_sha256_fingerprint(const std::string& value)
+        {
+            return value.size() == 64 && std::all_of(value.begin(), value.end(), [](const unsigned char ch)
+            {
+                return std::isxdigit(ch) != 0;
+            });
+        }
+
+        static std::string hex_encode(const BYTE* const data, const DWORD length)
+        {
+            std::ostringstream stream;
+            stream << std::hex << std::setfill('0');
+            for (DWORD i = 0; i < length; ++i)
+            {
+                stream << std::setw(2) << static_cast<unsigned int>(data[i]);
+            }
+            return stream.str();
+        }
+
+        void set_security_error(const std::string& prefix, const SECURITY_STATUS status)
+        {
+            std::ostringstream stream;
+            stream << prefix << ": 0x" << std::hex << static_cast<unsigned long>(status);
+            last_error_ = stream.str();
+        }
+
+        SOCKET socket_{ INVALID_SOCKET };
+        socks5_tls_options options_;
+        CredHandle credentials_{};
+        CtxtHandle context_{};
+        SecPkgContext_StreamSizes stream_sizes_{};
+        bool credentials_acquired_ = false;
+        bool context_acquired_ = false;
+        bool handshake_complete_ = false;
+        bool peer_closed_ = false;
+        bool shutdown_started_ = false;
+        bool receive_deadline_active_ = false;
+        ULONGLONG receive_deadline_ = 0;
+        static constexpr DWORD receive_operation_timeout_ms = 5000;
+        static constexpr auto tls_read_buffer_size = 16 * 1024;
+        std::vector<char> read_buffer_;
+        std::vector<char> encrypted_buffer_;
+        std::vector<char> decrypted_buffer_;
+        std::string last_error_;
+    };
+}

--- a/netlib/src/proxy/schannel_tls_stream.h
+++ b/netlib/src/proxy/schannel_tls_stream.h
@@ -8,6 +8,7 @@
 #define SCHANNEL_USE_BLACKLISTS
 #endif
 
+#include <WinSock2.h>
 #include <security.h>
 #include <winternl.h>
 #include <schannel.h>
@@ -16,11 +17,15 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
+
+#include "socks5_common.h"
 
 namespace proxy
 {

--- a/netlib/src/proxy/socks5_common.h
+++ b/netlib/src/proxy/socks5_common.h
@@ -2,6 +2,39 @@
 
 namespace proxy
 {
+    /**
+     * @brief Transport used to reach an upstream SOCKS5 proxy.
+     */
+    enum class socks5_transport : uint8_t
+    {
+        tcp = 0,
+        tls = 1
+    };
+
+    /**
+     * @brief TLS options for SOCKS5-over-TLS upstream connections.
+     */
+    struct socks5_tls_options
+    {
+        std::string server_name;
+        std::string pinned_cert_sha256;
+        bool allow_invalid_certificate = false;
+    };
+
+    /**
+     * @brief Full upstream connection options for a SOCKS5 proxy.
+     */
+    struct socks5_upstream_options
+    {
+        socks5_transport transport = socks5_transport::tcp;
+        socks5_tls_options tls;
+
+        [[nodiscard]] bool is_tls() const noexcept
+        {
+            return transport == socks5_transport::tls;
+        }
+    };
+
 #pragma pack(push,1) // Ensure tightly packed structures for protocol compliance
 
     // Constants defining SOCKS5 protocol specifics
@@ -154,6 +187,16 @@ namespace proxy
         }
 
         /**
+         * @brief Constructor for anonymous SOCKS5 negotiation with upstream transport options.
+         */
+        socks5_negotiate_context(const T& remote_address, uint16_t remote_port,
+            socks5_upstream_options upstream_options)
+            : negotiate_context<T>(remote_address, remote_port),
+            upstream_options(std::move(upstream_options))
+        {
+        }
+
+        /**
          * @brief Constructor for negotiation with optional auth parameters.
          */
         socks5_negotiate_context(const T& remote_srv_address, uint16_t remote_srv_port,
@@ -161,6 +204,19 @@ namespace proxy
             : negotiate_context<T>(remote_srv_address, remote_srv_port),
             socks5_username(std::move(socks5_username)),
             socks5_password(std::move(socks5_password))
+        {
+        }
+
+        /**
+         * @brief Constructor for negotiation with optional auth and upstream transport options.
+         */
+        socks5_negotiate_context(const T& remote_srv_address, uint16_t remote_srv_port,
+            std::optional<std::string> socks5_username, std::optional<std::string> socks5_password,
+            socks5_upstream_options upstream_options)
+            : negotiate_context<T>(remote_srv_address, remote_srv_port),
+            socks5_username(std::move(socks5_username)),
+            socks5_password(std::move(socks5_password)),
+            upstream_options(std::move(upstream_options))
         {
         }
 
@@ -177,5 +233,6 @@ namespace proxy
 
         std::optional<std::string> socks5_username{ std::nullopt }; ///< Optional username
         std::optional<std::string> socks5_password{ std::nullopt }; ///< Optional password
+        socks5_upstream_options upstream_options{}; ///< Upstream SOCKS transport options
     };
 }

--- a/netlib/src/proxy/socks5_common.h
+++ b/netlib/src/proxy/socks5_common.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "proxy_common.h"
+
 namespace proxy
 {
     /**

--- a/netlib/src/proxy/socks5_local_udp_proxy_server.h
+++ b/netlib/src/proxy/socks5_local_udp_proxy_server.h
@@ -1167,12 +1167,16 @@ namespace proxy
                           reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms)) == SOCKET_ERROR)
             {
                 NETLIB_WARNING("Failed to set socket receive timeout: {}", WSAGetLastError());
+                closesocket(socks_tcp_socket);
+                return INVALID_SOCKET;
             }
             
             if (setsockopt(socks_tcp_socket, SOL_SOCKET, SO_SNDTIMEO, 
                           reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms)) == SOCKET_ERROR)
             {
                 NETLIB_WARNING("Failed to set socket send timeout: {}", WSAGetLastError());
+                closesocket(socks_tcp_socket);
+                return INVALID_SOCKET;
             }
 
             if constexpr (address_type_t::af_type == AF_INET)
@@ -1322,7 +1326,7 @@ namespace proxy
             const SOCKET socks_tcp_socket,
             const address_type_t socks_server_address,
             std::unique_ptr<negotiate_context_t>&
-            negotiate_ctx) const noexcept
+            negotiate_ctx) const
         {
             using namespace std::string_literals;
 
@@ -1341,30 +1345,149 @@ namespace proxy
                 socks5_ident_req_size = sizeof(socks5_ident_req<1>);
             }
 
-            auto result = send(socks_tcp_socket, reinterpret_cast<const char*>(&ident_req),
-                static_cast<int>(socks5_ident_req_size), 0);
-            if (result == SOCKET_ERROR)
+            std::unique_ptr<schannel_tls_stream> tls_stream;
+            if (negotiate_ctx->upstream_options.is_tls())
+            {
+                tls_stream = std::make_unique<schannel_tls_stream>(
+                    socks_tcp_socket,
+                    negotiate_ctx->upstream_options.tls);
+                if (!tls_stream->handshake())
+                {
+                    NETLIB_INFO(
+                        "[SOCKS5TLS]: associate_to_socks5_proxy: TLS handshake failed: {}",
+                        tls_stream->last_error());
+                    return {};
+                }
+            }
+
+            auto control_socket_error = 0;
+            const auto send_all_raw = [socks_tcp_socket, &control_socket_error](
+                const void* const buffer, const int len) -> bool
+            {
+                control_socket_error = 0;
+                auto* bytes = static_cast<const char*>(buffer);
+                int sent_total = 0;
+                while (sent_total < len)
+                {
+                    const auto sent = send(socks_tcp_socket, bytes + sent_total, len - sent_total, 0);
+                    if (sent == SOCKET_ERROR)
+                    {
+                        control_socket_error = WSAGetLastError();
+                        return false;
+                    }
+                    if (sent == 0)
+                    {
+                        control_socket_error = WSAECONNRESET;
+                        return false;
+                    }
+                    sent_total += sent;
+                }
+                return true;
+            };
+
+            // Blocking read of exactly 'len' bytes (recv() may return short reads on a
+            // stream socket); returns false on error or premature close.
+            const auto recv_exact_raw = [&control_socket_error](
+                const SOCKET s, void* const buffer, const int len) -> bool
+            {
+                control_socket_error = 0;
+                // Bound the TOTAL time spent assembling these bytes, not just each recv().
+                // SO_RCVTIMEO is a per-call timeout, so a server that drips one byte just
+                // under it could otherwise keep this loop alive for timeout * byte-count.
+                constexpr DWORD total_timeout_ms = 5000;
+
+                DWORD original_timeout = total_timeout_ms;
+                int original_timeout_size = static_cast<int>(sizeof(original_timeout));
+                getsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                    reinterpret_cast<char*>(&original_timeout), &original_timeout_size);
+
+                const auto restore_timeout = [s, original_timeout]  // NOLINT(clang-diagnostic-padded)
+                {
+                    setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                        reinterpret_cast<const char*>(&original_timeout), sizeof(original_timeout));
+                };
+
+                auto* const bytes = static_cast<char*>(buffer);
+                const auto deadline = GetTickCount64() + total_timeout_ms;
+                int received = 0;
+                while (received < len)
+                {
+                    const auto now = GetTickCount64();
+                    if (now >= deadline)
+                    {
+                        control_socket_error = WSAETIMEDOUT;
+                        restore_timeout();
+                        return false;
+                    }
+
+                    auto remaining_ms = static_cast<DWORD>(deadline - now);
+                    if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
+                        reinterpret_cast<const char*>(&remaining_ms), sizeof(remaining_ms)) == SOCKET_ERROR)
+                    {
+                        control_socket_error = WSAGetLastError();
+                        restore_timeout();
+                        return false;
+                    }
+
+                    const auto n = recv(s, bytes + received, len - received, 0);
+                    if (n == SOCKET_ERROR)
+                    {
+                        control_socket_error = WSAGetLastError();
+                        restore_timeout();
+                        return false;
+                    }
+                    if (n == 0)
+                    {
+                        control_socket_error = WSAECONNRESET;
+                        restore_timeout();
+                        return false;
+                    }
+                    received += n;
+                }
+
+                restore_timeout();
+                return true;
+            };
+
+            const auto send_control = [&tls_stream, &send_all_raw](const void* const buffer, const int len) -> bool
+            {
+                return tls_stream ? tls_stream->send_all(buffer, len) : send_all_raw(buffer, len);
+            };
+
+            const auto recv_control = [&tls_stream, socks_tcp_socket, &recv_exact_raw](void* const buffer, const int len) -> bool
+            {
+                return tls_stream ? tls_stream->recv_exact(buffer, len) : recv_exact_raw(socks_tcp_socket, buffer, len);
+            };
+
+            const auto control_error = [&tls_stream, &control_socket_error]
+            {
+                return tls_stream
+                    ? tls_stream->last_error()
+                    : std::to_string(control_socket_error);
+            };
+
+            if (!send_control(reinterpret_cast<const char*>(&ident_req),
+                static_cast<int>(socks5_ident_req_size)))
             {
                 NETLIB_INFO(
                     "[SOCKS5]: associate_to_socks5_proxy: Failed to send socks5_ident_req: {}",
-                    WSAGetLastError());
+                    control_error());
                 return {};
             }
 
-            result = recv(socks_tcp_socket, reinterpret_cast<char*>(&ident_resp), sizeof(ident_resp), 0);
-            if (result == SOCKET_ERROR)
+            if (!recv_control(reinterpret_cast<char*>(&ident_resp), sizeof(ident_resp)))
             {
                 NETLIB_INFO(
                     "[SOCKS5]: associate_to_socks5_proxy: Failed to receive socks5_ident_resp: {}",
-                    WSAGetLastError());
+                    control_error());
                 return {};
             }
 
-            if ((ident_resp.version != 5) ||
-                (ident_resp.method == 0xFF))
+            if ((ident_resp.version != socks5_protocol_version) ||
+                (ident_resp.method != 0x00 && ident_resp.method != 0x02))
             {
                 NETLIB_INFO(
-                    "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 authentication has failed");
+                    "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 selected an unsupported authentication method");
                 return {};
             }
 
@@ -1405,27 +1528,25 @@ namespace proxy
                     negotiate_ctx->socks5_password.value()
                 );
 
-                result = send(socks_tcp_socket, reinterpret_cast<const char*>(&auth_req),
+                if (!send_control(reinterpret_cast<const char*>(&auth_req),
                     3 + static_cast<int>(negotiate_ctx->socks5_username.value().length()) + 
-                    static_cast<int>(negotiate_ctx->socks5_password.value().length()), 0);
-                if (result == SOCKET_ERROR)
+                    static_cast<int>(negotiate_ctx->socks5_password.value().length())))
                 {
                     NETLIB_INFO(
                         "[SOCKS5]: associate_to_socks5_proxy: Failed to send socks5_username_auth: {}",
-                        WSAGetLastError());
+                        control_error());
                     return {};
                 }
 
-                result = recv(socks_tcp_socket, reinterpret_cast<char*>(&ident_resp), sizeof(ident_resp), 0);
-                if (result == SOCKET_ERROR)
+                if (!recv_control(reinterpret_cast<char*>(&ident_resp), sizeof(ident_resp)))
                 {
                     NETLIB_INFO(
                         "[SOCKS5]: associate_to_socks5_proxy: Failed to receive socks5_ident_resp: {}",
-                        WSAGetLastError());
+                        control_error());
                     return {};
                 }
 
-                if (ident_resp.method != 0x0)
+                if (ident_resp.version != socks5_username_auth_version || ident_resp.method != 0x00)
                 {
                     NETLIB_INFO(
                         "[SOCKS5]: associate_to_socks5_proxy: USERNAME/PASSWORD authentication has failed!");
@@ -1466,12 +1587,11 @@ namespace proxy
                     associate_req_len = 4 + static_cast<int>(sizeof(in6_addr)) + static_cast<int>(sizeof(unsigned short));
                 }
             }
-            result = send(socks_tcp_socket, reinterpret_cast<const char*>(associate_req_buf), associate_req_len, 0);
-            if (result == SOCKET_ERROR)
+            if (!send_control(reinterpret_cast<const char*>(associate_req_buf), associate_req_len))
             {
                 NETLIB_INFO(
                     "[SOCKS5]: associate_to_socks5_proxy: Failed to send SOCKS5 ASSOCIATE request: {}",
-                    WSAGetLastError());
+                    control_error());
                 return {};
             }
 
@@ -1486,66 +1606,6 @@ namespace proxy
             // exactly the bytes implied by the returned ATYP and take BND.PORT from the
             // correct position so the relay port is family-agnostic and correct.
 
-            // Blocking read of exactly 'len' bytes (recv() may return short reads on a
-            // stream socket); returns false on error or premature close.
-            const auto recv_exact = [](const SOCKET s, void* const buffer, const int len) -> bool
-            {
-                // Bound the TOTAL time spent assembling these bytes, not just each recv().
-                // SO_RCVTIMEO is a per-call timeout, so a server that drips one byte just
-                // under it could otherwise keep this loop (and the IOCP worker that holds
-                // the server lock) alive for timeout * byte-count. Hold a single absolute
-                // deadline, shrink the receive timeout toward it on every iteration, and
-                // restore the socket's default timeout before returning.
-                constexpr DWORD total_timeout_ms = 5000;
-
-                // Save the socket's configured receive timeout and restore exactly that on
-                // every exit path, since the loop below temporarily shrinks SO_RCVTIMEO
-                // toward the deadline (leaving a tiny/stale value on the shared control
-                // socket would otherwise affect any later read on it).
-                DWORD original_timeout = total_timeout_ms;
-                int original_timeout_size = static_cast<int>(sizeof(original_timeout));
-                getsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
-                    reinterpret_cast<char*>(&original_timeout), &original_timeout_size);
-
-                const auto restore_timeout = [s, original_timeout]  // NOLINT(clang-diagnostic-padded)
-                {
-                    setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
-                        reinterpret_cast<const char*>(&original_timeout), sizeof(original_timeout));
-                };
-
-                auto* const bytes = static_cast<char*>(buffer);
-                const auto deadline = GetTickCount64() + total_timeout_ms;
-                int received = 0;
-                while (received < len)
-                {
-                    const auto now = GetTickCount64();
-                    if (now >= deadline)
-                    {
-                        restore_timeout();
-                        return false;
-                    }
-
-                    auto remaining_ms = static_cast<DWORD>(deadline - now);
-                    if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO,
-                        reinterpret_cast<const char*>(&remaining_ms), sizeof(remaining_ms)) == SOCKET_ERROR)
-                    {
-                        restore_timeout();
-                        return false;
-                    }
-
-                    const auto n = recv(s, bytes + received, len - received, 0);
-                    if (n == SOCKET_ERROR || n == 0)
-                    {
-                        restore_timeout();
-                        return false;
-                    }
-                    received += n;
-                }
-
-                restore_timeout();
-                return true;
-            };
-
             // Fixed 4-byte reply prefix: VER, REP, RSV, ATYP.
             struct socks5_resp_prefix
             {
@@ -1555,15 +1615,17 @@ namespace proxy
                 unsigned char address_type;
             } resp_prefix{};
 
-            if (!recv_exact(socks_tcp_socket, &resp_prefix, sizeof(resp_prefix)))
+            if (!recv_control(&resp_prefix, sizeof(resp_prefix)))
             {
                 NETLIB_INFO(
-                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive SOCKS5 ASSOCIATE reply header");
+                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive SOCKS5 ASSOCIATE reply header: {}",
+                    control_error());
                 return {};
             }
 
-            if ((resp_prefix.version != 5) ||
-                (resp_prefix.reply != 0))
+            if ((resp_prefix.version != socks5_protocol_version) ||
+                (resp_prefix.reply != 0) ||
+                (resp_prefix.reserved != 0))
             {
                 NETLIB_INFO(
                     "[SOCKS5]: associate_to_socks5_proxy: SOCKS5 ASSOCIATE has failed");
@@ -1584,10 +1646,17 @@ namespace proxy
             case 3: // domain name
                 {
                     unsigned char domain_len = 0;
-                    if (!recv_exact(socks_tcp_socket, &domain_len, sizeof(domain_len)))
+                    if (!recv_control(&domain_len, sizeof(domain_len)))
                     {
                         NETLIB_INFO(
-                            "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR domain length");
+                            "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR domain length: {}",
+                            control_error());
+                        return {};
+                    }
+                    if (domain_len == 0)
+                    {
+                        NETLIB_INFO(
+                            "[SOCKS5]: associate_to_socks5_proxy: Empty BND.ADDR domain in ASSOCIATE reply");
                         return {};
                     }
                     bnd_addr_len = domain_len;
@@ -1603,11 +1672,12 @@ namespace proxy
             // Read BND.ADDR followed by the 2-byte BND.PORT. The buffer is sized for the
             // largest possible BND.ADDR (a 255-byte domain) plus the port.
             unsigned char bnd_addr_and_port[255 + sizeof(unsigned short)]{};
-            if (!recv_exact(socks_tcp_socket, bnd_addr_and_port,
+            if (!recv_control(bnd_addr_and_port,
                 bnd_addr_len + static_cast<int>(sizeof(unsigned short))))
             {
                 NETLIB_INFO(
-                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR/BND.PORT");
+                    "[SOCKS5]: associate_to_socks5_proxy: Failed to receive BND.ADDR/BND.PORT: {}",
+                    control_error());
                 return {};
             }
 
@@ -1711,7 +1781,17 @@ namespace proxy
                 return false;
             }
 
-            auto udp_endpoint = associate_to_socks5_proxy(socks5_tcp_socket, remote_address, negotiate_ctx);
+            std::optional<net::ip_endpoint<address_type_t>> udp_endpoint;
+            try
+            {
+                udp_endpoint = associate_to_socks5_proxy(socks5_tcp_socket, remote_address, negotiate_ctx);
+            }
+            catch (...)
+            {
+                closesocket(socks5_tcp_socket);
+                lock.lock();
+                throw;
+            }
             if (!udp_endpoint.has_value())
             {
                 NETLIB_DEBUG(

--- a/netlib/src/proxy/socks5_tcp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_tcp_proxy_socket.h
@@ -114,6 +114,230 @@ namespace proxy
         }
 
         /**
+         * @brief Starts plain SOCKS5 negotiation or the native SOCKS5-over-TLS path.
+         */
+        bool start() override
+        {
+            auto* const negotiate_context_ptr = dynamic_cast<negotiate_context_t*>(
+                tcp_proxy_socket<T>::negotiate_ctx_.get());
+            if (negotiate_context_ptr == nullptr || !negotiate_context_ptr->upstream_options.is_tls())
+            {
+                return tcp_proxy_socket<T>::start();
+            }
+
+            return start_tls_transport(*negotiate_context_ptr);
+        }
+
+        void process_receive_buffer_complete(const uint32_t io_size, per_io_context_t* io_context) override
+        {
+            if (!tls_relay_active_.load(std::memory_order_acquire))
+            {
+                tcp_proxy_socket<T>::process_receive_buffer_complete(io_size, io_context);
+                return;
+            }
+
+            NETLIB_DEBUG(
+                "SOCKS5Tls relay received {} bytes from the {} socket",
+                io_size,
+                io_context->is_local ? "local" : "upstream");
+
+            std::scoped_lock lock(tcp_proxy_socket<T>::lock_);
+            tcp_proxy_socket<T>::timestamp_ = std::chrono::steady_clock::now();
+
+            if (tcp_proxy_socket<T>::connection_status_ == connection_status::client_completed)
+            {
+                if (io_context->is_local)
+                {
+                    tcp_proxy_socket<T>::local_recv_buf_.len = 0;
+                }
+                else
+                {
+                    tcp_proxy_socket<T>::remote_recv_buf_.len = 0;
+                }
+                return;
+            }
+
+            if (io_context->is_local)
+            {
+                tcp_proxy_socket<T>::local_recv_buf_.len = 0;
+                if (tcp_proxy_socket<T>::remote_send_buf_.len != 0)
+                {
+                    NETLIB_ERROR("SOCKS5Tls relay invariant failed: overlapping sends to the upstream proxy");
+                    tcp_proxy_socket<T>::close_client<true>(true, true);
+                    return;
+                }
+
+                if (!tls_stream_->encrypt(
+                    tcp_proxy_socket<T>::from_local_to_remote_buffer_.data(),
+                    io_size,
+                    tls_encrypted_send_buffer_))
+                {
+                    NETLIB_WARNING("SOCKS5Tls relay encryption failed: {}", tls_stream_->last_error());
+                    tcp_proxy_socket<T>::close_client<true>(true, true);
+                    return;
+                }
+
+                if (!post_tls_remote_send_locked())
+                {
+                    tcp_proxy_socket<T>::close_client<true>(false, false);
+                }
+                return;
+            }
+
+            tcp_proxy_socket<T>::remote_recv_buf_.len = 0;
+            if (tcp_proxy_socket<T>::local_send_buf_.len != 0)
+            {
+                NETLIB_ERROR("SOCKS5Tls relay invariant failed: overlapping sends to the local client");
+                tcp_proxy_socket<T>::close_client<true>(true, false);
+                return;
+            }
+
+            const auto decrypt_result = tls_stream_->decrypt_available(
+                tcp_proxy_socket<T>::from_remote_to_local_buffer_.data(),
+                io_size,
+                tls_plaintext_send_buffer_);
+            if (decrypt_result == schannel_tls_stream::decrypt_status::failed)
+            {
+                NETLIB_WARNING("SOCKS5Tls relay decryption failed: {}", tls_stream_->last_error());
+                tcp_proxy_socket<T>::close_client<true>(true, false);
+                return;
+            }
+
+            if (decrypt_result == schannel_tls_stream::decrypt_status::closed)
+            {
+                tls_remote_closed_ = true;
+                tcp_proxy_socket<T>::connection_status_ = connection_status::client_completed;
+            }
+
+            if (!tls_plaintext_send_buffer_.empty())
+            {
+                if (!post_tls_local_send_locked())
+                {
+                    tcp_proxy_socket<T>::close_client<true>(false, true);
+                }
+                return;
+            }
+
+            if (tls_remote_closed_)
+            {
+                close_tls_after_drain_locked();
+                return;
+            }
+
+            if (!post_tls_remote_receive_locked())
+            {
+                tcp_proxy_socket<T>::close_client<true>(true, false);
+            }
+        }
+
+        void process_send_buffer_complete(const uint32_t io_size, per_io_context_t* io_context) override
+        {
+            if (!tls_relay_active_.load(std::memory_order_acquire))
+            {
+                tcp_proxy_socket<T>::process_send_buffer_complete(io_size, io_context);
+                return;
+            }
+
+            NETLIB_DEBUG(
+                "SOCKS5Tls relay sent {} bytes to the {} socket",
+                io_size,
+                io_context->is_local ? "local" : "upstream");
+
+            std::scoped_lock lock(tcp_proxy_socket<T>::lock_);
+            tcp_proxy_socket<T>::timestamp_ = std::chrono::steady_clock::now();
+
+            auto& send_buffer = io_context->is_local
+                ? tcp_proxy_socket<T>::local_send_buf_
+                : tcp_proxy_socket<T>::remote_send_buf_;
+            if (io_size == 0 || io_size > send_buffer.len)
+            {
+                NETLIB_WARNING(
+                    "SOCKS5Tls relay received an invalid send completion ({} of {} bytes)",
+                    io_size,
+                    send_buffer.len);
+                tcp_proxy_socket<T>::close_client<true>(false, io_context->is_local);
+                return;
+            }
+
+            send_buffer.buf += io_size;
+            send_buffer.len -= io_size;
+            if (send_buffer.len != 0)
+            {
+                reset_overlapped(io_context->is_local
+                    ? tcp_proxy_socket<T>::io_context_send_to_local_
+                    : tcp_proxy_socket<T>::io_context_send_to_remote_);
+                const auto socket = io_context->is_local
+                    ? tcp_proxy_socket<T>::local_socket_
+                    : tcp_proxy_socket<T>::remote_socket_;
+                if (this->post_send(socket, &send_buffer, io_context) == SOCKET_ERROR)
+                {
+                    tcp_proxy_socket<T>::close_client<true>(false, io_context->is_local);
+                }
+                return;
+            }
+
+            send_buffer.buf = nullptr;
+            if (io_context->is_local)
+            {
+                tls_plaintext_send_buffer_.clear();
+            }
+            else
+            {
+                tls_encrypted_send_buffer_.clear();
+            }
+
+            if (tcp_proxy_socket<T>::connection_status_ == connection_status::client_completed)
+            {
+                close_tls_after_drain_locked();
+                return;
+            }
+
+            const auto receive_posted = io_context->is_local
+                ? post_tls_remote_receive_locked()
+                : post_tls_local_receive_locked();
+            if (!receive_posted)
+            {
+                tcp_proxy_socket<T>::close_client<true>(true, !io_context->is_local);
+            }
+        }
+
+        void on_peer_read_shutdown(const bool is_local) override
+        {
+            if (!tls_relay_active_.load(std::memory_order_acquire))
+            {
+                tcp_proxy_socket<T>::on_peer_read_shutdown(is_local);
+                return;
+            }
+
+            std::scoped_lock lock(tcp_proxy_socket<T>::lock_);
+            if (tcp_proxy_socket<T>::connection_status_ == connection_status::client_completed)
+            {
+                return;
+            }
+
+            tcp_proxy_socket<T>::timestamp_ = std::chrono::steady_clock::now();
+            tcp_proxy_socket<T>::connection_status_ = connection_status::client_completed;
+            if (is_local)
+            {
+                tcp_proxy_socket<T>::local_recv_buf_.len = 0;
+            }
+            else
+            {
+                tcp_proxy_socket<T>::remote_recv_buf_.len = 0;
+            }
+
+            const auto socket = is_local
+                ? tcp_proxy_socket<T>::local_socket_
+                : tcp_proxy_socket<T>::remote_socket_;
+            if (socket != static_cast<SOCKET>(INVALID_SOCKET) && shutdown(socket, SD_RECEIVE) == SOCKET_ERROR)
+            {
+                NETLIB_DEBUG("SOCKS5Tls relay shutdown(SD_RECEIVE) failed: {}", WSAGetLastError());
+            }
+
+            close_tls_after_drain_locked();
+        }
+
+        /**
          * @brief Handles completion of a SOCKS5 negotiation receive operation.
          *
          * This method is invoked when a negotiation-related receive operation completes on the remote socket.
@@ -160,8 +384,8 @@ namespace proxy
 
                     current_state_ = socks5_state::login_responded;
 
-                    if ((ident_resp_.version != 5) ||
-                        (ident_resp_.method == 0xFF))
+                    if ((ident_resp_.version != socks5_protocol_version) ||
+                        (ident_resp_.method != 0x00 && ident_resp_.method != 0x02))
                     {
                         // SOCKS v5 identification or authentication failed
                         tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
@@ -239,7 +463,7 @@ namespace proxy
 
                     current_state_ = socks5_state::password_responded;
 
-                    if (ident_resp_.method != 0)
+                    if (ident_resp_.version != socks5_username_auth_version || ident_resp_.method != 0)
                     {
                         // SOCKS v5 identification or authentication failed
                         tcp_proxy_socket<T>::close_client<true>(true, false);  // NOLINT(bugprone-chained-comparison)
@@ -257,6 +481,7 @@ namespace proxy
                     }
 
                     if ((connect_response_header_.version != socks5_protocol_version) ||
+                        (connect_response_header_.reserved != 0) ||
                         (connect_response_header_.reply != 0))
                     {
                         // SOCKS v5 connect failed
@@ -309,6 +534,11 @@ namespace proxy
                     }
 
                     const auto domain_length = connect_response_tail_[0];
+                    if (domain_length == 0)
+                    {
+                        tcp_proxy_socket<T>::close_client<true>(true, false);
+                        return;
+                    }
                     if (!start_connect_reply_receive(
                         socks5_state::connect_reply_tail,
                         connect_response_tail_.data() + 1,
@@ -335,6 +565,60 @@ namespace proxy
         }
 
     private:
+        class socket_send_timeout_guard
+        {
+        public:
+            explicit socket_send_timeout_guard(const SOCKET socket) noexcept
+                : socket_(socket)
+            {
+                int option_size = static_cast<int>(sizeof(original_timeout_));
+                if (getsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO,
+                    reinterpret_cast<char*>(&original_timeout_), &option_size) == SOCKET_ERROR)
+                {
+                    error_ = WSAGetLastError();
+                    return;
+                }
+
+                constexpr DWORD timeout_ms = 5000;
+                if (setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO,
+                    reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms)) == SOCKET_ERROR)
+                {
+                    error_ = WSAGetLastError();
+                    return;
+                }
+
+                configured_ = true;
+            }
+
+            socket_send_timeout_guard(const socket_send_timeout_guard&) = delete;
+            socket_send_timeout_guard& operator=(const socket_send_timeout_guard&) = delete;
+
+            ~socket_send_timeout_guard()
+            {
+                if (configured_)
+                {
+                    setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO,
+                        reinterpret_cast<const char*>(&original_timeout_), sizeof(original_timeout_));
+                }
+            }
+
+            [[nodiscard]] bool configured() const noexcept
+            {
+                return configured_;
+            }
+
+            [[nodiscard]] int error() const noexcept
+            {
+                return error_;
+            }
+
+        private:
+            SOCKET socket_{ INVALID_SOCKET };
+            DWORD original_timeout_ = 0;
+            int error_ = 0;
+            bool configured_ = false;
+        };
+
         struct socks5_resp_header
         {
             unsigned char version = socks5_protocol_version;
@@ -342,6 +626,382 @@ namespace proxy
             unsigned char reserved{};
             unsigned char address_type{};
         };
+
+        [[nodiscard]] bool start_tls_transport(negotiate_context_t& negotiate_context)
+        {
+            if (tcp_proxy_socket<T>::is_disable_nagle_)
+            {
+                const int enabled = 1;
+                if (setsockopt(tcp_proxy_socket<T>::remote_socket_, IPPROTO_TCP, TCP_NODELAY,
+                    reinterpret_cast<const char*>(&enabled), sizeof(enabled)) == SOCKET_ERROR)
+                {
+                    NETLIB_WARNING("SOCKS5Tls failed to set TCP_NODELAY: {}", WSAGetLastError());
+                }
+            }
+
+            // WSAEventSelect makes the connect socket non-blocking. TLS setup is deliberately
+            // synchronous and bounded, after which the socket returns to overlapped IOCP I/O.
+            if (WSAEventSelect(tcp_proxy_socket<T>::remote_socket_, nullptr, 0) == SOCKET_ERROR)
+            {
+                NETLIB_WARNING("SOCKS5Tls failed to detach the connect event: {}", WSAGetLastError());
+                tcp_proxy_socket<T>::close_client(false, false);
+                return false;
+            }
+
+            u_long blocking_mode = 0;
+            if (ioctlsocket(tcp_proxy_socket<T>::remote_socket_, FIONBIO, &blocking_mode) == SOCKET_ERROR)
+            {
+                NETLIB_WARNING("SOCKS5Tls failed to restore blocking setup mode: {}", WSAGetLastError());
+                tcp_proxy_socket<T>::close_client(false, false);
+                return false;
+            }
+
+            socket_send_timeout_guard send_timeout{ tcp_proxy_socket<T>::remote_socket_ };
+            if (!send_timeout.configured())
+            {
+                NETLIB_WARNING("SOCKS5Tls failed to configure the setup send timeout: {}", send_timeout.error());
+                tcp_proxy_socket<T>::close_client(false, false);
+                return false;
+            }
+
+            tls_stream_ = std::make_unique<schannel_tls_stream>(
+                tcp_proxy_socket<T>::remote_socket_,
+                negotiate_context.upstream_options.tls);
+            if (!tls_stream_->handshake())
+            {
+                NETLIB_WARNING("SOCKS5Tls handshake failed: {}", tls_stream_->last_error());
+                tcp_proxy_socket<T>::close_client(false, false);
+                return false;
+            }
+
+            if (!perform_tls_socks5_connect(negotiate_context))
+            {
+                NETLIB_WARNING("SOCKS5Tls CONNECT negotiation failed: {}", tls_negotiation_error_);
+                tcp_proxy_socket<T>::close_client(false, false);
+                return false;
+            }
+
+            return start_tls_data_relay();
+        }
+
+        [[nodiscard]] bool perform_tls_socks5_connect(const negotiate_context_t& negotiate_context)
+        {
+            const auto fail = [this](std::string error)
+            {
+                tls_negotiation_error_ = std::move(error);
+                return false;
+            };
+            const auto send_tls = [this, &fail](const void* const data, const int length)
+            {
+                return tls_stream_->send_all(data, length)
+                    ? true
+                    : fail(tls_stream_->last_error());
+            };
+            const auto recv_tls = [this, &fail](void* const data, const int length)
+            {
+                return tls_stream_->recv_exact(data, length)
+                    ? true
+                    : fail(tls_stream_->last_error());
+            };
+
+            const auto has_username = negotiate_context.socks5_username.has_value();
+            const auto has_password = negotiate_context.socks5_password.has_value();
+            if (has_username != has_password)
+            {
+                return fail("SOCKS5 username and password must be configured together.");
+            }
+            if (has_username && (negotiate_context.socks5_username->empty() ||
+                negotiate_context.socks5_username->size() > socks5_username_max_length ||
+                negotiate_context.socks5_password->empty() ||
+                negotiate_context.socks5_password->size() > socks5_username_max_length))
+            {
+                return fail("SOCKS5 username and password must each contain between 1 and 255 bytes.");
+            }
+
+            socks5_ident_req<2> ident_request{};
+            ident_request.methods[0] = 0x00;
+            auto ident_request_size = sizeof(socks5_ident_req<1>);
+            if (has_username)
+            {
+                ident_request.number_of_methods = 2;
+                ident_request.methods[1] = 0x02;
+                ident_request_size = sizeof(ident_request);
+            }
+            else
+            {
+                ident_request.number_of_methods = 1;
+            }
+
+            socks5_ident_resp ident_response{};
+            if (!send_tls(&ident_request, static_cast<int>(ident_request_size)) ||
+                !recv_tls(&ident_response, sizeof(ident_response)))
+            {
+                return false;
+            }
+            if (ident_response.version != socks5_protocol_version)
+            {
+                return fail("The upstream returned an invalid SOCKS5 method-selection version.");
+            }
+            if (ident_response.method != 0x00 && ident_response.method != 0x02)
+            {
+                return fail("The upstream selected an unsupported SOCKS5 authentication method.");
+            }
+
+            if (ident_response.method == 0x02)
+            {
+                if (!has_username)
+                {
+                    return fail("The upstream requires SOCKS5 username/password authentication.");
+                }
+
+                socks5_username_auth username_auth{};
+                const auto auth_size = username_auth.init(
+                    *negotiate_context.socks5_username,
+                    *negotiate_context.socks5_password);
+                socks5_ident_resp auth_response{};
+                if (auth_size == 0 ||
+                    !send_tls(&username_auth, static_cast<int>(auth_size)) ||
+                    !recv_tls(&auth_response, sizeof(auth_response)))
+                {
+                    return false;
+                }
+                if (auth_response.version != socks5_username_auth_version || auth_response.method != 0)
+                {
+                    return fail("The upstream rejected SOCKS5 username/password authentication.");
+                }
+            }
+
+            socks5_req<address_type_t> connect_request{
+                socks5_protocol_version,
+                1,
+                0,
+                address_type_t::af_type == AF_INET ? static_cast<unsigned char>(1) : static_cast<unsigned char>(4),
+                negotiate_context.remote_address,
+                htons(negotiate_context.remote_port)
+            };
+
+            socks5_resp_header response_header{};
+            if (!send_tls(&connect_request, sizeof(connect_request)) ||
+                !recv_tls(&response_header, sizeof(response_header)))
+            {
+                return false;
+            }
+            if (response_header.version != socks5_protocol_version || response_header.reserved != 0)
+            {
+                return fail("The upstream returned an invalid SOCKS5 CONNECT response header.");
+            }
+            if (response_header.reply != 0)
+            {
+                return fail("The upstream rejected SOCKS5 CONNECT with reply code " +
+                    std::to_string(response_header.reply) + ".");
+            }
+
+            std::array<unsigned char, socks5_username_max_length + sizeof(unsigned short)> response_tail{};
+            switch (response_header.address_type)
+            {
+            case 1:
+                return recv_tls(response_tail.data(), 4 + sizeof(unsigned short));
+            case 4:
+                return recv_tls(response_tail.data(), 16 + sizeof(unsigned short));
+            case 3:
+            {
+                unsigned char domain_length = 0;
+                if (!recv_tls(&domain_length, sizeof(domain_length)))
+                {
+                    return false;
+                }
+                if (domain_length == 0)
+                {
+                    return fail("The upstream returned an empty SOCKS5 bound domain name.");
+                }
+                return recv_tls(
+                    response_tail.data(),
+                    static_cast<int>(domain_length + sizeof(unsigned short)));
+            }
+            default:
+                return fail("The upstream returned an unsupported SOCKS5 bound address type.");
+            }
+        }
+
+        [[nodiscard]] bool start_tls_data_relay()
+        {
+            std::scoped_lock lock(tcp_proxy_socket<T>::lock_);
+            tls_relay_active_.store(true, std::memory_order_release);
+
+            const auto decrypt_result = tls_stream_->decrypt_available(
+                nullptr,
+                0,
+                tls_plaintext_send_buffer_);
+            if (decrypt_result == schannel_tls_stream::decrypt_status::failed)
+            {
+                NETLIB_WARNING("SOCKS5Tls failed to process buffered data: {}", tls_stream_->last_error());
+                tcp_proxy_socket<T>::close_client<true>(true, false);
+                return false;
+            }
+            if (decrypt_result == schannel_tls_stream::decrypt_status::closed)
+            {
+                tls_remote_closed_ = true;
+                tcp_proxy_socket<T>::connection_status_ = connection_status::client_completed;
+            }
+
+            if (tcp_proxy_socket<T>::connection_status_ != connection_status::client_completed &&
+                !post_tls_local_receive_locked())
+            {
+                tcp_proxy_socket<T>::close_client<true>(true, true);
+                return false;
+            }
+
+            if (!tls_plaintext_send_buffer_.empty())
+            {
+                NETLIB_DEBUG(
+                    "SOCKS5Tls relay has {} bytes of setup read-ahead",
+                    tls_plaintext_send_buffer_.size());
+                if (!post_tls_local_send_locked())
+                {
+                    tcp_proxy_socket<T>::close_client<true>(false, true);
+                    return false;
+                }
+                return true;
+            }
+
+            if (tls_remote_closed_)
+            {
+                close_tls_after_drain_locked();
+                return false;
+            }
+
+            if (!post_tls_remote_receive_locked())
+            {
+                tcp_proxy_socket<T>::close_client<true>(true, false);
+                return false;
+            }
+
+            NETLIB_INFO("SOCKS5Tls TCP CONNECT relay established");
+            return true;
+        }
+
+        [[nodiscard]] bool post_tls_local_receive_locked()
+        {
+            reset_overlapped(tcp_proxy_socket<T>::io_context_recv_from_local_);
+            tcp_proxy_socket<T>::local_recv_buf_.buf =
+                tcp_proxy_socket<T>::from_local_to_remote_buffer_.data();
+            tcp_proxy_socket<T>::local_recv_buf_.len = static_cast<ULONG>(
+                tcp_proxy_socket<T>::from_local_to_remote_buffer_.size());
+            if (this->post_recv(
+                tcp_proxy_socket<T>::local_socket_,
+                &this->local_recv_buf_,
+                &this->io_context_recv_from_local_) == SOCKET_ERROR)
+            {
+                tcp_proxy_socket<T>::local_recv_buf_.len = 0;
+                NETLIB_WARNING("SOCKS5Tls failed to post a local receive: {}", WSAGetLastError());
+                return false;
+            }
+            NETLIB_DEBUG("SOCKS5Tls relay posted a local receive");
+            return true;
+        }
+
+        [[nodiscard]] bool post_tls_remote_receive_locked()
+        {
+            reset_overlapped(tcp_proxy_socket<T>::io_context_recv_from_remote_);
+            tcp_proxy_socket<T>::remote_recv_buf_.buf =
+                tcp_proxy_socket<T>::from_remote_to_local_buffer_.data();
+            tcp_proxy_socket<T>::remote_recv_buf_.len = static_cast<ULONG>(
+                tcp_proxy_socket<T>::from_remote_to_local_buffer_.size());
+            if (this->post_recv(
+                tcp_proxy_socket<T>::remote_socket_,
+                &this->remote_recv_buf_,
+                &this->io_context_recv_from_remote_) == SOCKET_ERROR)
+            {
+                tcp_proxy_socket<T>::remote_recv_buf_.len = 0;
+                NETLIB_WARNING("SOCKS5Tls failed to post an upstream receive: {}", WSAGetLastError());
+                return false;
+            }
+            NETLIB_DEBUG("SOCKS5Tls relay posted an upstream receive");
+            return true;
+        }
+
+        [[nodiscard]] bool post_tls_local_send_locked()
+        {
+            if (tls_plaintext_send_buffer_.empty())
+            {
+                return false;
+            }
+
+            reset_overlapped(tcp_proxy_socket<T>::io_context_send_to_local_);
+            tcp_proxy_socket<T>::local_send_buf_.buf = tls_plaintext_send_buffer_.data();
+            tcp_proxy_socket<T>::local_send_buf_.len = static_cast<ULONG>(tls_plaintext_send_buffer_.size());
+            if (this->post_send(
+                tcp_proxy_socket<T>::local_socket_,
+                &this->local_send_buf_,
+                &this->io_context_send_to_local_) == SOCKET_ERROR)
+            {
+                tcp_proxy_socket<T>::local_send_buf_.len = 0;
+                NETLIB_WARNING("SOCKS5Tls failed to post a local send: {}", WSAGetLastError());
+                return false;
+            }
+            NETLIB_DEBUG(
+                "SOCKS5Tls relay posted {} plaintext bytes to the local socket",
+                tcp_proxy_socket<T>::local_send_buf_.len);
+            return true;
+        }
+
+        [[nodiscard]] bool post_tls_remote_send_locked()
+        {
+            if (tls_encrypted_send_buffer_.empty())
+            {
+                return false;
+            }
+
+            reset_overlapped(tcp_proxy_socket<T>::io_context_send_to_remote_);
+            tcp_proxy_socket<T>::remote_send_buf_.buf = tls_encrypted_send_buffer_.data();
+            tcp_proxy_socket<T>::remote_send_buf_.len = static_cast<ULONG>(tls_encrypted_send_buffer_.size());
+            if (this->post_send(
+                tcp_proxy_socket<T>::remote_socket_,
+                &this->remote_send_buf_,
+                &this->io_context_send_to_remote_) == SOCKET_ERROR)
+            {
+                tcp_proxy_socket<T>::remote_send_buf_.len = 0;
+                NETLIB_WARNING("SOCKS5Tls failed to post an upstream send: {}", WSAGetLastError());
+                return false;
+            }
+            NETLIB_DEBUG(
+                "SOCKS5Tls relay posted {} encrypted bytes to the upstream socket",
+                tcp_proxy_socket<T>::remote_send_buf_.len);
+            return true;
+        }
+
+        void close_tls_after_drain_locked()
+        {
+            if (tcp_proxy_socket<T>::local_send_buf_.len != 0 ||
+                tcp_proxy_socket<T>::remote_send_buf_.len != 0)
+            {
+                return;
+            }
+
+            if (!tls_shutdown_started_ &&
+                tcp_proxy_socket<T>::remote_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
+            {
+                tls_shutdown_started_ = true;
+                std::vector<char> shutdown_token;
+                if (tls_stream_->create_shutdown_token(shutdown_token))
+                {
+                    tls_encrypted_send_buffer_ = std::move(shutdown_token);
+                    if (post_tls_remote_send_locked())
+                    {
+                        return;
+                    }
+                    NETLIB_WARNING("SOCKS5Tls failed to send close_notify: {}", WSAGetLastError());
+                }
+                else
+                {
+                    NETLIB_WARNING("SOCKS5Tls failed to create close_notify: {}", tls_stream_->last_error());
+                }
+            }
+
+            tcp_proxy_socket<T>::local_recv_buf_.len = 0;
+            tcp_proxy_socket<T>::remote_recv_buf_.len = 0;
+            tcp_proxy_socket<T>::close_client<true>(true, true);
+        }
 
         static void reset_overlapped(per_io_context_t& io_context) noexcept
         {
@@ -480,6 +1140,13 @@ namespace proxy
         socks5_resp_header connect_response_header_{};
         socks5_username_auth username_auth_{};
         std::array<unsigned char, 1 + socks5_username_max_length + sizeof(unsigned short)> connect_response_tail_{};
+        std::unique_ptr<schannel_tls_stream> tls_stream_;
+        std::vector<char> tls_encrypted_send_buffer_;
+        std::vector<char> tls_plaintext_send_buffer_;
+        std::string tls_negotiation_error_;
+        std::atomic_bool tls_relay_active_{ false };
+        bool tls_remote_closed_ = false;
+        bool tls_shutdown_started_ = false;
 
     protected:
         /**

--- a/netlib/src/proxy/socks5_udp_proxy_socket.h
+++ b/netlib/src/proxy/socks5_udp_proxy_socket.h
@@ -146,6 +146,10 @@ namespace proxy
         /// </summary>
         SOCKET socks_socket_;
 
+        /// Serializes control-socket polling with teardown. The UDP relay does not otherwise read
+        /// this socket after negotiation, so the maintenance thread polls it for peer closure.
+        mutable std::mutex socks_socket_lock_;
+
         /// <summary>
         /// Shared pointer to the packet pool for efficient allocation and reuse of network packet buffers.
         /// </summary>
@@ -213,6 +217,53 @@ namespace proxy
         /// reference our io_context member" guarantee rather than a wall-clock grace.
         /// </summary>
         std::atomic<long> outstanding_io_{ 0 };
+
+        /**
+         * @brief Checks whether the SOCKS5 UDP control connection was closed by the proxy.
+         *
+         * A SOCKS5 UDP association lasts only as long as its TCP control connection. After the
+         * ASSOCIATE reply no further application data is expected on that connection, so either
+         * readable data (for example, an encrypted TLS close_notify) or EOF means the cached UDP
+         * relay must be retired. The zero-timeout select keeps the maintenance scan non-blocking.
+         */
+        [[nodiscard]] bool is_control_channel_closed() const noexcept
+        {
+            std::scoped_lock lock(socks_socket_lock_);
+            if (socks_socket_ == static_cast<SOCKET>(INVALID_SOCKET))
+                return true;
+
+            fd_set read_set;
+            FD_ZERO(&read_set);
+            FD_SET(socks_socket_, &read_set);
+            timeval timeout{};
+
+            const auto select_result = select(0, &read_set, nullptr, nullptr, &timeout);
+            if (select_result == 0)
+                return false;
+            if (select_result == SOCKET_ERROR)
+                return WSAGetLastError() != WSAEINTR;
+
+            char pending_byte{};
+            const auto recv_result = recv(socks_socket_, &pending_byte, 1, MSG_PEEK);
+            if (recv_result == SOCKET_ERROR)
+            {
+                const auto error = WSAGetLastError();
+                return error != WSAEWOULDBLOCK && error != WSAEINTR;
+            }
+
+            return true;
+        }
+
+        void close_control_channel() noexcept
+        {
+            std::scoped_lock lock(socks_socket_lock_);
+            if (socks_socket_ == static_cast<SOCKET>(INVALID_SOCKET))
+                return;
+
+            CancelIoEx(reinterpret_cast<HANDLE>(socks_socket_), nullptr);  // NOLINT(performance-no-int-to-ptr)
+            closesocket(socks_socket_);
+            socks_socket_ = INVALID_SOCKET;
+        }
 
     public:
         /**
@@ -283,13 +334,7 @@ namespace proxy
                 remote_socket_ = INVALID_SOCKET;
             }
 
-            if (socks_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
-            {
-                // Cancel all pending I/O operations on the SOCKS TCP socket before closing
-                CancelIoEx(reinterpret_cast<HANDLE>(socks_socket_), nullptr);  // NOLINT(performance-no-int-to-ptr)
-                closesocket(socks_socket_);
-                socks_socket_ = INVALID_SOCKET;
-            }
+            close_control_channel();
         }
 
         /**
@@ -389,12 +434,7 @@ namespace proxy
                 closesocket(remote_socket_);
                 remote_socket_ = INVALID_SOCKET;
             }
-            if (socks_socket_ != static_cast<SOCKET>(INVALID_SOCKET))
-            {
-                CancelIoEx(reinterpret_cast<HANDLE>(socks_socket_), nullptr);  // NOLINT(performance-no-int-to-ptr)
-                closesocket(socks_socket_);
-                socks_socket_ = INVALID_SOCKET;
-            }
+            close_control_channel();
             ready_for_removal_.store(true);
         }
 
@@ -461,8 +501,9 @@ namespace proxy
         /**
          * @brief Checks if the proxy socket is ready to be removed.
          *
-         * The socket is considered ready for removal if it has been marked as such,
-         * or if no packets have been processed for more than 5 minutes.
+         * The socket is considered ready for removal if it has been marked as such, if the SOCKS5
+         * TCP control connection has closed, or if no packets have been processed for more than
+         * 5 minutes.
          *
          * @return True if the socket should be removed, false otherwise.
          */
@@ -470,8 +511,17 @@ namespace proxy
         {
             using namespace std::chrono_literals;
 
-            if (!ready_for_removal_.load() && (std::chrono::steady_clock::now() - timestamp_ <= 5min))
+            const auto explicitly_closed = ready_for_removal_.load();
+            const auto control_channel_closed = !explicitly_closed && is_control_channel_closed();
+            if (!explicitly_closed && !control_channel_closed &&
+                (std::chrono::steady_clock::now() - timestamp_ <= 5min))
                 return false;
+
+            if (control_channel_closed)
+            {
+                NETLIB_DEBUG("SOCKS5 UDP control channel closed for relay {}:{}; retiring association",
+                    remote_peer_address_, remote_peer_port_);
+            }
 
             // Ready (explicit close or idle timeout). Break the per-I/O self-reference cycle so
             // the destructor can run, but only after a one-cycle grace. First pass: close the

--- a/netlib/src/proxy/socks_local_router.h
+++ b/netlib/src/proxy/socks_local_router.h
@@ -68,6 +68,7 @@ namespace proxy
         {
             std::optional<net::ip_endpoint<net::ip_address_v4>> ipv4;
             std::optional<net::ip_endpoint<net::ip_address_v6>> ipv6;
+            std::string host;
         };
 
     private:
@@ -1095,7 +1096,8 @@ namespace proxy
                   std::unique_ptr<socks5_local_udp_proxy_server<socks5_udp_proxy_socket<AddrT>>>>
         build_proxy_pair(const net::ip_endpoint<AddrT>& upstream,
                          const supported_protocols protocols,
-                         const std::optional<std::pair<std::string, std::string>>& cred_pair)
+                         const std::optional<std::pair<std::string, std::string>>& cred_pair,
+                         socks5_upstream_options upstream_options)
         {
             using tcp_server_t = tcp_proxy_server<socks5_tcp_proxy_socket<AddrT>>;
             using udp_server_t = socks5_local_udp_proxy_server<socks5_udp_proxy_socket<AddrT>>;
@@ -1105,7 +1107,7 @@ namespace proxy
             auto tcp_server = (protocols == both || protocols == tcp)
                 ? std::make_unique<tcp_server_t>(
                     0, io_port_,
-                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
+                    [this, upstream, cred_pair, upstream_options](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
                         -> std::tuple<AddrT, uint16_t, std::unique_ptr<tcp_negotiate_t>>
                     {
                         auto& mapper = tcp_mapper_for<AddrT>();
@@ -1140,7 +1142,8 @@ namespace proxy
                                 std::make_unique<tcp_negotiate_t>(
                                     remote_address, remote_port,
                                     cred_pair ? std::optional(cred_pair.value().first) : std::nullopt,
-                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt));
+                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt,
+                                    upstream_options));
                         }
 
                         return std::make_tuple(AddrT{}, 0, nullptr);
@@ -1150,7 +1153,7 @@ namespace proxy
             auto udp_server = (protocols == both || protocols == udp)
                 ? std::make_unique<udp_server_t>(
                     0, io_port_,
-                    [this, upstream, cred_pair](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
+                    [this, upstream, cred_pair, upstream_options](const AddrT address, const uint16_t port)  // NOLINT(clang-diagnostic-padded)
                         -> std::tuple<AddrT, uint16_t, std::unique_ptr<udp_negotiate_t>>
                     {
                         auto& mapper = udp_mapper_for<AddrT>();
@@ -1175,7 +1178,8 @@ namespace proxy
                                 std::make_unique<udp_negotiate_t>(
                                     AddrT{}, 0,
                                     cred_pair ? std::optional(cred_pair.value().first) : std::nullopt,
-                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt));
+                                    cred_pair ? std::optional(cred_pair.value().second) : std::nullopt,
+                                    upstream_options));
                         }
 
                         return std::make_tuple(AddrT{}, 0, nullptr);
@@ -1198,6 +1202,7 @@ namespace proxy
          * @param protocols enum representing the protocols to be proxied.
          * @param cred_pair optional pair of strings representing username and password for authentication.
          * @param address_families enum representing the destination address family/families to be proxied.
+         * @param upstream_options transport and TLS settings for the upstream SOCKS5 connection.
          * @param start boolean flag to start the proxy server after creating it.
          * @return an optional value containing the index of the added proxy server if successful, std::nullopt otherwise.
          */
@@ -1206,6 +1211,7 @@ namespace proxy
             const supported_protocols protocols,
             const std::optional<std::pair<std::string, std::string>>& cred_pair,
             const supported_address_families address_families = supported_address_families::all,
+            socks5_upstream_options upstream_options = {},
             const bool start = false
         )
         {
@@ -1233,6 +1239,11 @@ namespace proxy
                     "Failed to add SOCKS5 proxy {}: no destination address families are enabled.",
                     endpoint);
                 return {};
+            }
+
+            if (upstream_options.is_tls() && upstream_options.tls.server_name.empty())
+            {
+                upstream_options.tls.server_name = proxy_endpoint->host;
             }
 
             if (!proxy_endpoint->ipv4)
@@ -1266,7 +1277,8 @@ namespace proxy
 
                 if (ipv4_destinations_enabled)
                 {
-                    auto proxy_pair_v4 = build_proxy_pair<net::ip_address_v4>(*proxy_endpoint->ipv4, protocols, cred_pair);
+                    auto proxy_pair_v4 = build_proxy_pair<net::ip_address_v4>(
+                        *proxy_endpoint->ipv4, protocols, cred_pair, upstream_options);
                     socks_tcp_proxy_server = std::move(proxy_pair_v4.first);
                     socks_udp_proxy_server = std::move(proxy_pair_v4.second);
                 }
@@ -1293,7 +1305,8 @@ namespace proxy
                             proxy_endpoint->ipv4->port
                         };
 
-                        auto proxy_pair_v6 = build_proxy_pair<net::ip_address_v6>(*upstream_v6, protocols, cred_pair);
+                        auto proxy_pair_v6 = build_proxy_pair<net::ip_address_v6>(
+                            *upstream_v6, protocols, cred_pair, upstream_options);
                         socks_tcp_proxy_server_v6 = std::move(proxy_pair_v6.first);
                         socks_udp_proxy_server_v6 = std::move(proxy_pair_v6.second);
                     }
@@ -1532,6 +1545,20 @@ namespace proxy
         }
 
         /**
+         * Backwards-compatible overload with explicit destination address families.
+         */
+        std::optional<size_t> add_socks5_proxy(
+            const std::string& endpoint,
+            const supported_protocols protocols,
+            const std::optional<std::pair<std::string, std::string>>& cred_pair,
+            const supported_address_families address_families,
+            const bool start
+        )
+        {
+            return add_socks5_proxy(endpoint, protocols, cred_pair, address_families, {}, start);
+        }
+
+        /**
          * Backwards-compatible overload that enables both IPv4 and IPv6 destinations.
          */
         std::optional<size_t> add_socks5_proxy(
@@ -1541,7 +1568,7 @@ namespace proxy
             const bool start
         )
         {
-            return add_socks5_proxy(endpoint, protocols, cred_pair, supported_address_families::all, start);
+            return add_socks5_proxy(endpoint, protocols, cred_pair, supported_address_families::all, {}, start);
         }
 
         /**
@@ -1664,6 +1691,7 @@ namespace proxy
             }
 
             resolved_proxy_endpoint result;
+            result.host = host;
             for (const auto* address = addresses; address != nullptr; address = address->ai_next)
             {
                 if (!result.ipv4 && address->ai_family == AF_INET &&

--- a/netlib/src/proxy/tcp_proxy_server.h
+++ b/netlib/src/proxy/tcp_proxy_server.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <utility>
+
 namespace proxy
 {
     /**
@@ -94,6 +99,78 @@ namespace proxy
          */
         constexpr static size_t connections_array_size = 64;
 
+        /** Number of blocking TLS/SOCKS setup operations allowed in parallel. */
+        constexpr static size_t connection_setup_worker_count = 8;
+
+        /** Maximum number of connected sockets waiting for a setup worker. */
+        constexpr static size_t connection_setup_queue_capacity = connections_array_size * 4;
+
+        /** Owns a connected socket pair until a setup worker constructs the proxy socket. */
+        struct connection_setup_task
+        {
+            connection_setup_task() = default;
+
+            connection_setup_task(const SOCKET local, const SOCKET remote,
+                std::unique_ptr<negotiate_context_t> context) noexcept
+                : local_socket(local), remote_socket(remote), negotiate_context(std::move(context))
+            {
+            }
+
+            connection_setup_task(const connection_setup_task&) = delete;
+            connection_setup_task& operator=(const connection_setup_task&) = delete;
+
+            connection_setup_task(connection_setup_task&& other) noexcept
+                : local_socket(std::exchange(other.local_socket, INVALID_SOCKET)),
+                remote_socket(std::exchange(other.remote_socket, INVALID_SOCKET)),
+                negotiate_context(std::move(other.negotiate_context))
+            {
+            }
+
+            connection_setup_task& operator=(connection_setup_task&& other) noexcept
+            {
+                if (this != &other)
+                {
+                    close();
+                    local_socket = std::exchange(other.local_socket, INVALID_SOCKET);
+                    remote_socket = std::exchange(other.remote_socket, INVALID_SOCKET);
+                    negotiate_context = std::move(other.negotiate_context);
+                }
+                return *this;
+            }
+
+            ~connection_setup_task()
+            {
+                close();
+            }
+
+            void release_sockets() noexcept
+            {
+                local_socket = INVALID_SOCKET;
+                remote_socket = INVALID_SOCKET;
+            }
+
+            SOCKET local_socket{ INVALID_SOCKET };
+            SOCKET remote_socket{ INVALID_SOCKET };
+            std::unique_ptr<negotiate_context_t> negotiate_context;
+
+        private:
+            static void close_socket(SOCKET& socket) noexcept
+            {
+                if (socket == INVALID_SOCKET)
+                    return;
+
+                shutdown(socket, SD_BOTH);
+                closesocket(socket);
+                socket = INVALID_SOCKET;
+            }
+
+            void close() noexcept
+            {
+                close_socket(local_socket);
+                close_socket(remote_socket);
+            }
+        };
+
         /**
          * @brief Reference to the I/O completion port used for asynchronous socket operations.
          *
@@ -130,6 +207,13 @@ namespace proxy
          * @brief Thread for handling asynchronous connections to remote hosts.
          */
         std::thread connect_to_remote_host_thread_;
+
+        /** Workers that keep blocking TLS/SOCKS negotiation off the connect-event thread. */
+        std::vector<std::thread> connection_setup_workers_;
+
+        std::mutex connection_setup_lock_;
+        std::condition_variable connection_setup_cv_;
+        std::deque<connection_setup_task> connection_setup_queue_;
 
         /**
          * @brief Vector of active proxy socket instances, one per client session.
@@ -475,9 +559,33 @@ namespace proxy
                 return false;
             }
 
-            proxy_server_ = std::thread(&tcp_proxy_server::start_proxy_thread, this);
-            check_clients_thread_ = std::thread(&tcp_proxy_server::clear_thread, this);
-            connect_to_remote_host_thread_ = std::thread(&tcp_proxy_server::connect_to_remote_host_thread, this);
+            try
+            {
+                connection_setup_workers_.reserve(connection_setup_worker_count);
+                for (size_t i = 0; i < connection_setup_worker_count; ++i)
+                {
+                    connection_setup_workers_.emplace_back(
+                        &tcp_proxy_server::connection_setup_worker, this);
+                }
+
+                // Start accepting only after both setup dispatch stages are available.
+                connect_to_remote_host_thread_ =
+                    std::thread(&tcp_proxy_server::connect_to_remote_host_thread, this);
+                check_clients_thread_ = std::thread(&tcp_proxy_server::clear_thread, this);
+                proxy_server_ = std::thread(&tcp_proxy_server::start_proxy_thread, this);
+            }
+            catch (const std::exception& e)
+            {
+                NETLIB_ERROR("tcp_proxy_server::start: failed to launch worker threads: {}", e.what());
+                stop();
+                return false;
+            }
+            catch (...)
+            {
+                NETLIB_ERROR("tcp_proxy_server::start: failed to launch worker threads: unknown exception");
+                stop();
+                return false;
+            }
 
             return true;
         }
@@ -508,18 +616,24 @@ namespace proxy
                 return;
             }
 
-            // Step 1: Signal shutdown - IOCP lambda will check this and exit
+            // Step 1: Signal shutdown. Setup workers leave queued tasks untouched so stop() can
+            // close those socket pairs after every in-progress setup has returned.
             end_server_ = true;
+            connection_setup_cv_.notify_all();
 
             // Step 2: Close server socket
             // This causes any pending accept/I/O operations to complete immediately with an error.
             // When IOCP threads wake up, they'll see end_server_ == true and return false.
-            closesocket(server_socket_);
-            server_socket_ = INVALID_SOCKET;
+            if (server_socket_ != INVALID_SOCKET)
+            {
+                closesocket(server_socket_);
+                server_socket_ = INVALID_SOCKET;
+            }
 
             {
                 std::unique_lock lock(lock_);
-                ::WSASetEvent(std::get<0>(sock_array_events_[0]));
+                if (!sock_array_events_.empty() && std::get<0>(sock_array_events_[0]) != WSA_INVALID_EVENT)
+                    ::WSASetEvent(std::get<0>(sock_array_events_[0]));
             }
 
             // The IOCP handler stays registered until AFTER the drain below: close_client()'s aborted
@@ -529,22 +643,35 @@ namespace proxy
 
             using namespace std::chrono_literals;
 
-            // Step 3: Quiesce the server's worker threads before tearing sessions down, so no new
-            // session is accepted/connected and no concurrent cleanup mutates proxy_sockets_ during
-            // the drain. They all exit once end_server_ is set and the server socket is closed. This
-            // matters more than on the UDP side: TCP creates sessions in connect_to_remote_host_thread_,
-            // so a socket added after the drain declared success would be freed with I/O still pending.
+            // Step 3: Quiesce every producer before tearing sessions down. The connect-event thread
+            // stops adding setup tasks, then setup workers finish any operation already in progress.
+            // This guarantees no socket can be published after the I/O drain begins.
             if (proxy_server_.joinable())
             {
                 proxy_server_.join();
             }
-            if (check_clients_thread_.joinable())
-            {
-                check_clients_thread_.join();
-            }
             if (connect_to_remote_host_thread_.joinable())
             {
                 connect_to_remote_host_thread_.join();
+            }
+            for (auto& worker : connection_setup_workers_)
+            {
+                if (worker.joinable())
+                    worker.join();
+            }
+            connection_setup_workers_.clear();
+
+            {
+                std::unique_lock lock(connection_setup_lock_);
+                connection_setup_queue_.clear();
+            }
+
+            // Also handles a partial start() where the connect-event thread was never launched.
+            close_pending_connections();
+
+            if (check_clients_thread_.joinable())
+            {
+                check_clients_thread_.join();
             }
 
             // Step 4: Cancel every proxy socket's pending I/O so its posted operations complete
@@ -986,7 +1113,7 @@ namespace proxy
             // permanently occupies one of the limited slots and leaks the WSAEVENT. After
             // connections_array_size such failures the server rejects every new connection until
             // it is restarted. Erase our entry on those paths.
-            auto undo_pending_entry = [this, tracked_event]()
+            auto undo_pending_entry = [this, tracked_event]() -> bool
             {
                 std::scoped_lock lock(lock_);
                 for (auto it = sock_array_events_.begin(); it != sock_array_events_.end(); ++it)
@@ -995,9 +1122,10 @@ namespace proxy
                     {
                         WSACloseEvent(std::get<0>(*it));
                         sock_array_events_.erase(it);
-                        break;
+                        return true;
                     }
                 }
+                return false;
             };
 
             NETLIB_DEBUG("connect_to_remote_host: Initiating connection to {}:{}", remote_ip, remote_port);
@@ -1016,10 +1144,17 @@ namespace proxy
                     if (const auto error = WSAGetLastError(); error != WSAEWOULDBLOCK)
                     {
                         NETLIB_WARNING("connect_to_remote_host: IPv4 connect failed: {}", error);
-                        shutdown(remote_socket, SD_BOTH);
-                        closesocket(remote_socket);
-                        undo_pending_entry();
-                        return false;
+                        if (undo_pending_entry())
+                        {
+                            shutdown(remote_socket, SD_BOTH);
+                            closesocket(remote_socket);
+                            return false;
+                        }
+
+                        // The connect-event thread (or shutdown cleanup) already claimed the
+                        // tuple and therefore owns both socket handles. Returning true prevents
+                        // the accept thread from closing the local handle a second time.
+                        return true;
                     }
                     NETLIB_DEBUG("connect_to_remote_host: IPv4 connection in progress (WSAEWOULDBLOCK)");
                 }
@@ -1041,10 +1176,17 @@ namespace proxy
                     if (const auto error = WSAGetLastError(); error != WSAEWOULDBLOCK)
                     {
                         NETLIB_WARNING("connect_to_remote_host: IPv6 connect failed: {}", error);
-                        shutdown(remote_socket, SD_BOTH);
-                        closesocket(remote_socket);
-                        undo_pending_entry();
-                        return false;
+                        if (undo_pending_entry())
+                        {
+                            shutdown(remote_socket, SD_BOTH);
+                            closesocket(remote_socket);
+                            return false;
+                        }
+
+                        // The connect-event thread (or shutdown cleanup) already claimed the
+                        // tuple and therefore owns both socket handles. Returning true prevents
+                        // the accept thread from closing the local handle a second time.
+                        return true;
                     }
                     else
                     {
@@ -1086,17 +1228,182 @@ namespace proxy
                     break;
                 }
 
-                if (sock_array_events_.size() >= connections_array_size) {
-                    NETLIB_WARNING("Too many pending connections, rejecting new client.");
-                    closesocket(accepted);
-                    continue;
-                }
-
                 if (const auto connected = connect_to_remote_host(accepted); !connected)
                 {
                     closesocket(accepted);
                 }
             }
+        }
+
+        [[nodiscard]] bool enqueue_connection_setup(connection_setup_task&& task) noexcept
+        {
+            try
+            {
+                {
+                    std::unique_lock lock(connection_setup_lock_);
+                    if (end_server_.load(std::memory_order_acquire))
+                        return false;
+
+                    if (connection_setup_queue_.size() >= connection_setup_queue_capacity)
+                    {
+                        NETLIB_WARNING("Connection setup queue full, rejecting connected client");
+                        return false;
+                    }
+
+                    connection_setup_queue_.emplace_back(std::move(task));
+                }
+
+                connection_setup_cv_.notify_one();
+                return true;
+            }
+            catch (const std::exception& e)
+            {
+                NETLIB_ERROR("Failed to enqueue connected client for proxy setup: {}", e.what());
+            }
+            catch (...)
+            {
+                NETLIB_ERROR("Failed to enqueue connected client for proxy setup: unknown exception");
+            }
+
+            return false;
+        }
+
+        void initialize_proxy_socket(connection_setup_task task) noexcept
+        {
+            if (end_server_.load(std::memory_order_acquire))
+                return;
+
+            std::shared_ptr<T> socket;
+            const auto clean_failed_socket = [this, &socket]
+            {
+                if (!socket)
+                    return;
+
+                socket->close_client(false, true);
+                socket->close_client(false, false);
+                if (socket->outstanding_io() == 0)
+                {
+                    socket->release_self_references();
+                    socket.reset();
+                    return;
+                }
+
+                // If setup threw after posting overlapped I/O, retain the session so normal
+                // cleanup or stop() can wait for its cancellation completions.
+                std::scoped_lock lock(lock_);
+                proxy_sockets_.push_back(std::move(socket));
+            };
+
+            try
+            {
+                socket = std::make_shared<T>(
+                    task.local_socket,
+                    task.remote_socket,
+                    std::move(task.negotiate_context),
+                    logger::log_level_,
+                    logger::log_stream_);
+
+                // The proxy socket now owns both handles. The task must not close them when it
+                // leaves this function.
+                task.release_sockets();
+
+                socket->initialize_io_contexts();
+                if (!socket->associate_to_completion_port(completion_key_, completion_port_))
+                    throw std::runtime_error("associate_to_completion_port failed");
+
+                // Avoid entering a blocking handshake when shutdown won the race after this task
+                // left the queue. No I/O has been posted yet, so it can be released immediately.
+                if (end_server_.load(std::memory_order_acquire))
+                {
+                    clean_failed_socket();
+                    return;
+                }
+
+                // SOCKS5Tls performs its bounded blocking TLS and SOCKS exchange here. This is
+                // intentionally a setup-worker operation, never connect-event-thread work.
+                socket->start();
+
+                {
+                    std::scoped_lock lock(lock_);
+                    proxy_sockets_.push_back(std::move(socket));
+                }
+            }
+            catch (const std::exception& e)
+            {
+                NETLIB_ERROR("Connection setup worker failed to initialize proxy socket: {}", e.what());
+                try
+                {
+                    clean_failed_socket();
+                }
+                catch (...)
+                {
+                    NETLIB_ERROR("Connection setup worker could not retain a partially initialized socket");
+                }
+            }
+            catch (...)
+            {
+                NETLIB_ERROR("Connection setup worker failed to initialize proxy socket: unknown exception");
+                try
+                {
+                    clean_failed_socket();
+                }
+                catch (...)
+                {
+                    NETLIB_ERROR("Connection setup worker could not retain a partially initialized socket");
+                }
+            }
+        }
+
+        void connection_setup_worker()
+        {
+            while (true)
+            {
+                connection_setup_task task;
+                {
+                    std::unique_lock lock(connection_setup_lock_);
+                    connection_setup_cv_.wait(lock, [this]
+                    {
+                        return end_server_.load(std::memory_order_acquire) ||
+                            !connection_setup_queue_.empty();
+                    });
+
+                    if (end_server_.load(std::memory_order_acquire))
+                        return;
+
+                    task = std::move(connection_setup_queue_.front());
+                    connection_setup_queue_.pop_front();
+                }
+
+                initialize_proxy_socket(std::move(task));
+            }
+        }
+
+        void close_pending_connections()
+        {
+            std::unique_lock lock(lock_);
+            for (auto& pending : sock_array_events_)
+            {
+                if (std::get<0>(pending) != WSA_INVALID_EVENT)
+                {
+                    WSACloseEvent(std::get<0>(pending));
+                    std::get<0>(pending) = WSA_INVALID_EVENT;
+                }
+
+                if (std::get<1>(pending) != INVALID_SOCKET)
+                {
+                    shutdown(std::get<1>(pending), SD_BOTH);
+                    closesocket(std::get<1>(pending));
+                    std::get<1>(pending) = INVALID_SOCKET;
+                }
+
+                if (std::get<2>(pending) != INVALID_SOCKET)
+                {
+                    shutdown(std::get<2>(pending), SD_BOTH);
+                    closesocket(std::get<2>(pending));
+                    std::get<2>(pending) = INVALID_SOCKET;
+                }
+            }
+            sock_array_events_.clear();
         }
 
         /**
@@ -1159,36 +1466,51 @@ namespace proxy
 
                 if (event_index != 0)
                 {
-                    std::scoped_lock lock(lock_);
-
-                    // Extract socket handles before creating the shared_ptr
-                    // so we can clean them up if initialization fails
-                    auto local_socket = std::get<1>(sock_array_events_[event_index]);
-                    auto remote_socket = std::get<2>(sock_array_events_[event_index]);
-                    auto negotiate_ctx = std::move(std::get<3>(sock_array_events_[event_index]));
-
-                    // An FD_CONNECT event reports completion, not necessarily success. Retrieve
-                    // its error before handing the socket to the SOCKS5 session; otherwise a failed
-                    // connect is promoted to a live proxy socket.
+                    auto local_socket = static_cast<SOCKET>(INVALID_SOCKET);
+                    auto remote_socket = static_cast<SOCKET>(INVALID_SOCKET);
+                    std::unique_ptr<negotiate_context_t> negotiate_ctx;
                     int connect_error = 0;
-                    WSANETWORKEVENTS network_events{};
-                    if (WSAEnumNetworkEvents(remote_socket, wait_events[event_index], &network_events) == SOCKET_ERROR)
                     {
-                        connect_error = WSAGetLastError();
-                    }
-                    else if ((network_events.lNetworkEvents & FD_CONNECT) == 0)
-                    {
-                        connect_error = WSAEINVAL;
-                    }
-                    else
-                    {
-                        connect_error = network_events.iErrorCode[FD_CONNECT_BIT];
-                    }
+                        std::scoped_lock lock(lock_);
 
-                    WSACloseEvent(wait_events[event_index]);
+                        // The wait set is a snapshot. A synchronous connect failure can erase an
+                        // entry while this thread is waiting, so locate the live tuple by event
+                        // handle instead of indexing the potentially shifted vector.
+                        const auto signaled_event = wait_events[event_index];
+                        const auto pending = std::find_if(
+                            sock_array_events_.begin() + 1,
+                            sock_array_events_.end(),
+                            [signaled_event](const auto& entry)
+                            {
+                                return std::get<0>(entry) == signaled_event;
+                            });
+                        if (pending == sock_array_events_.end())
+                        {
+                            continue;
+                        }
 
-                    // Remove from tracking array first - we own the resources now
-                    sock_array_events_.erase(sock_array_events_.begin() + event_index);
+                        local_socket = std::get<1>(*pending);
+                        remote_socket = std::get<2>(*pending);
+                        negotiate_ctx = std::move(std::get<3>(*pending));
+
+                        // An FD_CONNECT event reports completion, not necessarily success.
+                        WSANETWORKEVENTS network_events{};
+                        if (WSAEnumNetworkEvents(remote_socket, signaled_event, &network_events) == SOCKET_ERROR)
+                        {
+                            connect_error = WSAGetLastError();
+                        }
+                        else if ((network_events.lNetworkEvents & FD_CONNECT) == 0)
+                        {
+                            connect_error = WSAEINVAL;
+                        }
+                        else
+                        {
+                            connect_error = network_events.iErrorCode[FD_CONNECT_BIT];
+                        }
+
+                        WSACloseEvent(signaled_event);
+                        sock_array_events_.erase(pending);
+                    }
 
                     if (connect_error != 0)
                     {
@@ -1200,76 +1522,14 @@ namespace proxy
                         continue;
                     }
 
-                    try
+                    connection_setup_task setup_task{
+                        local_socket,
+                        remote_socket,
+                        std::move(negotiate_ctx)
+                    };
+                    if (!enqueue_connection_setup(std::move(setup_task)))
                     {
-                        // Create socket as shared_ptr
-                        auto socket = std::make_shared<T>(
-                            local_socket,
-                            remote_socket,
-                            std::move(negotiate_ctx),
-                            logger::log_level_, logger::log_stream_);
-
-                        // The socket now OWNS both handles: its destructor closes them if any step
-                        // below throws (stack-unwinding destroys `socket` before the catch runs).
-                        // Null the local copies so the catch does NOT close them a second time --
-                        // a double closesocket that, with handle recycling, could tear down an
-                        // unrelated socket. If make_shared itself had thrown we would not reach here,
-                        // and the catch would still correctly close the un-transferred handles.
-                        local_socket = INVALID_SOCKET;
-                        remote_socket = INVALID_SOCKET;
-
-                        // Initialize I/O contexts - can throw std::bad_weak_ptr or std::runtime_error
-                        socket->initialize_io_contexts();
-
-                        // Associate with completion port. A false return means no completion handler
-                        // was registered (CreateIoCompletionPort failed, or completion_key_ is
-                        // invalid): the session's overlapped I/O would post but never complete, so
-                        // outstanding_io_ would never drain and the session would pin forever. Treat
-                        // it as a fatal init error so the catch tears the half-built session down.
-                        if (!socket->associate_to_completion_port(completion_key_, completion_port_))
-                            throw std::runtime_error("associate_to_completion_port failed");
-
-                        // Start the socket
-                        socket->start();
-
-                        // Store in vector - socket is now fully initialized
-                        proxy_sockets_.push_back(std::move(socket));
-                    }
-                    catch (const std::exception& e)
-                    {
-                        // Initialization failed - clean up sockets manually since they weren't
-                        // transferred to a successfully initialized proxy socket
-                        NETLIB_ERROR("connect_to_remote_host_thread: Failed to initialize proxy socket: {}", e.what());
-
-                        if (local_socket != INVALID_SOCKET)
-                        {
-                            shutdown(local_socket, SD_BOTH);
-                            closesocket(local_socket);
-                        }
-
-                        if (remote_socket != INVALID_SOCKET)
-                        {
-                            shutdown(remote_socket, SD_BOTH);
-                            closesocket(remote_socket);
-                        }
-                        // Continue processing other connections
-                    }
-                    catch (...)
-                    {
-                        NETLIB_ERROR("connect_to_remote_host_thread: Unknown exception during proxy socket initialization");
-
-                        if (local_socket != INVALID_SOCKET)
-                        {
-                            shutdown(local_socket, SD_BOTH);
-                            closesocket(local_socket);
-                        }
-
-                        if (remote_socket != INVALID_SOCKET)
-                        {
-                            shutdown(remote_socket, SD_BOTH);
-                            closesocket(remote_socket);
-                        }
-                        // Continue processing other connections
+                        NETLIB_WARNING("connect_to_remote_host_thread: unable to queue connected client for setup");
                     }
                 }
                 else
@@ -1278,32 +1538,7 @@ namespace proxy
                 }
             }
 
-            // cleanup on exit. Exclusive lock: this block MUTATES sock_array_events_
-            // (closes events/sockets and writes INVALID_SOCKET), so a shared (read) lock
-            // would be the wrong contract.
-            std::unique_lock lock(lock_);
-
-            for (auto&& a : sock_array_events_)
-            {
-                if (std::get<0>(a) != INVALID_HANDLE_VALUE)
-                {
-                    WSACloseEvent(std::get<0>(a));
-                }
-
-                if (std::get<1>(a) != INVALID_SOCKET)
-                {
-                    shutdown(std::get<1>(a), SD_BOTH);
-                    closesocket(std::get<1>(a));
-                    std::get<1>(a) = INVALID_SOCKET;
-                }
-
-                if (std::get<2>(a) != INVALID_SOCKET)
-                {
-                    shutdown(std::get<2>(a), SD_BOTH);
-                    closesocket(std::get<2>(a));
-                    std::get<2>(a) = INVALID_SOCKET;
-                }
-            }
+            close_pending_connections();
         }
 
         /**

--- a/netlib/src/proxy/tcp_proxy_socket.h
+++ b/netlib/src/proxy/tcp_proxy_socket.h
@@ -769,7 +769,7 @@ namespace proxy
          *
          * @param is_local true if the FIN was read on the local socket, false if on the remote.
          */
-        void on_peer_read_shutdown(const bool is_local)
+        virtual void on_peer_read_shutdown(const bool is_local)
         {
             std::scoped_lock lock(lock_);
 
@@ -820,7 +820,7 @@ namespace proxy
          *
          * Thread safety is ensured by acquiring a lock on the session state.
          *
-         * @return true if the session is fully closed and all buffers are empty (ready for removal),
+         * @return true if the session is fully closed and all I/O has drained (ready for removal),
          *         false otherwise.
          *
          * @note This method may be called periodically by a cleanup thread to manage session lifetimes.
@@ -900,22 +900,21 @@ namespace proxy
             if (sockets_closed)
             {
                 NETLIB_DEBUG("is_ready_for_removal: Both sockets are closed, checking buffer states");
-                NETLIB_DEBUG("is_ready_for_removal: Buffer lengths - remote_send: {}, local_send: {}, remote_recv: {}, local_recv: {}",
+                NETLIB_DEBUG("is_ready_for_removal: Buffer state - remote_send: {}, local_send: {}, remote_recv_capacity: {}, local_recv_capacity: {}",
                     remote_send_buf_.len, local_send_buf_.len, remote_recv_buf_.len, local_recv_buf_.len);
 
-                // If both sockets are closed, force-reset all buffer lengths
-                // The connection is dead, so any remaining data cannot be transmitted
-                if (remote_send_buf_.len != 0 || local_send_buf_.len != 0 || 
-                    remote_recv_buf_.len != 0 || local_recv_buf_.len != 0)
+                // A receive WSABUF's length is available capacity, not buffered payload. Only
+                // send lengths can represent data that was still pending when the sockets closed.
+                if (remote_send_buf_.len != 0 || local_send_buf_.len != 0)
                 {
-                    NETLIB_WARNING("is_ready_for_removal: Sockets closed with non-empty buffers, forcing buffer reset (data lost: remote_send={}, local_send={}, remote_recv={}, local_recv={})",
-                        remote_send_buf_.len, local_send_buf_.len, remote_recv_buf_.len, local_recv_buf_.len);
-                    
-                    remote_send_buf_.len = 0;
-                    local_send_buf_.len = 0;
-                    remote_recv_buf_.len = 0;
-                    local_recv_buf_.len = 0;
+                    NETLIB_WARNING("is_ready_for_removal: Sockets closed with pending send data (remote_send={}, local_send={})",
+                        remote_send_buf_.len, local_send_buf_.len);
                 }
+
+                remote_send_buf_.len = 0;
+                local_send_buf_.len = 0;
+                remote_recv_buf_.len = 0;
+                local_recv_buf_.len = 0;
 
                 // Break the per-session shared_ptr cycle: each per-I/O context member holds a
                 // strong reference back to this object so it stays alive while overlapped I/O

--- a/socksify/Socksifier.cpp
+++ b/socksify/Socksifier.cpp
@@ -211,7 +211,43 @@ void Socksifier::Socksifier::SetBypassLan()
 IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username, String^ password,
     SupportedProtocolsEnum protocols, SupportedAddressFamiliesEnum addressFamilies, const bool start)
 {
+    return AddSocks5Proxy(
+        endpoint,
+        username,
+        password,
+        protocols,
+        addressFamilies,
+        Socks5TransportEnum::TCP,
+        nullptr,
+        nullptr,
+        false,
+        start);
+}
+
+/// <summary>
+/// Adds a SOCKS5 proxy to the gateway with an explicit upstream transport.
+/// </summary>
+/// <param name="endpoint">The proxy endpoint (IP:Port).</param>
+/// <param name="username">The username for authentication.</param>
+/// <param name="password">The password for authentication.</param>
+/// <param name="protocols">The supported protocols.</param>
+/// <param name="addressFamilies">The supported destination address families.</param>
+/// <param name="transport">The upstream transport.</param>
+/// <param name="tlsServerName">TLS SNI and certificate validation name.</param>
+/// <param name="tlsPinnedSha256">Optional SHA-256 certificate fingerprint pin.</param>
+/// <param name="tlsAllowInvalidCertificate">Whether to bypass normal certificate validation.</param>
+/// <param name="start">Whether to start the proxy immediately.</param>
+/// <returns>A handle to the proxy instance, or -1 on failure.</returns>
+IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username, String^ password,
+    SupportedProtocolsEnum protocols, SupportedAddressFamiliesEnum addressFamilies, Socks5TransportEnum transport,
+    String^ tlsServerName, String^ tlsPinnedSha256, const bool tlsAllowInvalidCertificate, const bool start)
+{
     if (!unmanaged_ptr_)
+        return static_cast<IntPtr>(-1);
+
+    const auto has_username = !String::IsNullOrEmpty(username);
+    const auto has_password = !String::IsNullOrEmpty(password);
+    if (has_username != has_password)
         return static_cast<IntPtr>(-1);
 
     auto protocols_mx = supported_protocols_mx::both;
@@ -240,7 +276,24 @@ IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username
         break;
     }
 
-    if (username != nullptr && password != nullptr)
+    auto transport_mx = socks5_transport_mx::tcp;
+    switch (transport)
+    {
+    case Socks5TransportEnum::TLS:
+        transport_mx = socks5_transport_mx::tls;
+        break;
+    default:
+        break;
+    }
+
+    const auto tls_server_name_mx = tlsServerName != nullptr
+        ? msclr::interop::marshal_as<std::string>(tlsServerName)
+        : std::string{};
+    const auto tls_pinned_sha256_mx = tlsPinnedSha256 != nullptr
+        ? msclr::interop::marshal_as<std::string>(tlsPinnedSha256)
+        : std::string{};
+
+    if (has_username && has_password)
     {
         return static_cast<IntPtr>(unmanaged_ptr_->add_socks5_proxy(
             msclr::interop::marshal_as<std::string>(endpoint),
@@ -248,12 +301,25 @@ IntPtr Socksifier::Socksifier::AddSocks5Proxy(String^ endpoint, String^ username
             address_families_mx,
             start,
             msclr::interop::marshal_as<std::string>(username),
-            msclr::interop::marshal_as<std::string>(password)
+            msclr::interop::marshal_as<std::string>(password),
+            transport_mx,
+            tls_server_name_mx,
+            tls_pinned_sha256_mx,
+            tlsAllowInvalidCertificate
         ));
     }
 
     return static_cast<IntPtr>(unmanaged_ptr_->add_socks5_proxy(
-        msclr::interop::marshal_as<std::string>(endpoint), protocols_mx, address_families_mx, start));
+        msclr::interop::marshal_as<std::string>(endpoint),
+        protocols_mx,
+        address_families_mx,
+        start,
+        "",
+        "",
+        transport_mx,
+        tls_server_name_mx,
+        tls_pinned_sha256_mx,
+        tlsAllowInvalidCertificate));
 }
 
 /// <summary>

--- a/socksify/Socksifier.h
+++ b/socksify/Socksifier.h
@@ -99,6 +99,17 @@ namespace Socksifier
     };
 
     /// <summary>
+    /// Specifies the transport used to reach the upstream SOCKS5 proxy.
+    /// </summary>
+    public enum class Socks5TransportEnum
+    {
+        /// <summary>Plain TCP transport.</summary>
+        TCP,
+        /// <summary>TLS-wrapped TCP transport.</summary>
+        TLS
+    };
+
+    /// <summary>
     /// Represents a single log entry for Socksifier events.
     /// </summary>
     public ref class LogEntry sealed
@@ -274,6 +285,24 @@ namespace Socksifier
         /// <returns>A handle to the proxy instance.</returns>
         IntPtr AddSocks5Proxy(String^ endpoint, String^ username, String^ password, SupportedProtocolsEnum protocols,
             SupportedAddressFamiliesEnum addressFamilies, bool start);
+
+        /// <summary>
+        /// Adds a SOCKS5 proxy to the gateway with an explicit upstream transport.
+        /// </summary>
+        /// <param name="endpoint">The proxy endpoint (IP:Port).</param>
+        /// <param name="username">The username for authentication.</param>
+        /// <param name="password">The password for authentication.</param>
+        /// <param name="protocols">The supported protocols.</param>
+        /// <param name="addressFamilies">The supported destination address families.</param>
+        /// <param name="transport">The upstream transport.</param>
+        /// <param name="tlsServerName">TLS SNI and certificate validation name.</param>
+        /// <param name="tlsPinnedSha256">Optional SHA-256 certificate fingerprint pin.</param>
+        /// <param name="tlsAllowInvalidCertificate">Whether to bypass normal certificate validation.</param>
+        /// <param name="start">Whether to start the proxy immediately.</param>
+        /// <returns>A handle to the proxy instance.</returns>
+        IntPtr AddSocks5Proxy(String^ endpoint, String^ username, String^ password, SupportedProtocolsEnum protocols,
+            SupportedAddressFamiliesEnum addressFamilies, Socks5TransportEnum transport, String^ tlsServerName,
+            String^ tlsPinnedSha256, bool tlsAllowInvalidCertificate, bool start);
 
         /// <summary>
         /// Adds a SOCKS5 proxy to the gateway with both IPv4 and IPv6 destinations enabled.

--- a/socksify/mixed_types.h
+++ b/socksify/mixed_types.h
@@ -62,6 +62,17 @@ enum class supported_address_families_mx : uint8_t
 };
 
 /**
+ * @brief Specifies the transport used to reach the upstream SOCKS5 proxy.
+ */
+enum class socks5_transport_mx : uint8_t
+{
+    /// <summary>Plain TCP transport.</summary>
+    tcp = 0,
+    /// <summary>TLS-wrapped TCP transport.</summary>
+    tls = 1
+};
+
+/**
  * @brief Enumerates the types of events that can occur in the proxy gateway.
  */
 enum class event_type_mx : uint32_t

--- a/socksify/socksify.vcxproj
+++ b/socksify/socksify.vcxproj
@@ -139,7 +139,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -156,7 +156,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -173,7 +173,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -190,7 +190,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -208,7 +208,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -226,7 +226,7 @@
       <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)bin\lib\$(Platform)\$(Configuration)\ndisapi.lib;Iphlpapi.lib;ws2_32.lib;Advapi32.lib;Dnsapi.lib;Secur32.lib;Crypt32.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
@@ -255,6 +255,7 @@
     <ClInclude Include="..\netlib\src\pcap\pcap_stream_logger.h" />
     <ClInclude Include="..\netlib\src\proxy\packet_pool.h" />
     <ClInclude Include="..\netlib\src\proxy\proxy_common.h" />
+    <ClInclude Include="..\netlib\src\proxy\schannel_tls_stream.h" />
     <ClInclude Include="..\netlib\src\proxy\socks5_tcp_proxy_socket.h" />
     <ClInclude Include="..\netlib\src\proxy\socks5_udp_proxy_socket.h" />
     <ClInclude Include="..\netlib\src\proxy\socks5_common.h" />

--- a/socksify/socksify.vcxproj.filters
+++ b/socksify/socksify.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClInclude Include="..\netlib\src\proxy\proxy_common.h">
       <Filter>Header Files\netlib\proxy</Filter>
     </ClInclude>
+    <ClInclude Include="..\netlib\src\proxy\schannel_tls_stream.h">
+      <Filter>Header Files\netlib\proxy</Filter>
+    </ClInclude>
     <ClInclude Include="..\netlib\src\proxy\tcp_proxy_server.h">
       <Filter>Header Files\netlib\proxy</Filter>
     </ClInclude>

--- a/socksify/socksify_unmanaged.cpp
+++ b/socksify/socksify_unmanaged.cpp
@@ -240,6 +240,10 @@ void socksify_unmanaged::set_bypass_lan() const
  * @param start Whether to start the proxy immediately.
  * @param login Optional username for authentication.
  * @param password Optional password for authentication.
+ * @param transport Upstream transport used to reach the SOCKS5 proxy.
+ * @param tls_server_name Server name used for TLS SNI and certificate validation.
+ * @param tls_pinned_cert_sha256 Optional SHA-256 certificate fingerprint pin.
+ * @param tls_allow_invalid_certificate Whether to bypass normal certificate validation.
  * @return A handle (LONG_PTR) to the proxy instance, or -1 on failure.
  */
 LONG_PTR socksify_unmanaged::add_socks5_proxy(
@@ -248,12 +252,23 @@ LONG_PTR socksify_unmanaged::add_socks5_proxy(
     const supported_address_families_mx address_family,
     const bool start,
     const std::string& login,
-    const std::string& password) const
+    const std::string& password,
+    const socks5_transport_mx transport,
+    const std::string& tls_server_name,
+    const std::string& tls_pinned_cert_sha256,
+    const bool tls_allow_invalid_certificate) const
 {
     using namespace std::string_literals;
     std::optional<std::pair<std::string, std::string>> cred{ std::nullopt };
 
-    if (!login.empty())
+    if (login.empty() != password.empty() ||
+        login.size() > proxy::socks5_username_max_length ||
+        password.size() > proxy::socks5_username_max_length)
+    {
+        return -1;
+    }
+
+    if (!login.empty() && !password.empty())
     {
         cred = std::make_pair(login, password);
     }
@@ -287,7 +302,23 @@ LONG_PTR socksify_unmanaged::add_socks5_proxy(
         break;
     }
 
-    if (const auto result = proxy_->add_socks5_proxy(endpoint, protocols, cred, address_families, start); result)
+    proxy::socks5_upstream_options upstream_options{};
+    switch (transport)
+    {
+    case socks5_transport_mx::tls:
+        upstream_options.transport = proxy::socks5_transport::tls;
+        upstream_options.tls.server_name = tls_server_name;
+        upstream_options.tls.pinned_cert_sha256 = tls_pinned_cert_sha256;
+        upstream_options.tls.allow_invalid_certificate = tls_allow_invalid_certificate;
+        break;
+    case socks5_transport_mx::tcp:
+    default:
+        upstream_options.transport = proxy::socks5_transport::tcp;
+        break;
+    }
+
+    if (const auto result = proxy_->add_socks5_proxy(
+        endpoint, protocols, cred, address_families, upstream_options, start); result)
     {
         return static_cast<LONG_PTR>(result.value());
     }
@@ -303,9 +334,23 @@ LONG_PTR socksify_unmanaged::add_socks5_proxy(
     const supported_protocols_mx protocol,
     const bool start,
     const std::string& login,
-    const std::string& password) const
+    const std::string& password,
+    const socks5_transport_mx transport,
+    const std::string& tls_server_name,
+    const std::string& tls_pinned_cert_sha256,
+    const bool tls_allow_invalid_certificate) const
 {
-    return add_socks5_proxy(endpoint, protocol, supported_address_families_mx::both, start, login, password);
+    return add_socks5_proxy(
+        endpoint,
+        protocol,
+        supported_address_families_mx::both,
+        start,
+        login,
+        password,
+        transport,
+        tls_server_name,
+        tls_pinned_cert_sha256,
+        tls_allow_invalid_certificate);
 }
 
 /**

--- a/socksify/socksify_unmanaged.h
+++ b/socksify/socksify_unmanaged.h
@@ -81,6 +81,10 @@ public:
      * @param start Whether to start the proxy immediately.
      * @param login Optional username for authentication.
      * @param password Optional password for authentication.
+     * @param transport Upstream transport used to reach the SOCKS5 proxy.
+     * @param tls_server_name Server name used for TLS SNI and certificate validation.
+     * @param tls_pinned_cert_sha256 Optional SHA-256 certificate fingerprint pin.
+     * @param tls_allow_invalid_certificate Whether to bypass normal certificate validation.
      * @return A handle (LONG_PTR) to the proxy instance, or -1 on failure.
      */
     [[nodiscard]] LONG_PTR add_socks5_proxy(
@@ -89,7 +93,11 @@ public:
         supported_address_families_mx address_family,
         bool start = false,
         const std::string& login = "",
-        const std::string& password = ""
+        const std::string& password = "",
+        socks5_transport_mx transport = socks5_transport_mx::tcp,
+        const std::string& tls_server_name = "",
+        const std::string& tls_pinned_cert_sha256 = "",
+        bool tls_allow_invalid_certificate = false
     ) const;
 
     /**
@@ -100,7 +108,11 @@ public:
         supported_protocols_mx protocol,
         bool start = false,
         const std::string& login = "",
-        const std::string& password = ""
+        const std::string& password = "",
+        socks5_transport_mx transport = socks5_transport_mx::tcp,
+        const std::string& tls_server_name = "",
+        const std::string& tls_pinned_cert_sha256 = "",
+        bool tls_allow_invalid_certificate = false
     ) const;
 
     /**

--- a/socksify/unmanaged.h
+++ b/socksify/unmanaged.h
@@ -65,6 +65,7 @@
 #include "../netlib/src/winsys/io_completion_port.h"
 #include "../netlib/src/proxy/packet_pool.h"
 #include "../netlib/src/proxy/tcp_proxy_socket.h"
+#include "../netlib/src/proxy/schannel_tls_stream.h"
 #include "../netlib/src/proxy/socks5_tcp_proxy_socket.h"
 #include "../netlib/src/proxy/tcp_proxy_server.h"
 #include "../netlib/src/proxy/socks5_udp_proxy_socket.h"


### PR DESCRIPTION
## Summary

- add a native SChannel-backed SOCKS5-over-TLS transport with certificate chain/hostname validation, optional SHA-256 leaf pinning, and an explicit insecure test mode
- support both TCP CONNECT relays and TLS-protected UDP ASSOCIATE control channels while keeping plain SOCKS5 as the default
- expose transport and TLS settings through the managed config, C++/CLI API, and unmanaged router API without breaking existing callers
- move blocking TLS/SOCKS setup onto bounded worker queues so slow handshakes cannot stall unrelated TCP connects or UDP associations
- harden partial SOCKS replies, timeout handling, socket ownership, shutdown draining, and buffer diagnostics discovered during review

## Compatibility

- targets Alighieri TLS listeners and currently negotiates TLS 1.2
- preserves existing plain TCP behavior and AddSocks5Proxy overloads
- supports IPv4 and IPv6 destination listeners plus TCP and UDP routing

## Validation

- x64 Debug full solution build: passed
- C/C++ Code Analysis: 0 errors, 0 warnings
- x64 Release full solution build: passed
- sample configuration JSON parse: passed
- manual live test against an Alighieri SOCKS5Tls endpoint: TCP and UDP routing work, with the setup-worker change removing the observed site-opening stalls