### PR TITLE
Build: prepare v2.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ As of **v2.2.0**, ProxiFyre supports **LAN bypass**, allowing local network traf
 
 As of **v2.3.0**, ProxiFyre also proxies **IPv6** destinations. Previously only IPv4 traffic from a matched application was routed through the proxy while its IPv6 TCP/UDP traffic leaked out directly; now both address families are redirected to the configured SOCKS5 proxy.
 
+As of **v2.4.0**, ProxiFyre supports native **SOCKS5-over-TLS** upstreams through Windows SChannel, including encrypted TCP `CONNECT` relays and TLS-protected UDP `ASSOCIATE` control channels. This transport is compatible with [Alighieri](https://github.com/wiresock/alighieri) TLS listeners; normal unencrypted SOCKS5 remains the default.
+
 **Requirements and limitations:**
 
 - **Your client host must already have working IPv6 connectivity.** ProxiFyre redirects the IPv6 packets your applications actually transmit — it does *not* create IPv6 reachability. On an **IPv4-only host**, your applications never emit global IPv6 traffic, so there is nothing to redirect and you will still see IPv4-only egress even for IPv6-capable destinations. (This is inherent to the packet-filter design: it intercepts transmitted packets, it does not originate connections on the application's behalf.)
@@ -29,10 +31,10 @@ The application uses a configuration file named `app-config.json`. This JSON fil
 - **socks5ProxyEndpoint**: A string that specifies the SOCKS5 proxy endpoint.
 - **username**: A string that specifies the username for the proxy (optional).
 - **password**: A string that specifies the password for the proxy (optional).
-- **socks5Transport**: `"TCP"` for normal SOCKS5 (default) or `"TLS"` for SOCKS5-over-TLS.
-- **tlsServerName**: SNI/certificate validation name for `"socks5Transport": "TLS"` (defaults to the endpoint host).
-- **tlsPinnedSha256**: Optional SHA-256 certificate fingerprint pin for TLS upstreams.
-- **tlsAllowInvalidCertificate**: Allows invalid TLS certificates (default: `false`). Prefer `tlsPinnedSha256` for self-signed test certificates.
+- **socks5Transport** *(new in v2.4.0)*: `"TCP"` for normal SOCKS5 (default) or `"TLS"` for SOCKS5-over-TLS.
+- **tlsServerName** *(new in v2.4.0)*: SNI/certificate validation name for `"socks5Transport": "TLS"` (defaults to the endpoint host).
+- **tlsPinnedSha256** *(new in v2.4.0)*: Optional SHA-256 certificate fingerprint pin for TLS upstreams.
+- **tlsAllowInvalidCertificate** *(new in v2.4.0)*: Allows invalid TLS certificates (default: `false`). Prefer `tlsPinnedSha256` for self-signed test certificates.
 - **supportedProtocols**: An array of strings specifying the supported protocols (e.g., `"TCP"`, `"UDP"`).
 - **supportedAddressFamilies**: An array containing `"IPv4"`, `"IPv6"`, or both. If omitted, both are enabled. An explicit empty array or any other value is rejected as a configuration error.
 - **excludes** *(new in v2.1.1)*: An array of application names or paths to exclude from proxy routing.

--- a/socksify/AssemblyInfo.cpp
+++ b/socksify/AssemblyInfo.cpp
@@ -17,7 +17,7 @@ using namespace System::Security::Permissions;
 
 // Keep the major.minor in sync with the release tag. (The build-revision wildcard auto-fills
 // the last two fields.) A prior release left this at 2.0.* while ProxiFyre.exe advanced, so the
-// shipped socksify.dll reported a stale version; bumped for the 2.3.x line.
-[assembly:AssemblyVersionAttribute("2.3.*")];
+// shipped socksify.dll reported a stale version; keep this aligned with the release line.
+[assembly:AssemblyVersionAttribute("2.4.*")];
 
 [assembly:ComVisible(false)];


### PR DESCRIPTION
## Summary

- bump the native `socksify.dll` assembly version line from `2.3.*` to `2.4.*`
- announce native SOCKS5-over-TLS support and Alighieri compatibility in the README
- label the four SOCKS5Tls configuration fields as new in v2.4.0

## Release flow after merge

1. Create and push the `v2.4.0` tag from the merged `main` branch.
2. Let the tag-triggered workflow build and publish x86, x64, and ARM64 archives.
3. Run `sign/sign-update-release.ps1` to replace the generated archives with fully signed and verified packages.
4. Publish the prepared v2.4.0 release notes and verify the final assets.

The detailed release notes are intentionally kept outside this commit, following the v2.3.0 release process.

## Verification

- x64 Debug native build passed; C/C++ Code Analysis: 0 errors, 0 warnings
- x64 Release native build passed
- generated Debug and Release assemblies both report a `2.4.*` assembly version
- `git diff --cached --check` passed

Related feature PR: #160
Release-signing hardening: #159